### PR TITLE
Directories don't have trailing slashes in PHP stream wrappers

### DIFF
--- a/src/Aws/S3/StreamWrapper.php
+++ b/src/Aws/S3/StreamWrapper.php
@@ -491,7 +491,7 @@ class StreamWrapper
             $current = $this->objectIterator->current();
             if (isset($current['Prefix'])) {
                 // Include "directories"
-                $result = str_replace($this->openedBucketPrefix, '', $current['Prefix']);
+                $result = rtrim(str_replace($this->openedBucketPrefix, '', $current['Prefix']), '/');
                 $key = "s3://{$this->openedBucket}/{$current['Prefix']}";
                 $stat = $this->formatUrlStat($current['Prefix']);
             } else {

--- a/tests/Aws/Tests/S3/StreamWrapperTest.php
+++ b/tests/Aws/Tests/S3/StreamWrapperTest.php
@@ -422,7 +422,7 @@ class StreamWrapperTest extends \Guzzle\Tests\GuzzleTestCase
         }
 
         // This is the order that the mock responses should provide
-        $expected = array('a/', 'b/', 'c', 'd/','e', 'f', 'g/');
+        $expected = array('a', 'b', 'c', 'd', 'e', 'f', 'g');
 
         $this->assertEquals($expected, $files);
         $this->assertEquals(5, count($this->getMockedRequests()));


### PR DESCRIPTION
Fixes #128

```
OK, but incomplete or skipped tests!
Tests: 777, Assertions: 1942, Incomplete: 2, Skipped: 4.
```

Does have the potential to strip multiple trailing slashes with this use of `rtrim` but I'm not sure if that's ever a thing that could happen with S3 keys.
