### PR TITLE
Corrected requirements.txt to reference "rst2pdf"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-rst2dpf
+rst2pdf
 Sphinx>=1.2b1
 guzzle_sphinx_theme>=0.2.1


### PR DESCRIPTION
docs/requirements.txt incorrectly references the "rst2pdf" package.
