### PR TITLE
Made the StreamWrapper easily extendable

### DIFF
--- a/src/Aws/S3/StreamWrapper.php
+++ b/src/Aws/S3/StreamWrapper.php
@@ -132,7 +132,7 @@ class StreamWrapper
             stream_wrapper_unregister('s3');
         }
 
-        stream_wrapper_register('s3', __CLASS__, STREAM_IS_URL);
+        stream_wrapper_register('s3', get_called_class(), STREAM_IS_URL);
         self::$client = $client;
     }
 


### PR DESCRIPTION
I need to override the `getOptions` method (in order to set ACL globally). So I have extended the Class `StreamWrapper` and override `getOptions`. But The stream wrapper to use should be mine, not the one inside this repository.

Thanks
