### PR TITLE
Update S3Client.php

### DIFF
--- a/src/Aws/S3/S3Client.php
+++ b/src/Aws/S3/S3Client.php
@@ -52,6 +52,7 @@ use Guzzle\Service\Resource\ResourceIteratorInterface;
 /**
  * Client to interact with Amazon Simple Storage Service
  *
+ * @method \Aws\S3\S3SignatureInterface getSignature()
  * @method Model abortMultipartUpload(array $args = array()) {@command S3 AbortMultipartUpload}
  * @method Model completeMultipartUpload(array $args = array()) {@command S3 CompleteMultipartUpload}
  * @method Model copyObject(array $args = array()) {@command S3 CopyObject}


### PR DESCRIPTION
Updated DocBlock for `S3Client::getSignature()` call to return `S3SignatureInterface`, because that includes `::signString()`.

This helps IDE's that have code inspection features, such as PhpStorm; code such as this wouldn't pass without it:

<!-- language: lang-php -->

```
echo $s3->getSignature()->signString($policy, $credentials);
```
