### PR TITLE
Fix date format for parameters CreatedAfter and CreatedBefore in Emr res...

### DIFF
--- a/src/Aws/Emr/Resources/emr-2009-03-31.php
+++ b/src/Aws/Emr/Resources/emr-2009-03-31.php
@@ -273,7 +273,7 @@ return array (
                         'string',
                         'integer',
                     ),
-                    'format' => 'date-time',
+                    'format' => 'timestamp',
                     'location' => 'json',
                 ),
                 'CreatedBefore' => array(
@@ -282,7 +282,7 @@ return array (
                         'string',
                         'integer',
                     ),
-                    'format' => 'date-time',
+                    'format' => 'timestamp',
                     'location' => 'json',
                 ),
                 'JobFlowIds' => array(


### PR DESCRIPTION
When I call the describeJobFlows method with the CreatedAfter or CreatedBefore parameters, I always received an error from the server : class java.lang.String can not be converted to milliseconds since epoch
With previous version of the SDK, the error was : timestamp must follow ISO8601

After some debugging, Guzzle format the parameter to ISO 8601 (YYYY-MM-DDThh:mm:ssZ) but the API don't handle it.

If I change the format option on the resource file to "timestamp", everything is working.
