### PR TITLE
Allows the signature option of a client to be a string or a signature object

### DIFF
--- a/src/Aws/Common/Client/DefaultClient.php
+++ b/src/Aws/Common/Client/DefaultClient.php
@@ -47,6 +47,7 @@ class DefaultClient extends AbstractClient
      *
      * Generic client options:
      *
+     * - signature: Overrides the signature used by the client. Clients will always choose an appropriate default signature. However, it can be useful to override this with a custom setting. This can be set to "v4", "v3https", "v2" or an instance of Aws\Common\Signature\SignatureInterface.
      * - ssl.certificate_authority: Set to true to use the bundled CA cert or pass the full path to an SSL certificate bundle
      * - curl.options: Associative of CURLOPT_* cURL options to add to each request
      * - client.backoff.logger: `Guzzle\Log\LogAdapterInterface` object used to log backoff retries. Use 'debug' to emit PHP warnings when a retry is issued.

--- a/tests/Aws/Tests/S3/S3ClientTest.php
+++ b/tests/Aws/Tests/S3/S3ClientTest.php
@@ -447,8 +447,20 @@ class S3ClientTest extends \Guzzle\Tests\GuzzleTestCase
         $sig = $this->getMockBuilder('Aws\S3\S3Signature')
             ->disableOriginalConstructor()
             ->getMock();
-        $s3 = S3Client::factory(array(Options::SIGNATURE => $sig));
+        $s3 = S3Client::factory(array(
+            Options::SIGNATURE => $sig,
+            Options::REGION => 'cn-north-1'
+        ));
         $this->assertSame($sig, $s3->getSignature());
+    }
+
+    public function testCanForceS3SignatureUsingString()
+    {
+        $s3 = S3Client::factory(array(
+            Options::SIGNATURE => 's3',
+            Options::REGION => 'cn-north-1'
+        ));
+        $this->assertInstanceOf('Aws\S3\S3Signature', $s3->getSignature());
     }
 
     public function testCanForceSigV4Signature()
@@ -461,6 +473,22 @@ class S3ClientTest extends \Guzzle\Tests\GuzzleTestCase
             Options::REGION => 'us-east-1'
         ));
         $this->assertSame($sig, $s3->getSignature());
+    }
+
+    /**
+     * @expectedException Aws\Common\Exception\InvalidArgumentException
+     * @expectedExceptionMessage A region must be specified when using signature version 4
+     */
+    public function testEnsuresRegionIsSetWhenUsingV4()
+    {
+        $s3 = S3Client::factory(array(Options::SIGNATURE => 'v4'));
+        $this->assertInstanceOf('Aws\S3\S3SignatureV4', $s3->getSignature());
+    }
+
+    public function testCanForceS3SignatureV4UsingString()
+    {
+        $s3 = S3Client::factory(array(Options::SIGNATURE => 'v4', 'region' => 'us-west-2'));
+        $this->assertInstanceOf('Aws\S3\S3SignatureV4', $s3->getSignature());
     }
 
     public function testUsesSigV4SignatureInSpecificRegions()


### PR DESCRIPTION
This pull request allows the "signature" option to be a valid signature version string (e.g., "v4", "v3https", "v2", "s3"). This makes it easier to override the default signature with a different signature by name.

/cc @jeremeamia 
