### PR TITLE
fix __init__.py for doing 'make html' on WindowsOS

### DIFF
--- a/docs/_ext/aws/__init__.py
+++ b/docs/_ext/aws/__init__.py
@@ -129,7 +129,13 @@ class ServiceDescription():
         :param path: Path to the script to load
         """
         path = os.path.abspath(path)
-        sh = 'php -r \"$c = include \'' + path + '\'; echo json_encode($c);\"'
+        
+        # Make command to each environment Linux/Mac and Windows
+        if os.name == 'nt':
+            sh = 'php -r \"$c = include \'' + path + '\'; echo json_encode($c);\"'
+        else:
+            sh = 'php -r \'$c = include "' + path + '"; echo json_encode($c);\''
+        
         loaded = subprocess.check_output(sh, shell=True)
         return json.loads(loaded)
 


### PR DESCRIPTION
I was trying to write docs on Windows 7 (x64). 
Under Windows 7 with sphinx , I need to fix "docs_ext\aws__init__.py" for doing "make html". So I commited two fixed line on the code.
1. Use os.path insted of "/", where only I need
2. Exchange " and ' in __load_php()'s sh literal.
   Windows "php -r" command can be passed "(doble-quote) sentence. (On my thinking, Linux "php -r' support single&double-quote)

Please check it , if something on my request, Please let's me know.

Thanks for great product.
