### PR TITLE
Refactored default credentials and added environment credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Next Release
   notification subscriptions](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html) to the Amazon RDS
   client
 * Added the ability to get a Waiter object from a client using the `getWaiter()` method
+* Added the ability to load credentials from environmental variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`. This is
+  compatible with AWS Elastic Beanstalk environment configurations
 * Updated the Amazon RDS client to use the 2013-01-10 API version
 
 2.1.2 (2013-02-18)

--- a/src/Aws/Common/Client/ClientBuilder.php
+++ b/src/Aws/Common/Client/ClientBuilder.php
@@ -17,7 +17,6 @@
 namespace Aws\Common\Client;
 
 use Aws\Common\Credentials\Credentials;
-use Aws\Common\Credentials\RefreshableInstanceProfileCredentials;
 use Aws\Common\Enum\ClientOptions as Options;
 use Aws\Common\Exception\ExceptionListener;
 use Aws\Common\Exception\InvalidArgumentException;
@@ -200,7 +199,7 @@ class ClientBuilder
 
         // Resolve credentials
         if (!$credentials = $config->get('credentials')) {
-            $credentials = $this->getDefaultCredentials($config);
+            $credentials = Credentials::factory($config);
         }
 
         if (!$config->get(Options::BACKOFF)) {
@@ -255,24 +254,6 @@ class ClientBuilder
         }
 
         return $client;
-    }
-
-    /**
-     * Returns the default credentials for a client
-     *
-     * @param Collection $config
-     *
-     * @return Credentials
-     */
-    protected function getDefaultCredentials(Collection $config)
-    {
-        if ($config->get(Options::KEY) && $config->get(Options::SECRET)) {
-            // Credentials were not provided, so create them using keys
-            return Credentials::factory($config->getAll());
-        } else {
-            // Attempt to get credentials from the EC2 instance profile server
-            return new RefreshableInstanceProfileCredentials(new Credentials('', '', '', 1));
-        }
     }
 
     /**

--- a/tests/Aws/Tests/Common/Client/ClientBuilderTest.php
+++ b/tests/Aws/Tests/Common/Client/ClientBuilderTest.php
@@ -17,9 +17,9 @@
 namespace Aws\Tests\Common\Client;
 
 use Aws\Common\Client\ClientBuilder;
+use Aws\Common\Enum\ClientOptions as Options;
 use Aws\Common\Exception\Parser\JsonQueryExceptionParser;
 use Aws\Common\Credentials\Credentials;
-use Aws\Common\Enum\ClientOptions as Options;
 use Guzzle\Common\Collection;
 use Guzzle\Plugin\Backoff\BackoffPlugin;
 
@@ -180,14 +180,35 @@ class ClientBuilderTest extends \Guzzle\Tests\GuzzleTestCase
             )
         );
 
-        // Ensure that default credentials are set
-        $client = ClientBuilder::factory('Aws\\DynamoDb')->setConfig($config)->build();
-        $this->assertSame($creds, $client->getCredentials());
-
         // Ensure that specific credentials can be used
-        $config['credentials'] = null;
-        $client = ClientBuilder::factory('Aws\\DynamoDb')->setConfig($config)->build();
-        $this->assertInstanceOf('Aws\Common\Credentials\RefreshableInstanceProfileCredentials', $client->getCredentials());
+        $client1 = ClientBuilder::factory('Aws\\DynamoDb')->setConfig($config)->build();
+        $this->assertSame($creds, $client1->getCredentials());
+        unset($config['credentials']);
+
+        // Ensure that the instance metadata service is called when no credentials are supplied
+        $client2 = ClientBuilder::factory('Aws\\DynamoDb')->setConfig($config)->build();
+        try {
+            $client2->getCredentials()->getAccessKeyId();
+            $this->fail('An InstanceProfileCredentialsException should have been thrown.');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Aws\Common\Exception\InstanceProfileCredentialsException', $e);
+        }
+
+        // Ensure that environment credentials are picked up if supplied via putenv
+        $_SERVER[Credentials::ENV_KEY] = 'server-key';
+        $_SERVER[Credentials::ENV_SECRET] = 'server-secret';
+        $client3 = ClientBuilder::factory('Aws\\DynamoDb')->setConfig($config)->build();
+        $this->assertEquals('server-key', $client3->getCredentials()->getAccessKeyId());
+        $this->assertEquals('server-secret', $client3->getCredentials()->getSecretKey());
+        unset($_SERVER[Credentials::ENV_KEY], $_SERVER[Credentials::ENV_SECRET]);
+
+        // Ensure that environment credentials are picked up if supplied via putenv
+        putenv(Credentials::ENV_KEY . '=env-key');
+        putenv(Credentials::ENV_SECRET . '=env-secret');
+        $client4 = ClientBuilder::factory('Aws\\DynamoDb')->setConfig($config)->build();
+        $this->assertEquals('env-key', $client4->getCredentials()->getAccessKeyId());
+        $this->assertEquals('env-secret', $client4->getCredentials()->getSecretKey());
+        putenv(Credentials::ENV_KEY); putenv(Credentials::ENV_SECRET);
     }
 
     public function testAddsDefaultBackoffPluginIfNeeded()

--- a/tests/Aws/Tests/Common/Credentials/CredentialsTest.php
+++ b/tests/Aws/Tests/Common/Credentials/CredentialsTest.php
@@ -126,18 +126,6 @@ class CredentialsTest extends \Guzzle\Tests\GuzzleTestCase
 
     /**
      * @covers Aws\Common\Credentials\Credentials::factory
-     * @expectedException Aws\Common\Exception\InvalidArgumentException
-     * @expectedExceptionMessage The "credentials.client" credentials option must be an instance of Guzzle\Service\ClientInterface
-     */
-    public function testFactoryValidatesClientObject()
-    {
-        $credentials = Credentials::factory(array(
-            'credentials.client' => new \stdClass()
-        ));
-    }
-
-    /**
-     * @covers Aws\Common\Credentials\Credentials::factory
      */
     public function testFactoryCreatesInstanceProfileWhenNoKeysAreProvided()
     {

--- a/tests/Aws/Tests/Common/Credentials/RefreshableInstanceProfileCredentialsIntegrationTest.php
+++ b/tests/Aws/Tests/Common/Credentials/RefreshableInstanceProfileCredentialsIntegrationTest.php
@@ -28,17 +28,7 @@ use Doctrine\Common\Cache\ArrayCache;
 class RefreshableInstanceProfileCredentialsIntegrationTest extends \Aws\Tests\IntegrationTestCase
 {
     /**
-     * Ensures that a client is not required to get default credentials
-     */
-    public function testCredentialsFactoryDoesNotRequireClientObject()
-    {
-        $credentials = Credentials::factory();
-        $this->assertInstanceOf('Aws\Common\Credentials\RefreshableInstanceProfileCredentials', $credentials);
-    }
-
-    /**
-     * Ensures that instance profile credentials are used when no credentials
-     * are provided to a client
+     * Ensures that instance profile credentials are used when no credentials are provided to a client
      */
     public function testUsesInstanceProfileCredentialsByDefault()
     {
@@ -47,6 +37,7 @@ class RefreshableInstanceProfileCredentialsIntegrationTest extends \Aws\Tests\In
             'credentials.client' => $client
         ));
 
+        $this->assertInstanceOf('Aws\Common\Credentials\RefreshableInstanceProfileCredentials', $credentials);
         $this->assertSame($client, $this->readAttribute($credentials, 'client'));
 
         return array($credentials, $client);

--- a/tests/Aws/Tests/Common/Credentials/RefreshableInstanceProfileCredentialsTest.php
+++ b/tests/Aws/Tests/Common/Credentials/RefreshableInstanceProfileCredentialsTest.php
@@ -54,7 +54,7 @@ class RefreshableInstanceProfileCredentialsTest extends \Guzzle\Tests\GuzzleTest
     }
 
     /**
-     * @expectedException Aws\Common\Exception\InstanceProfileCredentialsException
+     * @expectedException \Aws\Common\Exception\InstanceProfileCredentialsException
      * @expectedExceptionMessage Error retrieving credentials from the instance profile metadata server
      */
     public function testExceptionsAreWrapped()
@@ -68,7 +68,7 @@ class RefreshableInstanceProfileCredentialsTest extends \Guzzle\Tests\GuzzleTest
     }
 
     /**
-     * @expectedException Aws\Common\Exception\InstanceProfileCredentialsException
+     * @expectedException \Aws\Common\Exception\InstanceProfileCredentialsException
      * @expectedExceptionMessage Unexpected response code: InstanceProfileNotFound
      */
     public function testEnsuresResponseCodeIsSuccess()


### PR DESCRIPTION
Two immediate benefits of this change are:
- Environment credentials that can be provided to Beanstalk environments via the console can now be picked up by the SDK automatically
- It's now possible to use environment credentials in your development environment, which makes it easy to run your app locally if your production environment relies instance profile credentials by using environment credentials, which require no code changes to your app.
