### PR TITLE
Added documentation for methods where there had previously been an unresolvable {@inheritdoc} tag.

### DIFF
--- a/src/Aws/CloudFront/CloudFrontSignature.php
+++ b/src/Aws/CloudFront/CloudFrontSignature.php
@@ -47,7 +47,12 @@ class CloudFrontSignature implements SignatureInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Sign a signature string by applying SHA-1 HMAC hashing.
+     *
+     * @param  string               $string      The signature string to hash.
+     * @param  CredentialsInterface $credentials Signing credentials.
+     *
+     * @return string                            The hashed signature string.
      */
     public function signString($string, CredentialsInterface $credentials)
     {

--- a/src/Aws/DynamoDb/Model/Attribute.php
+++ b/src/Aws/DynamoDb/Model/Attribute.php
@@ -154,7 +154,11 @@ class Attribute implements ToArrayInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Retrieve the formatted data.
+     *
+     * @param  string $format The format to apply to the data.
+     *
+     * @return string         The formatted version of the data.
      */
     public function getFormatted($format = Attribute::FORMAT_PUT)
     {
@@ -174,7 +178,9 @@ class Attribute implements ToArrayInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Retrieve the attribute type.
+     *
+     * @return string The attribute type.
      */
     public function getType()
     {
@@ -182,7 +188,9 @@ class Attribute implements ToArrayInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Retrieve the attribute value.
+     *
+     * @return string The attribute value.
      */
     public function getValue()
     {
@@ -190,7 +198,11 @@ class Attribute implements ToArrayInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Set the attribute type.
+     *
+     * @param  string $type The attribute type to set.
+     *
+     * @return string       The attribute type.
      */
     public function setType($type)
     {
@@ -204,7 +216,11 @@ class Attribute implements ToArrayInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Set the attribute value.
+     *
+     * @param  string $type The attribute value to set.
+     *
+     * @return string       The attribute value.
      */
     public function setValue($value)
     {

--- a/src/Aws/S3/AcpListener.php
+++ b/src/Aws/S3/AcpListener.php
@@ -35,7 +35,11 @@ class AcpListener implements EventSubscriberInterface
     }
 
     /**
-     * {@inheritdoc}
+     * An event handler for constructing ACP definitions.
+     *
+     * @param  Event  $event The event to respond to.
+     *
+     * @throws InvalidArgumentException
      */
     public function onCommandBeforePrepare(Event $event)
     {


### PR DESCRIPTION
The affected docblocks were trying to inherit documentation blocks from methods that didn't actually exist. Feel free to make adjustments to the content so that the documentation is clearer.
