### PR TITLE
Correctly adding params to multi-part upload syncs

### DIFF
--- a/src/Aws/S3/Sync/AbstractSyncBuilder.php
+++ b/src/Aws/S3/Sync/AbstractSyncBuilder.php
@@ -392,11 +392,6 @@ abstract class AbstractSyncBuilder
             function (Event $e) use ($params) {
                 if ($e['command'] instanceof CommandInterface) {
                     $e['command']->overwriteWith($params);
-                } elseif ($e['command'] instanceof TransferInterface) {
-                    // Multipart upload transfer object
-                    foreach ($params as $k => $v) {
-                        $e['command']->setOption($k, $v);
-                    }
                 }
             }
         );

--- a/src/Aws/S3/Sync/UploadSyncBuilder.php
+++ b/src/Aws/S3/Sync/UploadSyncBuilder.php
@@ -19,6 +19,7 @@ namespace Aws\S3\Sync;
 use \FilesystemIterator as FI;
 use Aws\Common\Model\MultipartUpload\AbstractTransfer;
 use Aws\S3\Model\Acp;
+use Guzzle\Common\HasDispatcherInterface;
 use Guzzle\Common\Event;
 use Guzzle\Service\Command\CommandInterface;
 
@@ -122,6 +123,21 @@ class UploadSyncBuilder extends AbstractSyncBuilder
         ));
 
         return $sync;
+    }
+
+    protected function addCustomParamListener(HasDispatcherInterface $sync)
+    {
+        // Handle the special multi-part upload event
+        parent::addCustomParamListener($sync);
+        $params = $this->params;
+        $sync->getEventDispatcher()->addListener(
+            UploadSync::BEFORE_MULTIPART_BUILD,
+            function (Event $e) use ($params) {
+                foreach ($params as $k => $v) {
+                    $e['builder']->setOption($k, $v);
+                }
+            }
+        );
     }
 
     protected function getTargetIterator()

--- a/tests/Aws/Tests/S3/Sync/UploadSyncBuilderTest.php
+++ b/tests/Aws/Tests/S3/Sync/UploadSyncBuilderTest.php
@@ -107,6 +107,7 @@ class UploadSyncBuilderTest extends \Guzzle\Tests\GuzzleTestCase
             ->setBaseDir(__DIR__)
             ->enableDebugOutput($out)
             ->setSourceIterator(new \ArrayIterator(array(new \SplFileInfo(__FILE__))))
+            ->setOperationParams(array('Metadata' => array('foo' => 'bar')))
             ->setMultipartUploadSize(filesize(__FILE__) - 1)
             ->setAcp(AcpBuilder::newInstance()->setOwner('123')->addGrantForEmail('READ_ACP', 'foo@baz.com')->build())
             ->build()
@@ -117,6 +118,7 @@ class UploadSyncBuilderTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals('POST', $requests[1]->getMethod());
         $this->assertContains('?uploads', $requests[1]->getResource());
         $this->assertNotNull($requests[1]->getHeader('x-amz-grant-read-acp'));
+        $this->assertEquals('bar', (string) $requests[1]->getHeader('x-amz-meta-foo'));
         $this->assertEquals('PUT', $requests[2]->getMethod());
         $this->assertEquals('POST', $requests[3]->getMethod());
         $this->assertContains('uploadId=', $requests[3]->getResource());


### PR DESCRIPTION
Previously, multi-part upload options were being erroneously added to
TransferInterface objects rather than the UploadBuilder. This meant that
options were being applied to UploadPart operations rather than the
Initiate multi-part upload operation. This change moves the addition of
custom parameters from the BEFORE_TRANSFER event to the BEFORE_MULTIPART_UPLOAD
event so that they are properly applied. Closes #195.
