### PR TITLE
Move API Ref in User Guide

### DIFF
--- a/docs/_ext/aws/templates/api_reference
+++ b/docs/_ext/aws/templates/api_reference
@@ -1,0 +1,28 @@
+
+API Reference
+-------------
+
+Please see the `{{ serviceFullName }} Client API reference <http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.{{ namespace }}{{ apiVersionSuffix }}.{{ namespace }}Client.html>`_
+for a details about all of the available methods, including descriptions of the inputs and outputs.
+
+{# Here we are creating a list-table. The contents of a list-table looks like:
+    * - Foo
+      - Bar
+    * - Baz
+      - Bam
+
+    We must also ensure that the same number of columns are available for each table row.
+#}
+
+.. list-table::
+    :header-rows: 0
+    :stub-columns: 0
+    :class: two-column
+
+    {% for key, op in description.operations.iteritems() %}
+    {% if loop.index is odd %}* {% else %}  {% endif %}- `{{ key }} <http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.{{ namespace}}{{ apiVersionSuffix }}.{{ namespace }}Client.html#_{{ op.magicMethod }}>`_
+    {%- if op.documentationUrl %}  (`service docs <{{ op.documentationUrl}}>`_){%- endif %}
+    {%- if loop.last and loop.index is odd %}
+      -
+    {%- endif %}
+    {% endfor %}

--- a/docs/_ext/aws/templates/client_intro
+++ b/docs/_ext/aws/templates/client_intro
@@ -60,31 +60,3 @@ clients so that you only have to specify your settings once.
     $client = $aws->get('{{ namespace }}');
 
 .. _{{ namespace }}{{ apiVersionSuffix }}_operations:
-
-API Reference
--------------
-
-Please see the `{{ serviceFullName }} Client API reference <http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.{{ namespace }}{{ apiVersionSuffix }}.{{ namespace }}Client.html>`_
-for a details about all of the available methods, including descriptions of the inputs and outputs.
-
-{# Here we are creating a list-table. The contents of a list-table looks like:
-    * - Foo
-      - Bar
-    * - Baz
-      - Bam
-
-    We must also ensure that the same number of columns are available for each table row.
-#}
-
-.. list-table::
-    :header-rows: 0
-    :stub-columns: 0
-    :class: two-column
-
-    {% for key, op in description.operations.iteritems() %}
-    {% if loop.index is odd %}* {% else %}  {% endif %}- `{{ key }} <http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.{{ namespace}}{{ apiVersionSuffix }}.{{ namespace }}Client.html#_{{ op.magicMethod }}>`_
-    {%- if op.documentationUrl %}  (`service docs <{{ op.documentationUrl}}>`_){%- endif %}
-    {%- if loop.last and loop.index is odd %}
-      -
-    {%- endif %}
-    {% endfor %}

--- a/docs/service-autoscaling.rst
+++ b/docs/service-autoscaling.rst
@@ -1,3 +1,5 @@
 .. service:: AutoScaling
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: AutoScaling

--- a/docs/service-cloudformation.rst
+++ b/docs/service-cloudformation.rst
@@ -1,3 +1,5 @@
 .. service:: CloudFormation
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: CloudFormation

--- a/docs/service-cloudfront-20120505.rst
+++ b/docs/service-cloudfront-20120505.rst
@@ -130,3 +130,5 @@ The following is an example of how you could use the signed URL to construct a w
     </html>
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: CloudFront 2012-05-05

--- a/docs/service-cloudfront.rst
+++ b/docs/service-cloudfront.rst
@@ -130,3 +130,5 @@ The following is an example of how you could use the signed URL to construct a w
     </html>
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: CloudFront

--- a/docs/service-cloudsearch.rst
+++ b/docs/service-cloudsearch.rst
@@ -1,3 +1,5 @@
 .. service:: CloudSearch
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: CloudSearch

--- a/docs/service-cloudtrail.rst
+++ b/docs/service-cloudtrail.rst
@@ -1,3 +1,11 @@
 .. service:: CloudTrail
 
+Blog articles
+-------------
+
+* `Using AWS CloudTrail in PHP - Part 1 <http://blogs.aws.amazon.com/php/post/Tx3HGFCVGT92TS8/Using-AWS-CloudTrail-in-PHP-Part-1>`_
+* `Using AWS CloudTrail in PHP - Part 2 <http://blogs.aws.amazon.com/php/post/Tx31JYLN2SC3GHB/Using-AWS-CloudTrail-in-PHP-Part-2>`_
+
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: CloudTrail

--- a/docs/service-cloudwatch.rst
+++ b/docs/service-cloudwatch.rst
@@ -1,3 +1,5 @@
 .. service:: CloudWatch
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: CloudWatch

--- a/docs/service-datapipeline.rst
+++ b/docs/service-datapipeline.rst
@@ -1,3 +1,5 @@
 .. service:: DataPipeline
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: DataPipeline

--- a/docs/service-directconnect.rst
+++ b/docs/service-directconnect.rst
@@ -1,3 +1,5 @@
 .. service:: DirectConnect
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: DirectConnect

--- a/docs/service-dynamodb-20111205.rst
+++ b/docs/service-dynamodb-20111205.rst
@@ -158,3 +158,5 @@ You can also use the ``WriteRequestBatch`` object to delete items in batches.
 
 The ``WriteRequestBatch``, ``PutRequest``, and ``DeleteRequest`` classes are all a part of the
 ``Aws\DynamoDb\Model\BatchRequest`` namespace.
+
+.. apiref:: DynamoDb 2011-12-05

--- a/docs/service-dynamodb.rst
+++ b/docs/service-dynamodb.rst
@@ -210,3 +210,5 @@ You can also use the ``WriteRequestBatch`` object to delete items in batches.
 
 The ``WriteRequestBatch``, ``PutRequest``, and ``DeleteRequest`` classes are all a part of the
 ``Aws\DynamoDb\Model\BatchRequest`` namespace.
+
+.. apiref:: DynamoDb

--- a/docs/service-ec2.rst
+++ b/docs/service-ec2.rst
@@ -1,3 +1,5 @@
 .. service:: Ec2
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Ec2

--- a/docs/service-elasticache.rst
+++ b/docs/service-elasticache.rst
@@ -1,3 +1,5 @@
 .. service:: ElastiCache
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: ElastiCache

--- a/docs/service-elasticbeanstalk.rst
+++ b/docs/service-elasticbeanstalk.rst
@@ -1,3 +1,5 @@
 .. service:: ElasticBeanstalk
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: ElasticBeanstalk

--- a/docs/service-elasticloadbalancing.rst
+++ b/docs/service-elasticloadbalancing.rst
@@ -1,3 +1,5 @@
 .. service:: ElasticLoadBalancing
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: ElasticLoadBalancing

--- a/docs/service-elastictranscoder.rst
+++ b/docs/service-elastictranscoder.rst
@@ -1,3 +1,5 @@
 .. service:: ElasticTranscoder
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: ElasticTranscoder

--- a/docs/service-emr.rst
+++ b/docs/service-emr.rst
@@ -1,3 +1,5 @@
 .. service:: Emr
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Emr

--- a/docs/service-glacier.rst
+++ b/docs/service-glacier.rst
@@ -1,3 +1,5 @@
 .. service:: Glacier
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Glacier

--- a/docs/service-iam.rst
+++ b/docs/service-iam.rst
@@ -1,3 +1,5 @@
 .. service:: Iam
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Iam

--- a/docs/service-importexport.rst
+++ b/docs/service-importexport.rst
@@ -1,3 +1,5 @@
 .. service:: ImportExport
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: ImportExport

--- a/docs/service-kinesis.rst
+++ b/docs/service-kinesis.rst
@@ -11,3 +11,5 @@ count.
 .. example:: Kinesis/Integration/Kinesis_20131104_Test.php testCreateStream
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Kinesis

--- a/docs/service-opsworks.rst
+++ b/docs/service-opsworks.rst
@@ -1,3 +1,5 @@
 .. service:: OpsWorks
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: OpsWorks

--- a/docs/service-rds.rst
+++ b/docs/service-rds.rst
@@ -1,3 +1,5 @@
 .. service:: Rds
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Rds

--- a/docs/service-redshift.rst
+++ b/docs/service-redshift.rst
@@ -74,3 +74,5 @@ object.
     foreach ($events as $event) {
         echo "{$event['Date']}: {$event['Message']}\n";
     }
+
+.. apiref:: Redshift

--- a/docs/service-route53.rst
+++ b/docs/service-route53.rst
@@ -1,3 +1,5 @@
 .. service:: Route53
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Route53

--- a/docs/service-s3.rst
+++ b/docs/service-s3.rst
@@ -446,3 +446,5 @@ Cleaning up
 Now that we've taken a tour of how you can use the Amazon S3 client, let's clean up any resources we may have created.
 
 .. example:: S3/Integration/S3_20060301_Test.php testCleanUpBucket
+
+.. apiref:: S3

--- a/docs/service-ses.rst
+++ b/docs/service-ses.rst
@@ -1,3 +1,5 @@
 .. service:: Ses
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Ses

--- a/docs/service-simpledb.rst
+++ b/docs/service-simpledb.rst
@@ -162,3 +162,4 @@ DeleteDomain operation might take 10 or more seconds to complete.
 
     $client->deleteDomain(array('DomainName' => 'mydomain'));
 
+.. apiref:: SimpleDb

--- a/docs/service-sns.rst
+++ b/docs/service-sns.rst
@@ -1,3 +1,5 @@
 .. service:: Sns
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Sns

--- a/docs/service-sqs.rst
+++ b/docs/service-sqs.rst
@@ -99,3 +99,5 @@ in the queue. To configure this behavior, you must use the ``WaitTimeSeconds`` p
 
 .. note:: You can also configure long-polling at the queue level by setting the ``ReceiveMessageWaitTimeSeconds`` queue
           attribute.
+
+.. apiref:: Sqs

--- a/docs/service-storagegateway.rst
+++ b/docs/service-storagegateway.rst
@@ -1,3 +1,5 @@
 .. service:: StorageGateway
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: StorageGateway

--- a/docs/service-sts.rst
+++ b/docs/service-sts.rst
@@ -88,3 +88,5 @@ You can also use the same technique when setting credentials on an existing clie
     $s3->setCredentials($credentials);
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Sts

--- a/docs/service-support.rst
+++ b/docs/service-support.rst
@@ -1,3 +1,5 @@
 .. service:: Support
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Support

--- a/docs/service-swf.rst
+++ b/docs/service-swf.rst
@@ -1,3 +1,5 @@
 .. service:: Swf
 
 .. include:: _snippets/incomplete.txt
+
+.. apiref:: Swf


### PR DESCRIPTION
Updated sphinx plugin and user guide pages so that the API refs appear at the bottom of each service-specific guide
