### PR TITLE
Adding content-type guessing to the S3 stream wrapper

### DIFF
--- a/src/Aws/S3/StreamWrapper.php
+++ b/src/Aws/S3/StreamWrapper.php
@@ -22,6 +22,7 @@ use Aws\S3\Exception\NoSuchKeyException;
 use Aws\S3\Iterator\ListObjectsIterator;
 use Guzzle\Http\EntityBody;
 use Guzzle\Http\CachingEntityBody;
+use Guzzle\Http\Mimetypes;
 use Guzzle\Stream\PhpStreamRequestFactory;
 use Guzzle\Service\Command\CommandInterface;
 
@@ -208,6 +209,14 @@ class StreamWrapper
         $this->body->rewind();
         $params = $this->params;
         $params['Body'] = $this->body;
+
+        // Attempt to guess the ContentType of the upload based on the
+        // file extension of the key
+        if (!isset($params['ContentType']) &&
+            ($type = Mimetypes::getInstance()->fromFilename($params['Key']))
+        ) {
+            $params['ContentType'] = $type;
+        }
 
         try {
             self::$client->putObject($params);

--- a/tests/Aws/Tests/S3/StreamWrapperTest.php
+++ b/tests/Aws/Tests/S3/StreamWrapperTest.php
@@ -177,6 +177,14 @@ class StreamWrapperTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertTrue(fclose($s));
     }
 
+    public function testAttemptsToGuessTheContentType()
+    {
+        $this->setMockResponse($this->client, array(new Response(200)));
+        file_put_contents('s3://foo/bar.txt', 'test');
+        $requests = $this->getMockedRequests();
+        $this->assertEquals('text/plain', $requests[0]->getHeader('Content-Type'));
+    }
+
     public function testCanOpenWriteOnlyStreams()
     {
         $this->setMockResponse($this->client, array(new Response(204)));


### PR DESCRIPTION
The content-type guessing in the SDK currently relies on the EntityBody provided to various operations to tell the SDK the content-type of the file being uploaded. This convention cannot be followed in the stream wrapper when using operations like file_put_contents because the content is always a stream that does not expose its content-type. Because the stream wrapper is uploading to Amazon S3 using a PUT operation (meaning create this object at the URL provided), it is safe to infer the content-type from the destination URL (as opposed to the default of gleaming this from the source content).

See: https://forums.aws.amazon.com/thread.jspa?messageID=516152#516152
