### PR TITLE
Fixed StreamWrapper::mkdir.

### DIFF
--- a/src/Aws/S3/StreamWrapper.php
+++ b/src/Aws/S3/StreamWrapper.php
@@ -375,8 +375,12 @@ class StreamWrapper
         $params = $this->getParams($path);
         $this->clearStatInfo($path);
 
-        if (!$params['Bucket'] || $params['Key']) {
+        if (!$params['Bucket']) {
             return false;
+        }
+
+        if ($params['Key']) {
+            return true;
         }
 
         try {


### PR DESCRIPTION
AWS-S3 is able to create a full path on a file_put_contents.
But If we run mkdir($path) before executing file_put_contents
the mkdir returns false.

With this patch, the mkdir always return true when a key is set.

![i have no iead](https://f.cloud.github.com/assets/408368/2160118/94c160f8-94b3-11e3-868a-f55cc89d9545.jpg)
