### PR TITLE
Remove default value for $args parameter

### DIFF
--- a/src/Aws/Common/Client/AbstractClient.php
+++ b/src/Aws/Common/Client/AbstractClient.php
@@ -92,7 +92,7 @@ abstract class AbstractClient extends Client implements AwsClientInterface
     /**
      * {@inheritdoc}
      */
-    public function __call($method, $args = null)
+    public function __call($method, $args)
     {
         if (substr($method, 0, 9) == 'waitUntil') {
             // Allow magic method calls for waiters (e.g. $client->waitUntil<WaiterName>($resource, $options))


### PR DESCRIPTION
This param should never really be null, only an empty array. Even if it ever is null, the code attempts an array_unshift on it without type checking.

Refs padraic/mockery#164
