### PR TITLE
No need to move bucket to host for some commands

### DIFF
--- a/src/Aws/S3/BucketStyleListener.php
+++ b/src/Aws/S3/BucketStyleListener.php
@@ -24,9 +24,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class BucketStyleListener implements EventSubscriberInterface
 {
-    /**
-     * {@inheritdoc}
-     */
+    private static $exclusions = array('GetBucketLocation' => true);
+
     public static function getSubscribedEvents()
     {
         return array('command.after_prepare' => array('onCommandAfterPrepare', -255));
@@ -43,6 +42,11 @@ class BucketStyleListener implements EventSubscriberInterface
         $bucket = $command['Bucket'];
         $request = $command->getRequest();
         $pathStyle = false;
+
+        // Skip operations that do not need the bucket moved to the host.
+        if (isset(self::$exclusions[$command->getName()])) {
+            return;
+        }
 
         if ($key = $command['Key']) {
             // Modify the command Key to account for the {/Key*} explosion into an array

--- a/tests/Aws/Tests/S3/BucketStyleListenerTest.php
+++ b/tests/Aws/Tests/S3/BucketStyleListenerTest.php
@@ -78,4 +78,14 @@ class BucketStyleListenerTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertEquals('foo.s3.amazonaws.com', $command->getRequest()->getHost());
         $this->assertEquals('/Bar', $command->getRequest()->getResource());
     }
+
+    public function testIgnoresExcludedCommands()
+    {
+        $s3 = $this->getServiceBuilder()->get('s3');
+        $this->setMockResponse($s3, array(new Response(200)));
+        $command = $s3->getCommand('GetBucketLocation', array('Bucket' => 'foo'));
+        $command->execute();
+        $this->assertEquals('s3.amazonaws.com', $command->getRequest()->getHost());
+        $this->assertEquals('/foo?location', $command->getRequest()->getResource());
+    }
 }


### PR DESCRIPTION
This commit updates the BucketStyleListener to not move the bucket name
to the host header for specific excluded operations. For example, this
makes it possible to iterate over your buckets and call
getBucketLocation on them without worrying about signature version 4
only regions like eu-central-1.
