### PR TITLE
Moving X-Amz-* headers to the query string with pre-signed URLs

### DIFF
--- a/src/Aws/S3/S3Md5Listener.php
+++ b/src/Aws/S3/S3Md5Listener.php
@@ -16,7 +16,6 @@
 
 namespace Aws\S3;
 
-use Aws\Common\Exception\RuntimeException;
 use Aws\Common\Signature\SignatureV4;
 use Guzzle\Common\Event;
 use Guzzle\Service\Command\CommandInterface;
@@ -63,7 +62,8 @@ class S3Md5Listener implements EventSubscriberInterface
     private function addMd5(CommandInterface $command)
     {
         $request = $command->getRequest();
-        if ($body = $request->getBody()) {
+        $body = $request->getBody();
+        if ($body && $body->getSize() > 0) {
             if (false !== ($md5 = $body->getContentMd5(true, true))) {
                 $request->setHeader('Content-MD5', $md5);
             }

--- a/tests/Aws/Tests/S3/Integration/S3_20060301_Test.php
+++ b/tests/Aws/Tests/S3/Integration/S3_20060301_Test.php
@@ -593,6 +593,37 @@ class S3_20060301_Test extends \Aws\Tests\IntegrationTestCase
     }
 
     /**
+     * Create a presigned URL with a command object that has x-amz-* headers.
+     *
+     * @depends testGetObjectWithSaveAs
+     */
+    public function testCreatePresignedUrlWithAcl()
+    {
+        $this->client->waitUntilBucketExists(array('Bucket' => $this->bucket));
+        $client = $this->client;
+        $bucket = $this->bucket;
+
+        $command = $client->getCommand('PutObject', array(
+            'Bucket'       => $bucket,
+            'Key'          => 'preput',
+            'ACL'          => 'public-read',
+            'Content-Type' => 'plain/text',
+            'Body'         => ''
+        ));
+
+        $signedUrl = $command->createPresignedUrl('+10 minutes');
+
+        $ch = curl_init($signedUrl);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+            'Content-Type: plain/text'
+        ));
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+        curl_setopt($ch, CURLOPT_POSTFIELDS, 'abc123');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_exec($ch);
+    }
+
+    /**
      * Clear the contents and delete a bucket
      *
      * @depends testGetObjectUrlWithSessionCredentials

--- a/tests/Aws/Tests/S3/S3SignatureTest.php
+++ b/tests/Aws/Tests/S3/S3SignatureTest.php
@@ -17,6 +17,7 @@
 namespace Aws\Tests\S3;
 
 use Aws\S3\S3Signature;
+use Guzzle\Http\Message\Request;
 
 /**
  * @covers Aws\S3\S3Signature
@@ -267,5 +268,27 @@ class S3SignatureTest extends \Guzzle\Tests\GuzzleTestCase
         } else {
             $this->assertFalse($request->hasHeader('x-amz-security-token'));
         }
+    }
+
+    public function testCreatesPreSignedUrlWithXAmzHeaders()
+    {
+        $signature = new S3Signature();
+        $request = new Request('GET', 'https://s3.amazonaws.com', array(
+            'X-Amz-Acl' => 'public-read'
+        ));
+        $c = $this->getServiceBuilder()->get('s3');
+        $request->setClient($c);
+        $this->assertContains(
+            'x-amz-acl:public-read',
+            $signature->createCanonicalizedString($request, time())
+        );
+        $this->assertContains(
+            '&x-amz-acl=public-read',
+            $signature->createPresignedUrl(
+                $request,
+                $c->getCredentials(),
+                time()
+            )
+        );
     }
 }


### PR DESCRIPTION
- Each x-amz-\* header can be moved to the query string after creating a
  pre-signed URL. This ensures that pre-signed URLs can be created for
  requests that utilize custom HTTP headers.
- Closes #250.
- Makes it so that setting ContentMD5 to false with pre-signed PUTs is no longer required.
