### PR TITLE
Strict standards notice - method not compatable

### DIFF
--- a/src/Aws/Common/Client/AbstractClient.php
+++ b/src/Aws/Common/Client/AbstractClient.php
@@ -91,7 +91,7 @@ abstract class AbstractClient extends Client implements AwsClientInterface
         }
     }
 
-    public function __call($method, $args)
+    public function __call($method, $args = NULL)
     {
         if (substr($method, 0, 3) === 'get' && substr($method, -8) === 'Iterator') {
             // Allow magic method calls for iterators (e.g. $client->get<CommandName>Iterator($params))


### PR DESCRIPTION
@danielbachhuber we can just track this branch which fixes the notice.

Should I PR back to the aws:master?
