### PR TITLE
Fixing some environment variable reading logic.

### DIFF
--- a/tests/Aws/Tests/Common/Credentials/CredentialsTest.php
+++ b/tests/Aws/Tests/Common/Credentials/CredentialsTest.php
@@ -24,6 +24,9 @@ class CredentialsTest extends \Guzzle\Tests\GuzzleTestCase
 {
     public function setUp()
     {
+        putenv('HOME=');
+        putenv('HOMEDRIVE=');
+        putenv('HOMEPATH=');
         $_SERVER['HOME'] = null;
         $_SERVER['HOMEDRIVE'] = null;
         $_SERVER['HOMEPATH'] = null;


### PR DESCRIPTION
@mtdowling Was working on something and ran into an issue where it was not finding my HOME dir with `$_SERVER`, but it was finding it with `getenv()`. I think we need to always do `isset($_SERVER[...]) ? $_SERVER[...] : getenv(...)` in order to have max compatibility.
