### PR TITLE
Support pagination (of Instances) in DescribeInstances

### DIFF
--- a/src/Common/Resources/api/ec2-2014-09-01.paginators.php
+++ b/src/Common/Resources/api/ec2-2014-09-01.paginators.php
@@ -34,7 +34,10 @@
       'result_key' => 'InstanceStatuses',
     ],
     'DescribeInstances' => [
-      'result_key' => 'Reservations',
+      'input_token' => 'NextToken',
+      'output_token' => 'NextToken',
+      'result_key' => 'Reservations[].Instances[]',
+      'limit_key' => 'MaxResults',
     ],
     'DescribeInternetGateways' => [
       'result_key' => 'InternetGateways',


### PR DESCRIPTION
This gives the behavior I would expect, and is similar to what how ```getIterator()``` used to work for DescribeInstances in the sense that it flatten out the reservations. It's hard to tell if ```getIterator()``` is still supposed to work this way since it currently doesn't work at all (see #419).