### PR TITLE
Handle missing / invalid POST data in Aws\Sns\MessageValidator\Message::fromRawPostData, in a way that is much easier to catch / handle.

### DIFF
--- a/src/Aws/Sns/MessageValidator/Message.php
+++ b/src/Aws/Sns/MessageValidator/Message.php
@@ -17,6 +17,7 @@
 namespace Aws\Sns\MessageValidator;
 
 use Aws\Common\Exception\InvalidArgumentException;
+use Aws\Common\Exception\UnexpectedValueException;
 use Guzzle\Common\Collection;
 
 class Message
@@ -86,10 +87,15 @@ class Message
      * Creates a message object from the raw POST data
      *
      * @return Message
+     * @throws UnexpectedValueException If the POST data is absent, or not a valid JSON document
      */
     public static function fromRawPostData()
     {
-        return self::fromArray(json_decode(file_get_contents('php://input'), true));
+        $data = json_decode(file_get_contents('php://input'), true);
+        if (!is_array($data)) {
+            throw new UnexpectedValueException('POST data absent, or not a valid JSON document', json_last_error());
+        }
+        return self::fromArray($data);
     }
 
     /**

--- a/tests/Aws/Tests/Sns/MessageValidator/MessageTest.php
+++ b/tests/Aws/Tests/Sns/MessageValidator/MessageTest.php
@@ -80,6 +80,12 @@ class MessageTest extends \Guzzle\Tests\GuzzleTestCase
         stream_wrapper_restore("php");
     }
 
+    public function testCreateFromRawPostFailsWithMissingData()
+    {
+        $this->setExpectedException('Aws\Common\Exception\UnexpectedValueException');
+        Message::fromRawPostData();
+    }
+
     /**
      * @dataProvider getDataForStringToSignTest
      */


### PR DESCRIPTION
Prior to this change, calling [Message::fromRawPostData](http://docs.aws.amazon.com/aws-sdk-php-2/latest/class-Aws.Sns.MessageValidator.Message.html#_fromRawPostData) with no POST data, or POST data that is either not valid JSON, or a JSON value other than a JSON object or array, then the internal call to [Message::fromArray](http://docs.aws.amazon.com/aws-sdk-php-2/latest/class-Aws.Sns.MessageValidator.Message.html#_fromArray) will be passed a non-array, resulting in a "catchable fatal error" [(E_RECOVERABLE_ERROR)](http://php.net/manual/en/errorfunc.constants.php) - not a PHP [Exception](http://docs.php.net/manual/en/class.exception.php), but an error that requires a handler to be set via [set_error_handler](http://docs.php.net/manual/en/function.set-error-handler.php) to be handled correctly.  This is both inconvenient, and very difficult to manage as part of any complex project.

This change prevents the "catchable fatal error", and throws an [Aws\Common\Exception\UnexpectedValueException](http://docs.aws.amazon.com/aws-sdk-php-2/latest/class-Aws.Common.Exception.UnexpectedValueException.html) instead.
