### PR TITLE
serializer url encode placeholder replace

### DIFF
--- a/src/Common/Api/Serializer/RestSerializer.php
+++ b/src/Common/Api/Serializer/RestSerializer.php
@@ -189,7 +189,7 @@ abstract class RestSerializer
         // Expand path place holders using Amazon's slightly different URI
         // template syntax.
         return preg_replace_callback(
-            '/\{([^\}]+)\}/',
+            '/%7B([^%7D]+)%7D/',
             function (array $matches) use ($varspecs) {
                 $isGreedy = substr($matches[1], -1, 1) == '+';
                 $k = $isGreedy ? substr($matches[1], 0, -1) : $matches[1];


### PR DESCRIPTION
Hi,

I recently tried the v3 beta version because of a bug in the v2 branch I was not able to resolve.

In this version, a file push to a S3 bucket has a strange name : 

```
$client = ... instance of a S3Client ....
$client->upload('my_bucket', 'data.txt', '');
```

It creates a file with name : BKey+}. After investigating, it seems that in the RestSerializer, you init a request object using guzzle Http. However it returns an uri with all parameters urlencoded event the aws placeholder. So they cannot be replaced in the following preg_replace_callback.

This pull request is a possible fix but I am not really sure it is the way to go for fixing this problem.

Regards.
