### PR TITLE
Added PHP 5.6 To Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: php
+
 php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+
 before_script:
 - sh -c 'if [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
 - cp test_services.json.dist test_services.json
 - composer install --dev
+
 script: vendor/bin/phpunit
+
+matrix:
+  allow_failures:
+    - php: 5.6
+  fast_finish: true


### PR DESCRIPTION
I've added php 5.6 to the travis config on allow failing, as has been done in guzzle.
