### PR TITLE
StreamWrapper: fopen mode x must create if file does not exist

### DIFF
--- a/src/Aws/S3/StreamWrapper.php
+++ b/src/Aws/S3/StreamWrapper.php
@@ -172,8 +172,8 @@ class StreamWrapper
         }
 
         // When using mode "x" validate if the file exists before attempting to read
-        if ($mode == 'x' && !self::$client->doesObjectExist($params['Bucket'], $params['Key'], $this->getOptions())) {
-            $errors[] = "{$path} does not exist on Amazon S3";
+        if ($mode == 'x' && self::$client->doesObjectExist($params['Bucket'], $params['Key'], $this->getOptions())) {
+            $errors[] = "{$path} already exists on Amazon S3";
         }
 
         if (!$errors) {


### PR DESCRIPTION
Currently `stream_open` for mode x is aborting if the file doesn't exist, but this is the opposite of [the PHP documentation for `fopen`](http://php.net/fopen):

> **x** Create and open for writing only; place the file pointer at the beginning of the file. If the file already exists, the fopen() call will fail by returning FALSE and generating an error of level E_WARNING. **If the file does not exist, attempt to create it.** This is equivalent to specifying O_EXCL|O_CREAT flags for the underlying open(2) system call.

The change to fix this is simple. However, there's now a failing test case for mode x. I couldn't figure out how to fix it (it tries to connect to AWS when it's a unit test, probably something with the mock that needs updating?) so I can't contribute that.
