### PR TITLE
Added support for credential files and credential profiles

### DIFF
--- a/src/Aws/Common/Enum/ClientOptions.php
+++ b/src/Aws/Common/Enum/ClientOptions.php
@@ -39,6 +39,11 @@ class ClientOptions extends Enum
     const CREDENTIALS = 'credentials';
 
     /**
+     * @var string Name of a credential profile to read from your ~/.aws/credentials file
+     */
+    const PROFILE = 'profile';
+
+    /**
      * @var string Custom AWS security token to use with request authentication
      */
     const TOKEN = 'token';

--- a/tests/Aws/Tests/Common/Credentials/.aws/credentials
+++ b/tests/Aws/Tests/Common/Credentials/.aws/credentials
@@ -1,0 +1,6 @@
+[default]
+aws_access_key_id=foo
+aws_secret_access_key=bar
+[test]
+aws_access_key_id=fizz
+aws_secret_access_key=buzz


### PR DESCRIPTION
Added support for credential files (INI format).

Your credential file should be stored in `~/.aws/credential`, and look like:

``` ini
[default]
aws_access_key_id=key1
aws_secret_access_key=secret1

[profile1]
aws_access_key_id=key2
aws_secret_access_key=secret2

[profile2]
aws_access_key_id=key3
aws_secret_access_key=secret3
```

/cc @mtdowling
