### PR TITLE
Amazon Glacier Documentation Update

### DIFF
--- a/src/Aws/Glacier/GlacierClient.php
+++ b/src/Aws/Glacier/GlacierClient.php
@@ -56,7 +56,7 @@ class GlacierClient extends AbstractClient
     protected $directory = __DIR__;
 
     /**
-     * Factory method to create a new Amazon DynamoDB client using an array of configuration options:
+     * Factory method to create a new Amazon Glacier client using an array of configuration options:
      *
      * Credential options (`key`, `secret`, and optional `token` OR `credentials` is required)
      *

--- a/src/Aws/Glacier/Model/MultipartUpload/UploadBuilder.php
+++ b/src/Aws/Glacier/Model/MultipartUpload/UploadBuilder.php
@@ -25,7 +25,7 @@ use Aws\Glacier\Model\MultipartUpload\UploadPartGenerator;
 
 /**
  * Easily create a multipart uploader used to quickly and reliably upload a
- * large file or data stream to Amazon S3 using multipart uploads
+ * large file or data stream to Amazon Glacier using multipart uploads
  */
 class UploadBuilder extends AbstractUploadBuilder
 {


### PR DESCRIPTION
Noticed that a couple of methods that Amazon Glacier borrows from other classes were mis-documented

http://docs.amazonwebservices.com/aws-sdk-php-2/latest/class-Aws.Glacier.GlacierClient.html

http://docs.amazonwebservices.com/aws-sdk-php-2/latest/namespace-Aws.Glacier.Model.MultipartUpload.html

This pull request updates the source files to correct this. Documentation will have to be regenerated.
