### PR TITLE
Added eu-west-1 SES region

### DIFF
--- a/src/Aws/Ses/Resources/ses-2010-12-01.php
+++ b/src/Aws/Ses/Resources/ses-2010-12-01.php
@@ -29,6 +29,11 @@ return array (
             'https' => true,
             'hostname' => 'email.us-east-1.amazonaws.com',
         ),
+        'eu-west-1' => array(
+            'http' => false,
+            'https' => true,
+            'hostname' => 'email.eu-west-1.amazonaws.com',
+        ),
     ),
     'operations' => array(
         'DeleteIdentity' => array(


### PR DESCRIPTION
Looks like EU (Ireland) was added as a SES region
http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html

Setting eu-west-1 throws an error unless added to service description.
