### PR TITLE
Added support for the S3 SSE-CPK

### DIFF
--- a/src/Aws/S3/Resources/s3-2006-03-01.php
+++ b/src/Aws/S3/Resources/s3-2006-03-01.php
@@ -325,6 +325,36 @@ return array (
                     'location' => 'header',
                     'sentAs' => 'x-amz-website-redirect-location',
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
+                'CopySourceSSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-copy-source-server-side-encryption-customer-algorithm',
+                ),
+                'CopySourceSSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-copy-source-server-side-encryption-customer-key',
+                ),
+                'CopySourceSSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-copy-source-server-side-encryption-customer-key-MD5',
+                ),
                 'ACP' => array(
                     'type' => 'object',
                     'additionalProperties' => true,
@@ -518,6 +548,21 @@ return array (
                     'type' => 'string',
                     'location' => 'header',
                     'sentAs' => 'x-amz-website-redirect-location',
+                ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
                 ),
                 'ACP' => array(
                     'type' => 'object',
@@ -1008,6 +1053,21 @@ return array (
                     'location' => 'query',
                     'sentAs' => 'versionId',
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
                 'SaveAs' => array(
                     'location' => 'response_body',
                 ),
@@ -1160,6 +1220,21 @@ return array (
                     'type' => 'string',
                     'location' => 'query',
                     'sentAs' => 'versionId',
+                ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
                 ),
             ),
             'errorResponses' => array(
@@ -2151,6 +2226,21 @@ return array (
                     'location' => 'header',
                     'sentAs' => 'x-amz-website-redirect-location',
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
                 'ACP' => array(
                     'type' => 'object',
                     'additionalProperties' => true,
@@ -2383,6 +2473,21 @@ return array (
                     'location' => 'query',
                     'sentAs' => 'uploadId',
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
             ),
         ),
         'UploadPartCopy' => array(
@@ -2466,6 +2571,36 @@ return array (
                     'type' => 'string',
                     'location' => 'query',
                     'sentAs' => 'uploadId',
+                ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
+                'CopySourceSSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-copy-source-server-side-encryption-customer-algorithm',
+                ),
+                'CopySourceSSECustomerKey' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-copy-source-server-side-encryption-customer-key',
+                ),
+                'CopySourceSSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-copy-source-server-side-encryption-customer-key-MD5',
                 ),
                 'command.expects' => array(
                     'static' => true,
@@ -2553,6 +2688,16 @@ return array (
                     'location' => 'header',
                     'sentAs' => 'x-amz-server-side-encryption',
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
                 'RequestId' => array(
                     'location' => 'header',
                     'sentAs' => 'x-amz-request-id',
@@ -2594,6 +2739,16 @@ return array (
                     'type' => 'string',
                     'location' => 'header',
                     'sentAs' => 'x-amz-server-side-encryption',
+                ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
                 ),
                 'RequestId' => array(
                     'location' => 'header',
@@ -3313,6 +3468,16 @@ return array (
                         'type' => 'string',
                     ),
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
                 'RequestId' => array(
                     'location' => 'header',
                     'sentAs' => 'x-amz-request-id',
@@ -3500,6 +3665,16 @@ return array (
                     'additionalProperties' => array(
                         'type' => 'string',
                     ),
+                ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
                 ),
                 'RequestId' => array(
                     'location' => 'header',
@@ -4113,6 +4288,16 @@ return array (
                     'location' => 'header',
                     'sentAs' => 'x-amz-version-id',
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
                 'RequestId' => array(
                     'location' => 'header',
                     'sentAs' => 'x-amz-request-id',
@@ -4154,6 +4339,16 @@ return array (
                     'type' => 'string',
                     'location' => 'header',
                 ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
+                ),
                 'RequestId' => array(
                     'location' => 'header',
                     'sentAs' => 'x-amz-request-id',
@@ -4181,6 +4376,16 @@ return array (
                     'type' => 'string',
                     'location' => 'header',
                     'sentAs' => 'x-amz-server-side-encryption',
+                ),
+                'SSECustomerAlgorithm' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-algorithm',
+                ),
+                'SSECustomerKeyMD5' => array(
+                    'type' => 'string',
+                    'location' => 'header',
+                    'sentAs' => 'x-amz-server-side-encryption-customer-key-MD5',
                 ),
                 'RequestId' => array(
                     'location' => 'header',

--- a/src/Aws/S3/S3Client.php
+++ b/src/Aws/S3/S3Client.php
@@ -216,6 +216,9 @@ class S3Client extends AbstractClient
         // Allow for specifying bodies with file paths and file handles
         $client->addSubscriber(new UploadBodyListener(array('PutObject', 'UploadPart')));
 
+        // Ensures that if a SSE-CPK key is provided, the key and md5 are formatted correctly
+        $client->addSubscriber(new SseCpkListener);
+
         // Add aliases for some S3 operations
         $default = CompositeFactory::getDefaultChain($client);
         $default->add(

--- a/src/Aws/S3/SseCpkListener.php
+++ b/src/Aws/S3/SseCpkListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Aws\S3;
+
+use Guzzle\Common\Event;
+use Guzzle\Service\Command\CommandInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This listener simplifies the SSE-CPK process by encoding and hashing the key.
+ */
+class SseCpkListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array('command.before_prepare' => 'onCommandBeforePrepare');
+    }
+
+    public function onCommandBeforePrepare(Event $event)
+    {
+        /** @var CommandInterface $command */
+        $command = $event['command'];
+
+        // Prepare the normal SSE-CPK headers
+        if ($command['SSECustomerKey']) {
+            $this->prepareSseParams($command);
+        }
+
+        // If it's a copy operation, prepare the SSE-CPK headers for the source.
+        if ($command['CopySourceSSECustomerKey']) {
+            $this->prepareSseParams($command, true);
+        }
+    }
+
+    private function prepareSseParams(CommandInterface $command, $isCopy = false)
+    {
+        $prefix = $isCopy ? 'CopySource' : '';
+
+        // Base64 encode the provided key
+        $key = $command[$prefix . 'SSECustomerKey'];
+        $command[$prefix . 'SSECustomerKey'] = base64_encode($key);
+
+        // Base64 the provided MD5 or, generate an MD5 if not provided
+        if ($md5 = $command[$prefix . 'SSECustomerKeyMD5']) {
+            $command[$prefix . 'SSECustomerKeyMD5'] = base64_encode($md5);
+        } else {
+            $command[$prefix . 'SSECustomerKeyMD5'] = base64_encode(md5($key, true));
+        }
+    }
+}

--- a/tests/Aws/Tests/S3/SseCpkListenerTest.php
+++ b/tests/Aws/Tests/S3/SseCpkListenerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Aws\Tests\S3;
+
+use Aws\S3\SseCpkListener;
+use Guzzle\Common\Event;
+use Guzzle\Service\Command\AbstractCommand;
+
+/**
+ * @covers Aws\S3\SseCpkListener
+ */
+class SseCpkListenerTest extends \Guzzle\Tests\GuzzleTestCase
+{
+    /**
+     * @dataProvider getListenerTestCases
+     */
+    public function testSseCpkListener($operation, array $params, array $expectedResults)
+    {
+        $this->assertContains('onCommandBeforePrepare', SseCpkListener::getSubscribedEvents());
+
+        $command = $this->getMock('Guzzle\Service\Command\AbstractCommand', array('getName', 'build'), array($params));
+        $command->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue($operation));
+        $command->expects($this->any())
+            ->method('build')
+            ->will($this->returnSelf());
+
+        $event = new Event(array('command' => $command));
+        $listener = new SseCpkListener();
+        $listener->onCommandBeforePrepare($event);
+
+        foreach ($expectedResults as $key => $value) {
+            $this->assertEquals($value, $expectedResults[$key]);
+        }
+    }
+
+    public function getListenerTestCases()
+    {
+        return array(
+            array(
+                'CopyObject',
+                array(
+                    'SSECustomerKey' => 'foo',
+                    'CopySourceSSECustomerKey' => 'bar',
+                ),
+                array(
+                    'SSECustomerAlgorithm' => null,
+                    'SSECustomerKey' => base64_encode('foo'),
+                    'SSECustomerKeyMD5' => base64_encode(md5('foo', true)),
+                    'CopySourceSSECustomerKey' => base64_encode('bar'),
+                    'CopySourceSSECustomerKeyMD5' => base64_encode(md5('bar', true)),
+                )
+            ),
+            array(
+                'PutObject',
+                array(
+                    'SSECustomerKey' => 'foo',
+                    'SSECustomerKeyMD5' => 'bar',
+                ),
+                array(
+                    'SSECustomerKey' => base64_encode('foo'),
+                    'SSECustomerKeyMD5' => base64_encode('bar'),
+                )
+            ),
+            array(
+                'ListObjects',
+                array(),
+                array(
+                    'SSECustomerKey' => null,
+                    'SSECustomerKeyMD5' => null,
+                )
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Adding support for [S3 server-side encryption using customer-provided keys](https://aws.amazon.com/releasenotes/2836182191827379). This includes a listener that handle base64-encoding the key and setting the base64-encoded hash of the key.
