### PR TITLE
Bug fix and test for throwing unhandled DynamoDbExceptions.

### DIFF
--- a/src/Aws/DynamoDb/Model/BatchRequest/WriteRequestBatchTransfer.php
+++ b/src/Aws/DynamoDb/Model/BatchRequest/WriteRequestBatchTransfer.php
@@ -104,6 +104,8 @@ class WriteRequestBatchTransfer implements BatchTransferInterface
                         $this->retryLargeRequest($request, $unprocessedRequests);
                     } elseif ($e->getExceptionCode() === 'ProvisionedThroughputExceededException') {
                         $this->handleUnprocessedRequestsAfterException($request, $unprocessedRequests);
+                    } else {
+                        $unhandledExceptions->add($e);
                     }
                 } else {
                     $unhandledExceptions->add($e);

--- a/tests/Aws/Tests/DynamoDb/Model/BatchRequest/WriteRequestBatchTransferTest.php
+++ b/tests/Aws/Tests/DynamoDb/Model/BatchRequest/WriteRequestBatchTransferTest.php
@@ -91,6 +91,12 @@ class WriteRequestBatchTransferTest extends \Guzzle\Tests\GuzzleTestCase
         $exceptionCollectionThroughput = new ExceptionCollection();
         $exceptionCollectionThroughput->add($throughputExceededException);
 
+        // Some DynamoDbException that will be rethrown, not handled (case #7)
+        $unhandledDynamoDbException = new DynamoDbException();
+        $unhandledDynamoDbException->setExceptionCode('UnhandledException');
+        $exceptionCollectionUnhandled = new ExceptionCollection();
+        $exceptionCollectionUnhandled->add($unhandledDynamoDbException);
+
         return array(
             array(
                 array('UnprocessedItems' => array()),
@@ -122,6 +128,11 @@ class WriteRequestBatchTransferTest extends \Guzzle\Tests\GuzzleTestCase
                 $this->throwException($exceptionCollectionThroughput),
                 'some-unprocessed-items'
             ),
+            array(
+                array('UnprocessedItems' => array()),
+                $this->throwException($exceptionCollectionUnhandled),
+                'exceptions-thrown'
+            )
         );
     }
 


### PR DESCRIPTION
When transferring a batch, certain DynamoDbExceptions are handled (retry large request, retry items rejected due to throttling).  Any other DynamoDbException were silently ignored.  The bug was introduced in https://github.com/aws/aws-sdk-php/commit/c882b65ae9f713d3f67a0c34a141f19ba4fa90d7#diff-bbde4badee36d6ebc40b1c7820e9196a.

This allows those exceptions to be thrown so the user can handle it rather than wondering why some of their data didn't get transferred.
