### PR TITLE
Added configuration for waitUntilSpotInstanceRequestFulfilled().

### DIFF
--- a/src/Aws/Ec2/Ec2Client.php
+++ b/src/Aws/Ec2/Ec2Client.php
@@ -175,6 +175,7 @@ use Guzzle\Service\Resource\ResourceIteratorInterface;
  * @method Model terminateInstances(array $args = array()) {@command Ec2 TerminateInstances}
  * @method Model unassignPrivateIpAddresses(array $args = array()) {@command Ec2 UnassignPrivateIpAddresses}
  * @method Model unmonitorInstances(array $args = array()) {@command Ec2 UnmonitorInstances}
+ * @method waitUntilSpotInstanceRequestFulfilled(array $input) The input array uses the parameters of the DescribeSpotInstanceRequests operation and waiter specific settings
  * @method waitUntilInstanceRunning(array $input) The input array uses the parameters of the DescribeInstances operation and waiter specific settings
  * @method waitUntilInstanceStopped(array $input) The input array uses the parameters of the DescribeInstances operation and waiter specific settings
  * @method waitUntilInstanceTerminated(array $input) The input array uses the parameters of the DescribeInstances operation and waiter specific settings

--- a/src/Aws/Ec2/Resources/ec2-2013-10-15.php
+++ b/src/Aws/Ec2/Resources/ec2-2013-10-15.php
@@ -15101,6 +15101,20 @@ return array (
             'max_attempts' => 40,
             'acceptor.type' => 'output',
         ),
+        '__SpotInstanceRequestState' => array(
+            'operation' => 'DescribeSpotInstanceRequests',
+            'acceptor.path' => 'SpotInstanceRequests/*/Status/Code',
+        ),
+        'SpotInstanceRequestFulfilled' => array(
+            'extends' => '__SpotInstanceRequestState',
+            'success.value' => 'fulfilled',
+            'failure.value' => array(
+                'schedule-expired',
+                'canceled-before-fulfillment',
+                'bad-parameters',
+                'system-error',
+            )
+        ),
         '__InstanceState' => array(
             'operation' => 'DescribeInstances',
             'acceptor.path' => 'Reservations/*/Instances/*/State/Name',


### PR DESCRIPTION
Added the configuration details to create the **waitUntilSpotInstanceRequestFulfilled()** waiter.

I grabbed the failure status code values from http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances-bid-status.html

The waiter works in my code, waiting for the "fulfilled" status, and also throwing an exception if I kill the spot request from the AWS Console, which puts the request into one of the failure statuses.

I did not add a spot instance test in **tests/Aws/Tests/Ec2/Integration/BasicOperationsTest.php**, even though that would be a good next step.
