### PR TITLE
Always add SignatureListener, even on NullCredential requests

### DIFF
--- a/src/Aws/Common/Client/AbstractClient.php
+++ b/src/Aws/Common/Client/AbstractClient.php
@@ -83,9 +83,7 @@ abstract class AbstractClient extends Client implements AwsClientInterface
 
         // Add the event listener so that requests are signed before they are sent
         $dispatcher = $this->getEventDispatcher();
-        if (!$credentials instanceof NullCredentials) {
-            $dispatcher->addSubscriber(new SignatureListener($credentials, $signature));
-        }
+        $dispatcher->addSubscriber(new SignatureListener($credentials, $signature));
 
         if ($backoff = $config->get(Options::BACKOFF)) {
             $dispatcher->addSubscriber($backoff, -255);

--- a/src/Aws/Common/Signature/SignatureListener.php
+++ b/src/Aws/Common/Signature/SignatureListener.php
@@ -17,6 +17,7 @@
 namespace Aws\Common\Signature;
 
 use Aws\Common\Credentials\CredentialsInterface;
+use Aws\Common\Credentials\NullCredentials;
 use Guzzle\Common\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -75,6 +76,8 @@ class SignatureListener implements EventSubscriberInterface
      */
     public function onRequestBeforeSend(Event $event)
     {
-        $this->signature->signRequest($event['request'], $this->credentials);
+        if(!$this->credentials instanceof NullCredentials) {
+            $this->signature->signRequest($event['request'], $this->credentials);
+        }
     }
 }

--- a/tests/Aws/Tests/Common/Signature/SignatureListenerTest.php
+++ b/tests/Aws/Tests/Common/Signature/SignatureListenerTest.php
@@ -17,6 +17,7 @@
 namespace Aws\Tests\Common\Signature;
 
 use Aws\Common\Credentials\Credentials;
+use Aws\Common\Credentials\NullCredentials;
 use Aws\Common\Signature\SignatureListener;
 use Guzzle\Common\Collection;
 use Guzzle\Http\Message\Request;
@@ -44,6 +45,26 @@ class SignatureListenerTest extends \Guzzle\Tests\GuzzleTestCase
         // Create a mock event
         $event = new Event(array(
             'request' => $request
+        ));
+
+        $listener->onRequestBeforeSend($event);
+    }
+
+    public function testDoesNotSignNullCredentialRequests() {
+        $request = new Request('GET', 'http://www.example.com');
+        $request->getEventDispatcher();
+        $credentials = new NullCredentials();
+        $signature = $this->getMock('Aws\Common\Signature\SignatureV4');
+
+        // Ensure that signing the request occurred once with the correct args
+        $signature->expects($this->never())
+          ->method('signRequest');
+
+        $listener = new SignatureListener($credentials, $signature);
+
+        // Create a mock event
+        $event = new Event(array(
+          'request' => $request
         ));
 
         $listener->onRequestBeforeSend($event);


### PR DESCRIPTION
Creating a new S3Client using NullCredentials, then setting legitimate credentials later on causes Authorization errors.  This is because the SignatureListener is only added when the client is created with NullCredentials, meaning the listener cannot respond to the client.credentials_changed event.  This pull request changes things so the listener is always added, and moves the check for NullCredentials into the SignatureListener plugin.