### PR TITLE
Better handling of error flags in S3 stream wrapper

### DIFF
--- a/tests/Aws/Tests/S3/Integration/StreamWrapperTest.php
+++ b/tests/Aws/Tests/S3/Integration/StreamWrapperTest.php
@@ -132,6 +132,20 @@ class StreamWrapperTest extends \Aws\Tests\IntegrationTestCase
     /**
      * @depends testOpensStreams
      */
+    public function testDoesNotRaiseErrorForMissingFile()
+    {
+        self::log('Testing invalid file');
+        $this->assertFalse(is_file('s3://ewfwefwfeweff/' . uniqid('foo')));
+        $this->assertFalse(is_link('s3://ewfwefwfeweff/' . uniqid('foo')));
+        try {
+            lstat('s3://ewfwefwfeweff/' . uniqid('foo'));
+            $this->fail('Did not trigger a warning');
+        } catch (\PHPUnit_Framework_Error_Warning $e) {}
+    }
+
+    /**
+     * @depends testOpensStreams
+     */
     public function testUploadsDir()
     {
         self::log('Uploading test directory under a prefix');

--- a/tests/Aws/Tests/S3/StreamWrapperTest.php
+++ b/tests/Aws/Tests/S3/StreamWrapperTest.php
@@ -95,8 +95,8 @@ class StreamWrapperTest extends \Guzzle\Tests\GuzzleTestCase
     }
 
     /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage simultaneous reading and writing
+     * @expectedException \PHPUnit_Framework_Error_Warning
+     * @expectedExceptionMessage The Amazon S3 stream wrapper does not allow simultaneous reading and writing.
      */
     public function testCanThrowExceptionsInsteadOfErrors()
     {


### PR DESCRIPTION
PHP stream wrappers provide flags to url_stat that should be used to determine
the response of a call and whether or not it raises an error. I've updated the
Amazon S3 stream wrapper to utilize these combinations of flags to emulate the
error handling of the "http" protocol stream wrapper.

I'm also removing the "throw_exceptions" option from the stream wrapper as that
completely breaks compatibility with other stream wrappers.

Closes #268 
