### PR TITLE
add eu-central-1 region to s3 definition file

### DIFF
--- a/src/Aws/S3/Resources/s3-2006-03-01.php
+++ b/src/Aws/S3/Resources/s3-2006-03-01.php
@@ -45,6 +45,11 @@ return array (
             'https' => true,
             'hostname' => 's3-eu-west-1.amazonaws.com',
         ),
+        'eu-central-1' => array(
+            'http' => true,
+            'https' => true,
+            'hostname' => 's3-eu-central-1.amazonaws.com',
+        ),
         'ap-northeast-1' => array(
             'http' => true,
             'https' => true,


### PR DESCRIPTION
hi guys,

i don't know, if the resource-definitions are deprecated, but the lack of the 'eu-central-1' region leads to an error in a deprecated method in AbstractClient (https://github.com/aws/aws-sdk-php/blob/master/src/Aws/Common/Client/AbstractClient.php#L115)
