### PR TITLE
Fixed regexp in isValidBucketName

### DIFF
--- a/src/Aws/S3/S3Client.php
+++ b/src/Aws/S3/S3Client.php
@@ -296,12 +296,10 @@ class S3Client extends AbstractClient
     {
         $bucketLen = strlen($bucket);
         if ($bucketLen < 3 || $bucketLen > 63 ||
-            // Cannot start or end with a '.'
-            $bucket[0] == '.' || $bucket[$bucketLen - 1] == '.' ||
             // Cannot look like an IP address
             preg_match('/(\d+\.){3}\d+$/', $bucket) ||
             // Cannot include special characters, must start and end with lower alnum
-            !preg_match('/^[a-z0-9][a-z0-9\-\.]*[a-z0-9]?$/', $bucket)
+            !preg_match('/^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$/', $bucket)
         ) {
             return false;
         }

--- a/tests/Aws/Tests/S3/S3ClientTest.php
+++ b/tests/Aws/Tests/S3/S3ClientTest.php
@@ -49,7 +49,9 @@ class S3ClientTest extends \Guzzle\Tests\GuzzleTestCase
             array('bucket-name', true),
             array('bucket', true),
             array('my.bucket.com', true),
-            array('test-fooCaps', false)
+            array('test-fooCaps', false),
+            array('w-w', true),
+            array('w------', false)
         );
     }
 


### PR DESCRIPTION
Fixed regexp so bucket names like "w------" are no longer valid
