### PR TITLE
Updating to PHPUnit 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/cache": "~1.0",
         "ext-openssl": "*",
         "monolog/monolog": "1.4.*",
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "4.*",
         "symfony/class-loader": "2.*",
         "symfony/yaml": "2.*"
     },

--- a/phpunit.functional.xml.dist
+++ b/phpunit.functional.xml.dist
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./tests/bootstrap.php"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader">
-
+         colors="true">
     <php>
         <!-- If you want to run the integration tests, you will need to provide
              the path to a service configuration file. You WILL be charged

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./tests/bootstrap.php"
-         colors="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader">
+         colors="true">
 
     <testsuites>
         <testsuite name="Aws">
@@ -22,10 +15,6 @@
             <group>performance</group>
         </exclude>
     </groups>
-
-    <logging>
-        <log type="junit" target="build/artifacts/logs/junit.xml" logIncompleteSkipped="false" />
-    </logging>
 
     <filter>
         <whitelist>

--- a/tests/Aws/Tests/S3/Sync/AbstractSyncTest.php
+++ b/tests/Aws/Tests/S3/Sync/AbstractSyncTest.php
@@ -23,6 +23,13 @@ use Aws\S3\Sync\AbstractSync;
  */
 class AbstractSyncTest extends \Guzzle\Tests\GuzzleTestCase
 {
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.5.13') >= 0) {
+            $this->markTestSkipped('TODO: Remove once PHPUnit is tagged');
+        }
+    }
+
     /**
      * @expectedException \Guzzle\Common\Exception\InvalidArgumentException
      */

--- a/tests/Aws/Tests/S3/Sync/ChangedFilesIteratorTest.php
+++ b/tests/Aws/Tests/S3/Sync/ChangedFilesIteratorTest.php
@@ -24,6 +24,13 @@ use Aws\S3\Sync\KeyConverter;
  */
 class ChangedFilesIteratorTest extends \Guzzle\Tests\GuzzleTestCase
 {
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.5.13') >= 0) {
+            $this->markTestSkipped('TODO: Remove once PHPUnit is tagged');
+        }
+    }
+
     public function testRetrievesAndCachesTargetData()
     {
         $ctime = strtotime('January 1, 2013');

--- a/tests/Aws/Tests/S3/Sync/DownloadSyncTest.php
+++ b/tests/Aws/Tests/S3/Sync/DownloadSyncTest.php
@@ -25,6 +25,13 @@ use Aws\S3\Sync\KeyConverter;
  */
 class DownloadSyncTest extends \Guzzle\Tests\GuzzleTestCase
 {
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.5.13') >= 0) {
+            $this->markTestSkipped('TODO: Remove once PHPUnit is tagged');
+        }
+    }
+
     protected function getSplFile($filename)
     {
         $file = $this->getMockBuilder('SplFileInfo')

--- a/tests/Aws/Tests/S3/Sync/UploadSyncTest.php
+++ b/tests/Aws/Tests/S3/Sync/UploadSyncTest.php
@@ -30,6 +30,10 @@ class UploadSyncTest extends \Guzzle\Tests\GuzzleTestCase
 
     public function setUp()
     {
+        if (version_compare(PHP_VERSION, '5.5.13') >= 0) {
+            $this->markTestSkipped('TODO: Remove once PHPUnit is tagged');
+        }
+
         $this->tmpFile = null;
     }
 


### PR DESCRIPTION
- Requires not running tests that mock built-in classes without invoking
  the class constructor.
- We will need to update the tests once a new version of PHPUnit has been
  tag that addresses the issue.

See: https://github.com/php/php-src/commit/3586d14b61fbf3932650899d99a09e25784cf587
