### PR TITLE
Corrected docblock @return type for AbstractUploadBuilder::getInstance.

### DIFF
--- a/src/Aws/Common/Model/MultipartUpload/AbstractUploadBuilder.php
+++ b/src/Aws/Common/Model/MultipartUpload/AbstractUploadBuilder.php
@@ -61,7 +61,7 @@ abstract class AbstractUploadBuilder
      *
      * @param AwsClientInterface $client Client to use
      *
-     * @return self
+     * @return $this
      */
     public function setClient(AwsClientInterface $client)
     {
@@ -78,7 +78,7 @@ abstract class AbstractUploadBuilder
      *                                             multipart upload. When an ID is passed, the builder will create a
      *                                             state object using the data from a ListParts API response.
      *
-     * @return self
+     * @return $this
      */
     public function resumeFrom($state)
     {
@@ -94,7 +94,7 @@ abstract class AbstractUploadBuilder
      *                                           You can also stream from a resource returned from fopen or a Guzzle
      *                                           {@see EntityBody} object.
      *
-     * @return self
+     * @return $this
      * @throws InvalidArgumentException when the source cannot be found or opened
      */
     public function setSource($source)
@@ -123,7 +123,7 @@ abstract class AbstractUploadBuilder
      *
      * @param array $headers Headers to add to the uploaded object
      *
-     * @return self
+     * @return $this
      */
     public function setHeaders(array $headers)
     {

--- a/src/Aws/Glacier/GlacierClient.php
+++ b/src/Aws/Glacier/GlacierClient.php
@@ -66,7 +66,7 @@ class GlacierClient extends AbstractClient
      *
      * @param array|Collection $config Client configuration data
      *
-     * @return self
+     * @return GlacierClient
      * @link http://docs.aws.amazon.com/aws-sdk-php/guide/latest/configuration.html#client-configuration-options
      */
     public static function factory($config = array())

--- a/src/Aws/Glacier/Model/MultipartUpload/TransferState.php
+++ b/src/Aws/Glacier/Model/MultipartUpload/TransferState.php
@@ -38,7 +38,7 @@ class TransferState extends AbstractTransferState
      */
     public static function fromUploadId(AwsClientInterface $client, UploadIdInterface $uploadId)
     {
-        $transferState = new self($uploadId);
+        $transferState = new static($uploadId);
         $listParts = $client->getIterator('ListParts', $uploadId->toParams());
 
         foreach ($listParts as $part) {
@@ -60,7 +60,7 @@ class TransferState extends AbstractTransferState
     /**
      * @param UploadPartGenerator $partGenerator Glacier upload helper object
      *
-     * @return self
+     * @return $this
      */
     public function setPartGenerator(UploadPartGenerator $partGenerator)
     {

--- a/src/Aws/Glacier/Model/MultipartUpload/UploadBuilder.php
+++ b/src/Aws/Glacier/Model/MultipartUpload/UploadBuilder.php
@@ -64,7 +64,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param string $accountId ID of the account
      *
-     * @return self
+     * @return $this
      */
     public function setAccountId($accountId)
     {
@@ -78,7 +78,7 @@ class UploadBuilder extends AbstractUploadBuilder
       *
       * @param string $vaultName Name of the vault
       *
-      * @return self
+      * @return $this
      */
     public function setVaultName($vaultName)
     {
@@ -92,7 +92,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param int $partSize Upload part size
      *
-     * @return self
+     * @return $this
      */
     public function setPartSize($partSize)
     {
@@ -106,7 +106,7 @@ class UploadBuilder extends AbstractUploadBuilder
       *
       * @param string $archiveDescription Archive description
       *
-      * @return self
+      * @return $this
      */
     public function setArchiveDescription($archiveDescription)
     {
@@ -121,7 +121,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param int $concurrency Concurrency level
      *
-     * @return self
+     * @return $this
      */
     public function setConcurrency($concurrency)
     {
@@ -135,7 +135,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param UploadPartGenerator $partGenerator Glacier upload helper object
      *
-     * @return self
+     * @return $this
      */
     public function setPartGenerator(UploadPartGenerator $partGenerator)
     {

--- a/src/Aws/Glacier/Model/MultipartUpload/UploadPartContext.php
+++ b/src/Aws/Glacier/Model/MultipartUpload/UploadPartContext.php
@@ -74,7 +74,7 @@ class UploadPartContext
      *
      * @param string $data Data to add to the context
      *
-     * @return self
+     * @return $this
      * @throws LogicException when the context is already finalized
      */
     public function addData($data)

--- a/src/Aws/S3/Model/Acp.php
+++ b/src/Aws/S3/Model/Acp.php
@@ -54,7 +54,7 @@ class Acp implements ToArrayInterface, \IteratorAggregate, \Countable
      *
      * @param array $data Array of ACP data
      *
-     * @return self
+     * @return Acp
      */
     public static function fromArray(array $data)
     {
@@ -100,7 +100,7 @@ class Acp implements ToArrayInterface, \IteratorAggregate, \Countable
      *
      * @param Grantee $owner ACP policy owner
      *
-     * @return self
+     * @return $this
      *
      * @throws InvalidArgumentException if the grantee does not have an ID set
      */
@@ -130,7 +130,7 @@ class Acp implements ToArrayInterface, \IteratorAggregate, \Countable
      *
      * @param array|\Traversable $grants List of grants for the ACP
      *
-     * @return self
+     * @return $this
      *
      * @throws InvalidArgumentException
      */
@@ -167,7 +167,7 @@ class Acp implements ToArrayInterface, \IteratorAggregate, \Countable
      *
      * @param Grant $grant Grant to add
      *
-     * @return self
+     * @return $this
      */
     public function addGrant(Grant $grant)
     {
@@ -205,7 +205,7 @@ class Acp implements ToArrayInterface, \IteratorAggregate, \Countable
      *
      * @param AbstractCommand $command Command to be updated
      *
-     * @return self
+     * @return $this
      */
     public function updateCommand(AbstractCommand $command)
     {

--- a/src/Aws/S3/Model/AcpBuilder.php
+++ b/src/Aws/S3/Model/AcpBuilder.php
@@ -36,11 +36,11 @@ class AcpBuilder
     /**
      * Static method for chainable instantiation
      *
-     * @return self
+     * @return static
      */
     public static function newInstance()
     {
-        return new self;
+        return new static;
     }
 
     /**
@@ -49,7 +49,7 @@ class AcpBuilder
      * @param string $id          Owner identifier
      * @param string $displayName Owner display name
      *
-     * @return self
+     * @return $this
      */
     public function setOwner($id, $displayName = null)
     {
@@ -65,7 +65,7 @@ class AcpBuilder
      * @param string $id          Grantee identifier
      * @param string $displayName Grantee display name
      *
-     * @return self
+     * @return $this
      */
     public function addGrantForUser($permission, $id, $displayName = null)
     {
@@ -81,7 +81,7 @@ class AcpBuilder
      * @param string $permission Permission for the Grant
      * @param string $email      Grantee email address
      *
-     * @return self
+     * @return $this
      */
     public function addGrantForEmail($permission, $email)
     {
@@ -97,7 +97,7 @@ class AcpBuilder
      * @param string $permission Permission for the Grant
      * @param string $group      Grantee group
      *
-     * @return self
+     * @return $this
      */
     public function addGrantForGroup($permission, $group)
     {
@@ -113,7 +113,7 @@ class AcpBuilder
      * @param string  $permission Permission for the Grant
      * @param Grantee $grantee    The Grantee for the Grant
      *
-     * @return self
+     * @return $this
      */
     public function addGrant($permission, Grantee $grantee)
     {

--- a/src/Aws/S3/Model/ClearBucket.php
+++ b/src/Aws/S3/Model/ClearBucket.php
@@ -81,7 +81,7 @@ class ClearBucket extends AbstractHasDispatcher
      *
      * @param string $bucket Name of the bucket to clear
      *
-     * @return self
+     * @return $this
      */
     public function setBucket($bucket)
     {
@@ -114,7 +114,7 @@ class ClearBucket extends AbstractHasDispatcher
      *
      * @param \Iterator $iterator Iterator used to yield the keys to be deleted
      *
-     * @return self
+     * @return $this
      */
     public function setIterator(\Iterator $iterator)
     {
@@ -129,7 +129,7 @@ class ClearBucket extends AbstractHasDispatcher
      * @param string $mfa MFA token to send with each request. The value is the concatenation of the authentication
      *                    device's serial number, a space, and the value displayed on your authentication device.
      *
-     * @return self
+     * @return $this
      */
     public function setMfa($mfa)
     {

--- a/src/Aws/S3/Model/DeleteObjectsBatch.php
+++ b/src/Aws/S3/Model/DeleteObjectsBatch.php
@@ -38,7 +38,7 @@ class DeleteObjectsBatch extends AbstractBatchDecorator
      * @param string             $bucket Bucket that contains the objects to delete
      * @param string             $mfa    MFA token to use with the request
      *
-     * @return self
+     * @return static
      */
     public static function factory(AwsClientInterface $client, $bucket, $mfa = null)
     {
@@ -47,7 +47,7 @@ class DeleteObjectsBatch extends AbstractBatchDecorator
             ->transferWith(new DeleteObjectsTransfer($client, $bucket, $mfa))
             ->build();
 
-        return new self($batch);
+        return new static($batch);
     }
 
     /**
@@ -56,7 +56,7 @@ class DeleteObjectsBatch extends AbstractBatchDecorator
      * @param string $key       Key of the object
      * @param string $versionId VersionID of the object
      *
-     * @return self
+     * @return $this
      */
     public function addKey($key, $versionId = null)
     {
@@ -82,6 +82,6 @@ class DeleteObjectsBatch extends AbstractBatchDecorator
             throw new InvalidArgumentException('Item must be a DeleteObject command or array containing a Key and VersionId key.');
         }
 
-        return $this->decoratedBatch->add($item);
+        return parent::add($item);
     }
 }

--- a/src/Aws/S3/Model/DeleteObjectsTransfer.php
+++ b/src/Aws/S3/Model/DeleteObjectsTransfer.php
@@ -64,7 +64,7 @@ class DeleteObjectsTransfer implements BatchTransferInterface
      *
      * @param string $token MFA token
      *
-     * @return self
+     * @return $this
      */
     public function setMfa($token)
     {

--- a/src/Aws/S3/Model/Grant.php
+++ b/src/Aws/S3/Model/Grant.php
@@ -63,7 +63,7 @@ class Grant implements ToArrayInterface
      *
      * @param Grantee $grantee Affected grantee
      *
-     * @return self
+     * @return $this
      */
     public function setGrantee(Grantee $grantee)
     {
@@ -87,7 +87,7 @@ class Grant implements ToArrayInterface
      *
      * @param string $permission Permission applied
      *
-     * @return self
+     * @return $this
      *
      * @throws InvalidArgumentException
      */

--- a/src/Aws/S3/Model/Grantee.php
+++ b/src/Aws/S3/Model/Grantee.php
@@ -214,7 +214,7 @@ class Grantee implements ToArrayInterface
      */
     public function getHeaderValue()
     {
-        $key = self::$headerMap[$this->type];
+        $key = static::$headerMap[$this->type];
 
         return "{$key}=\"{$this->id}\"";
     }

--- a/src/Aws/S3/Model/MultipartUpload/UploadBuilder.php
+++ b/src/Aws/S3/Model/MultipartUpload/UploadBuilder.php
@@ -67,7 +67,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param string $bucket Name of the bucket
      *
-     * @return self
+     * @return $this
      */
     public function setBucket($bucket)
     {
@@ -79,7 +79,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param string $key Key of the object to upload
      *
-     * @return self
+     * @return $this
      */
     public function setKey($key)
     {
@@ -91,7 +91,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param int $minSize Minimum acceptable part size in bytes
      *
-     * @return self
+     * @return $this
      */
     public function setMinPartSize($minSize)
     {
@@ -107,7 +107,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param int $concurrency Concurrency level
      *
-     * @return self
+     * @return $this
      */
     public function setConcurrency($concurrency)
     {
@@ -121,7 +121,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param string $md5 MD5 hash of the entire body
      *
-     * @return self
+     * @return $this
      */
     public function setMd5($md5)
     {
@@ -137,7 +137,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param bool $calculateMd5 Set to true to calculate the MD5 hash of the body
      *
-     * @return self
+     * @return $this
      */
     public function calculateMd5($calculateMd5)
     {
@@ -152,7 +152,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param bool $usePartMd5 Set to true to calculate the MD5 has of each part
      *
-     * @return self
+     * @return $this
      */
     public function calculatePartMd5($usePartMd5)
     {
@@ -166,7 +166,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param Acp $acp ACP to set on the object
      *
-     * @return self
+     * @return $this
      */
     public function setAcp(Acp $acp)
     {
@@ -179,7 +179,7 @@ class UploadBuilder extends AbstractUploadBuilder
      * @param string $name  Option name
      * @param string $value Option value
      *
-     * @return self
+     * @return $this
      */
     public function setOption($name, $value)
     {
@@ -193,7 +193,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param array $options Array of CreateMultipartUpload operation parameters
      *
-     * @return self
+     * @return $this
      */
     public function addOptions(array $options)
     {
@@ -207,7 +207,7 @@ class UploadBuilder extends AbstractUploadBuilder
      *
      * @param array $options Transfer options
      *
-     * @return self
+     * @return $this
      */
     public function setTransferOptions(array $options)
     {

--- a/src/Aws/S3/S3Client.php
+++ b/src/Aws/S3/S3Client.php
@@ -156,7 +156,7 @@ class S3Client extends AbstractClient
      *
      * @param array|Collection $config Client configuration data
      *
-     * @return self
+     * @return S3Client
      * @link http://docs.aws.amazon.com/aws-sdk-php/guide/latest/configuration.html#client-configuration-options
      */
     public static function factory($config = array())
@@ -165,10 +165,10 @@ class S3Client extends AbstractClient
 
         // Configure the custom exponential backoff plugin for retrying S3 specific errors
         if (!isset($config[Options::BACKOFF])) {
-            $config[Options::BACKOFF] = self::createBackoffPlugin($exceptionParser);
+            $config[Options::BACKOFF] = static::createBackoffPlugin($exceptionParser);
         }
 
-        $config[Options::SIGNATURE] = $signature = self::createSignature($config);
+        $config[Options::SIGNATURE] = $signature = static::createSignature($config);
 
         $client = ClientBuilder::factory(__NAMESPACE__)
             ->setConfig($config)
@@ -222,7 +222,7 @@ class S3Client extends AbstractClient
         // Add aliases for some S3 operations
         $default = CompositeFactory::getDefaultChain($client);
         $default->add(
-            new AliasFactory($client, self::$commandAliases),
+            new AliasFactory($client, static::$commandAliases),
             'Guzzle\Service\Command\Factory\ServiceDescriptionFactory'
         );
         $client->setCommandFactory($default);
@@ -456,7 +456,7 @@ class S3Client extends AbstractClient
     /**
      * Register the Amazon S3 stream wrapper and associates it with this client object
      *
-     * @return self
+     * @return $this
      */
     public function registerStreamWrapper()
     {

--- a/src/Aws/S3/Sync/AbstractSyncBuilder.php
+++ b/src/Aws/S3/Sync/AbstractSyncBuilder.php
@@ -65,7 +65,7 @@ abstract class AbstractSyncBuilder
     protected $debug;
 
     /**
-     * @return self
+     * @return static
      */
     public static function getInstance()
     {
@@ -77,7 +77,7 @@ abstract class AbstractSyncBuilder
      *
      * @param string $bucket Amazon S3 bucket name
      *
-     * @return self
+     * @return $this
      */
     public function setBucket($bucket)
     {
@@ -91,7 +91,7 @@ abstract class AbstractSyncBuilder
      *
      * @param S3Client $client Amazon S3 client
      *
-     * @return self
+     * @return $this
      */
     public function setClient(S3Client $client)
     {
@@ -105,7 +105,7 @@ abstract class AbstractSyncBuilder
      *
      * @param \Iterator $iterator
      *
-     * @return self
+     * @return $this
      */
     public function setSourceIterator(\Iterator $iterator)
     {
@@ -119,7 +119,7 @@ abstract class AbstractSyncBuilder
      *
      * @param FileNameConverterInterface $converter Filename to object key provider
      *
-     * @return self
+     * @return $this
      */
     public function setSourceFilenameConverter(FilenameConverterInterface $converter)
     {
@@ -133,7 +133,7 @@ abstract class AbstractSyncBuilder
      *
      * @param FileNameConverterInterface $converter Filename to object key provider
      *
-     * @return self
+     * @return $this
      */
     public function setTargetFilenameConverter(FilenameConverterInterface $converter)
     {
@@ -148,7 +148,7 @@ abstract class AbstractSyncBuilder
      *
      * @param string $baseDir Base directory, which will be deleted from each uploaded object key
      *
-     * @return self
+     * @return $this
      */
     public function setBaseDir($baseDir)
     {
@@ -164,7 +164,7 @@ abstract class AbstractSyncBuilder
      *
      * @param string $keyPrefix Prefix for each uploaded key
      *
-     * @return self
+     * @return $this
      */
     public function setKeyPrefix($keyPrefix)
     {
@@ -179,7 +179,7 @@ abstract class AbstractSyncBuilder
      *
      * @param string $delimiter Delimiter to use to separate paths
      *
-     * @return self
+     * @return $this
      */
     public function setDelimiter($delimiter)
     {
@@ -193,7 +193,7 @@ abstract class AbstractSyncBuilder
      *
      * @param array $params Associative array of PutObject (upload) GetObject (download) parameters
      *
-     * @return self
+     * @return $this
      */
     public function setOperationParams(array $params)
     {
@@ -207,7 +207,7 @@ abstract class AbstractSyncBuilder
      *
      * @param int $concurrency Number of concurrent transfers
      *
-     * @return self
+     * @return $this
      */
     public function setConcurrency($concurrency)
     {
@@ -221,7 +221,7 @@ abstract class AbstractSyncBuilder
      *
      * @param bool $force Set to true to force transfers without checking if it has changed
      *
-     * @return self
+     * @return $this
      */
     public function force($force = false)
     {
@@ -235,7 +235,7 @@ abstract class AbstractSyncBuilder
      *
      * @param bool|resource $enabledOrResource Set to true or false to enable or disable debug output. Pass an opened
      *                                         fopen resource to write to instead of writing to standard out.
-     * @return self
+     * @return $this
      */
     public function enableDebugOutput($enabledOrResource = true)
     {
@@ -249,7 +249,7 @@ abstract class AbstractSyncBuilder
      *
      * @param string $search Regular expression search (in preg_match format). Any filename that matches this regex
      *                       will not be transferred.
-     * @return self
+     * @return $this
      */
     public function addRegexFilter($search)
     {
@@ -301,7 +301,7 @@ abstract class AbstractSyncBuilder
     /**
      * Hook to implement in subclasses
      *
-     * @return self
+     * @return AbstractSync
      */
     abstract protected function specificBuild();
 

--- a/src/Aws/S3/Sync/DownloadSyncBuilder.php
+++ b/src/Aws/S3/Sync/DownloadSyncBuilder.php
@@ -38,7 +38,7 @@ class DownloadSyncBuilder extends AbstractSyncBuilder
      *
      * @param string $directory Directory
      *
-     * @return self
+     * @return $this
      */
     public function setDirectory($directory)
     {

--- a/src/Aws/S3/Sync/UploadSyncBuilder.php
+++ b/src/Aws/S3/Sync/UploadSyncBuilder.php
@@ -36,7 +36,7 @@ class UploadSyncBuilder extends AbstractSyncBuilder
      *
      * @param string $path Path that contains files to upload
      *
-     * @return self
+     * @return $this
      */
     public function uploadFromDirectory($path)
     {
@@ -54,7 +54,7 @@ class UploadSyncBuilder extends AbstractSyncBuilder
      *
      * @param string $glob Glob expression
      *
-     * @return self
+     * @return $this
      * @link http://www.php.net/manual/en/function.glob.php
      */
     public function uploadFromGlob($glob)
@@ -71,7 +71,7 @@ class UploadSyncBuilder extends AbstractSyncBuilder
      *
      * @param string $acl Canned ACL for each upload
      *
-     * @return self
+     * @return $this
      */
     public function setAcl($acl)
     {
@@ -85,7 +85,7 @@ class UploadSyncBuilder extends AbstractSyncBuilder
      *
      * @param Acp $acp Access control policy
      *
-     * @return self
+     * @return $this
      */
     public function setAcp(Acp $acp)
     {
@@ -100,7 +100,7 @@ class UploadSyncBuilder extends AbstractSyncBuilder
      *
      * @param int $size Size threshold
      *
-     * @return self
+     * @return $this
      */
     public function setMultipartUploadSize($size)
     {


### PR DESCRIPTION
The @return type self doesn't respect late binding. So analysers will thing the return type is an AbstractUploadBuilder, which is incorrect. Setting the return type to static will fix this.
