### PR TITLE
Multipart sync event

### DIFF
--- a/src/Aws/S3/Sync/UploadSync.php
+++ b/src/Aws/S3/Sync/UploadSync.php
@@ -69,7 +69,7 @@ class UploadSync extends AbstractSync
 
             $this->dispatch(
                 self::BEFORE_MULTIPART_BUILD,
-                array('builder' => $builder,'file' => $file)
+                array('builder' => $builder, 'file' => $file)
             );
 
             return $builder->build();


### PR DESCRIPTION
This PR add an event that is fired before a multi-part upload is created during a sync of files. This allows for granular   customization of multipart uploads during a sync.
