### PR TITLE
rawurlencode string to sign

### DIFF
--- a/src/Aws/S3/S3Signature.php
+++ b/src/Aws/S3/S3Signature.php
@@ -74,7 +74,7 @@ class S3Signature implements S3SignatureInterface
      */
     public function signString($string, CredentialsInterface $credentials)
     {
-        return base64_encode(hash_hmac('sha1', $string, $credentials->getSecretKey(), true));
+        return rawurlencode(base64_encode(hash_hmac('sha1', $string, $credentials->getSecretKey(), true)));
     }
 
     /**


### PR DESCRIPTION
I've been trying to use the SDK to create pre signed urls to upload directly to S3 but every request has resulted in a 403 forbidden response.

I have been able to get this working by creating the signatures myself using the method described here http://www.ioncannon.net/programming/1539/ The only difference is that the string is being encoded. 

After making the change to my local SDK the pre-signed urls now work.
