### PR TITLE
allow rmdir to remove bucket or object

### DIFF
--- a/src/Aws/S3/StreamWrapper.php
+++ b/src/Aws/S3/StreamWrapper.php
@@ -404,7 +404,15 @@ class StreamWrapper
 
         try {
             if ($params['Key']) {
-                return $this->unlink($path);
+                $result = self::$client->listObjects(array(
+                    'Bucket'  => $params['Bucket'],
+                    'Prefix'  => $path,
+                    'MaxKeys' => 1
+                ));
+                if (!$result['Contents'] && !$result['CommonPrefixes']) {
+                    return $this->unlink($path);
+                }
+                return $this->triggerError('Pseudo directory is not empty');
             } else {
                 self::$client->deleteBucket(array('Bucket' => $params['Bucket']));
             }

--- a/tests/Aws/Tests/S3/StreamWrapperTest.php
+++ b/tests/Aws/Tests/S3/StreamWrapperTest.php
@@ -376,13 +376,14 @@ class StreamWrapperTest extends \Guzzle\Tests\GuzzleTestCase
 
     public function testCanDeleteObjectWithRmDir()
     {
-        $this->setMockResponse($this->client, array(new Response(204)));
+        $this->setMockResponse($this->client, array(new Response(200), new Response(204)));
         $this->assertTrue(rmdir('s3://bucket/object/'));
         $requests = $this->getMockedRequests();
-        $this->assertEquals(1, count($requests));
-        $this->assertEquals('DELETE', $requests[0]->getMethod());
-        $this->assertEquals('/object/', $requests[0]->getResource());
-        $this->assertEquals('bucket.s3.amazonaws.com', $requests[0]->getHost());
+        $this->assertEquals(2, count($requests));
+        $this->assertEquals('GET', $requests[0]->getMethod());
+        $this->assertEquals('DELETE', $requests[1]->getMethod());
+        $this->assertEquals('/object/', $requests[1]->getResource());
+        $this->assertEquals('bucket.s3.amazonaws.com', $requests[1]->getHost());
     }
 
     /**


### PR DESCRIPTION
this is done for consistency with mkdir which allows to create object or bucket
