### PR TITLE
Moving client factories to a single directory

### DIFF
--- a/src/ClientFactory/ClientFactory.php
+++ b/src/ClientFactory/ClientFactory.php
@@ -1,10 +1,13 @@
 <?php
-namespace Aws;
+namespace Aws\ClientFactory;
 
 use InvalidArgumentException as IAE;
+use Aws\Sdk;
+use Aws\AwsClientInterface;
 use Aws\Api\FilesystemApiProvider;
 use Aws\Api\Service;
 use Aws\Api\Validator;
+use Aws\EndpointProvider;
 use Aws\Credentials\Credentials;
 use Aws\Credentials\CredentialsInterface;
 use Aws\Credentials\NullCredentials;
@@ -137,7 +140,7 @@ class ClientFactory
         }
 
         if (!isset($args['api_provider'])) {
-            $args['api_provider'] = new FilesystemApiProvider(__DIR__ . '/data');
+            $args['api_provider'] = new FilesystemApiProvider(__DIR__ . '/../data');
         }
 
         if (!isset($args['endpoint_provider'])) {

--- a/src/ClientFactory/CloudSearchDomain.php
+++ b/src/ClientFactory/CloudSearchDomain.php
@@ -1,13 +1,12 @@
 <?php
-namespace Aws\CloudSearchDomain;
+namespace Aws\ClientFactory;
 
-use Aws\ClientFactory;
 use GuzzleHttp\Url;
 
 /**
  * @internal
  */
-class CloudSearchDomainFactory extends ClientFactory
+class CloudSearchDomain extends ClientFactory
 {
     /**
      * {@inheritdoc}

--- a/src/ClientFactory/DynamoDb.php
+++ b/src/ClientFactory/DynamoDb.php
@@ -1,7 +1,6 @@
 <?php
-namespace Aws\DynamoDb;
+namespace Aws\ClientFactory;
 
-use Aws\ClientFactory;
 use Aws\Retry\ThrottlingFilter;
 use Aws\Retry\Crc32Filter;
 use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
@@ -9,7 +8,7 @@ use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
 /**
  * @internal
  */
-class DynamoDbFactory extends ClientFactory
+class DynamoDb extends ClientFactory
 {
     protected function createClient(array $args)
     {

--- a/src/ClientFactory/Glacier.php
+++ b/src/ClientFactory/Glacier.php
@@ -1,13 +1,13 @@
 <?php
-namespace Aws\Glacier;
+namespace Aws\ClientFactory;
 
-use Aws\ClientFactory;
 use Aws\Subscriber\SourceFile;
+use Aws\Glacier\ApplyChecksumsSubscriber;
 
 /**
  * @internal
  */
-class GlacierFactory extends ClientFactory
+class Glacier extends ClientFactory
 {
     protected function createClient(array $args)
     {

--- a/src/ClientFactory/Route53.php
+++ b/src/ClientFactory/Route53.php
@@ -1,12 +1,12 @@
 <?php
-namespace Aws\Route53;
+namespace Aws\ClientFactory;
 
-use Aws\ClientFactory;
+use Aws\Route53\CleanIdSubscriber;
 
 /**
  * @internal
  */
-class Route53Factory extends ClientFactory
+class Route53 extends ClientFactory
 {
     protected function createClient(array $args)
     {

--- a/src/ClientFactory/S3.php
+++ b/src/ClientFactory/S3.php
@@ -1,13 +1,18 @@
 <?php
-namespace Aws\S3;
+namespace Aws\ClientFactory;
 
-use Aws\ClientFactory;
 use Aws\Retry\S3TimeoutFilter;
 use Aws\Signature\S3Signature;
 use Aws\Signature\S3SignatureV4;
 use Aws\Signature\SignatureV4;
 use Aws\Subscriber\SaveAs;
 use Aws\Subscriber\SourceFile;
+use Aws\S3\ApplyMd5Subscriber;
+use Aws\S3\PutObjectUrlSubscriber;
+use Aws\S3\BucketStyleSubscriber;
+use Aws\S3\SSECSubscriber;
+use Aws\S3\PermanentRedirectSubscriber;
+use Aws\S3\S3UriParser;
 use GuzzleHttp\Message\ResponseInterface;
 use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
 
@@ -21,7 +26,7 @@ use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
  *
  * @internal
  */
-class S3Factory extends ClientFactory
+class S3 extends ClientFactory
 {
     /**
      * {@inheritdoc}

--- a/src/ClientFactory/Sqs.php
+++ b/src/ClientFactory/Sqs.php
@@ -1,13 +1,16 @@
 <?php
-namespace Aws\Sqs;
+namespace Aws\ClientFactory;
 
-use Aws\ClientFactory;
+use Aws\Sqs\QueueUrlSubscriber;
+use Aws\Sqs\Md5ValidatorSubscriber;
 
 /**
  * Modifies the host used when connecting to queues and validates the MD5 body
  * of received messages.
+ *
+ * @internal
  */
-class SqsFactory extends ClientFactory
+class Sqs extends ClientFactory
 {
     protected function createClient(array $args)
     {

--- a/src/ClientFactory/Sts.php
+++ b/src/ClientFactory/Sts.php
@@ -1,12 +1,10 @@
 <?php
-namespace Aws\Sts;
-
-use Aws\ClientFactory;
+namespace Aws\ClientFactory;
 
 /**
  * @internal
  */
-class StsFactory extends ClientFactory
+class Sts extends ClientFactory
 {
     /**
      * {@inheritdoc}

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -217,12 +217,12 @@ class Sdk
         // Set the service name and determine if it is linked to a known class
         $args['service'] = $name;
         $args['class_name'] = false;
-        $factoryName = 'Aws\ClientFactory';
+        $factoryName = 'Aws\\ClientFactory\\ClientFactory';
 
         if (isset(self::$services[$name])) {
             $args['class_name'] = self::$services[$name];
-            if (class_exists("Aws\\{$args['class_name']}\\{$args['class_name']}Factory")) {
-                $factoryName = "Aws\\{$args['class_name']}\\{$args['class_name']}Factory";
+            if (class_exists("Aws\\ClientFactory\\{$args['class_name']}")) {
+                $factoryName = "Aws\\ClientFactory\\{$args['class_name']}";
             }
         }
 

--- a/tests/Api/Serializer/ComplianceTest.php
+++ b/tests/Api/Serializer/ComplianceTest.php
@@ -3,7 +3,7 @@ namespace Aws\Test\Api\Serializer;
 
 use Aws\Api\Service;
 use Aws\AwsClient;
-use Aws\ClientFactory;
+use Aws\ClientFactory\ClientFactory;
 use Aws\Credentials\NullCredentials;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Client;
@@ -72,7 +72,7 @@ class ComplianceTest extends \PHPUnit_Framework_TestCase
             'api' => $service,
             'credentials' => new NullCredentials(),
             'client' => new Client(),
-            'signature' => $this->getMock('Aws\Commom\Signature\SignatureInterface'),
+            'signature' => $this->getMock('Aws\Signature\SignatureInterface'),
             'region' => 'us-west-2',
             'endpoint' => $ep,
             'error_parser' => Service::createErrorParser($service->getProtocol()),

--- a/tests/ClientFactory/ClientFactoryTest.php
+++ b/tests/ClientFactory/ClientFactoryTest.php
@@ -1,17 +1,17 @@
 <?php
-namespace Aws\Test\Common;
+namespace Aws\Test\ClientFactory;
 
+use Aws\ClientFactory\ClientFactory;
 use Aws\Credentials\Credentials;
 use Aws\Credentials\NullCredentials;
 use Aws\Exception\AwsException;
-use Aws\ClientFactory;
 use Aws\Test\SdkTest;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Client;
 use Aws\Credentials\Provider;
 
 /**
- * @covers Aws\ClientFactory
+ * @covers Aws\ClientFactory\ClientFactory
  */
 class ClientFactoryTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/ClientFactory/CloudSearchDomainTest.php
+++ b/tests/ClientFactory/CloudSearchDomainTest.php
@@ -1,24 +1,24 @@
 <?php
-namespace Aws\Test\CloudSearchDomain;
+namespace Aws\Test\ClientFactory;
 
-use Aws\CloudSearchDomain\CloudSearchDomainFactory;
+use Aws\ClientFactory\CloudSearchDomain;
 
 /**
- * @covers Aws\CloudSearchDomain\CloudSearchDomainFactory
+ * @covers Aws\ClientFactory\CloudSearchDomain
  */
-class CloudSearchDomainFactoryTest extends \PHPUnit_Framework_TestCase
+class CloudSearchDomainTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testRequiresEndpoint()
     {
-        (new CloudSearchDomainFactory)->create();
+        (new CloudSearchDomain)->create();
     }
 
     public function testGetsRegionFromEndpoint()
     {
-        $client = (new CloudSearchDomainFactory)->create([
+        $client = (new CloudSearchDomain)->create([
             'service'   => 'cloudsearchdomain',
             'endpoint'  => 'search-foo.us-west-2.cloudsearch.amazon.com',
             'signature' => 'v4',

--- a/tests/ClientFactory/DynamoDbTest.php
+++ b/tests/ClientFactory/DynamoDbTest.php
@@ -1,18 +1,18 @@
 <?php
-namespace Aws\Test\DynamoDb;
+namespace Aws\Test\ClientFactory;
 
-use Aws\DynamoDb\DynamoDbFactory;
+use Aws\ClientFactory\DynamoDb;
 use Aws\Test\SdkTest;
 use GuzzleHttp\Subscriber\Retry\RetrySubscriber;
 
 /**
- * @covers Aws\DynamoDb\DynamoDbFactory
+ * @covers Aws\ClientFactory\DynamoDb
  */
 class DynamoDbFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testDisablesRedirects()
     {
-        $f = new DynamoDbFactory();
+        $f = new DynamoDb();
         $client = $f->create([
             'service' => 'dynamodb',
             'region'  => 'us-west-2',
@@ -23,7 +23,7 @@ class DynamoDbFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testUsesCustomBackoffStrategy()
     {
-        $f = new DynamoDbFactory();
+        $f = new DynamoDb();
         $client = $f->create([
             'service' => 'dynamodb',
             'region'  => 'us-west-2',
@@ -53,7 +53,7 @@ class DynamoDbFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCanDisableRetries()
     {
-        $f = new DynamoDbFactory();
+        $f = new DynamoDb();
         $client = $f->create([
             'service' => 'dynamodb',
             'region'  => 'us-west-2',

--- a/tests/ClientFactory/GlacierTest.php
+++ b/tests/ClientFactory/GlacierTest.php
@@ -1,18 +1,18 @@
 <?php
-namespace Aws\Test\Glacier;
+namespace Aws\Test\ClientFactory;
 
-use Aws\Glacier\GlacierFactory;
+use Aws\ClientFactory\Glacier;
 use Aws\Result;
 use GuzzleHttp\Command\Event\PreparedEvent;
 
 /**
- * @covers Aws\Glacier\GlacierFactory
+ * @covers Aws\ClientFactory\Glacier
  */
-class GlacierFactoryTest extends \PHPUnit_Framework_TestCase
+class GlacierTest extends \PHPUnit_Framework_TestCase
 {
     public function testHasNecessaryDefaults()
     {
-        $client = (new GlacierFactory)->create([
+        $client = (new Glacier)->create([
             'service' => 'glacier',
             'region'  => 'us-west-2',
             'version' => 'latest'
@@ -32,7 +32,7 @@ class GlacierFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreatesClientWithSubscribers()
     {
-        $client = (new GlacierFactory)->create([
+        $client = (new Glacier)->create([
             'service' => 'glacier',
             'region'  => 'us-west-2',
             'version' => 'latest'

--- a/tests/ClientFactory/Route53Test.php
+++ b/tests/ClientFactory/Route53Test.php
@@ -1,17 +1,17 @@
 <?php
 namespace Aws\Test\Route53;
 
-use Aws\Route53\Route53Factory;
+use Aws\ClientFactory\Route53;
 use Aws\Test\SdkTest;
 
 /**
- * @covers Aws\Route53\Route53Factory
+ * @covers Aws\ClientFactory\Route53
  */
-class Route53FactoryTest extends \PHPUnit_Framework_TestCase
+class Route53Test extends \PHPUnit_Framework_TestCase
 {
     public function testAttachesSubscribers()
     {
-        $f = new Route53Factory();
+        $f = new Route53();
         $client = $f->create([
             'service' => 'route53',
             'region'  => 'us-west-2',

--- a/tests/ClientFactory/S3Test.php
+++ b/tests/ClientFactory/S3Test.php
@@ -1,16 +1,16 @@
 <?php
-namespace Aws\Test\S3;
+namespace Aws\Test\ClientFactory;
 
-use Aws\S3\S3Factory;
+use Aws\ClientFactory\S3;
 
 /**
- * @covers Aws\S3\S3Factory
+ * @covers Aws\ClientFactory\S3
  */
 class S3FactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreatesS3Signature()
     {
-        $c = (new S3Factory())->create([
+        $c = (new S3())->create([
             'service'   => 's3',
             'signature' => 's3',
             'version'   => 'latest'
@@ -24,7 +24,7 @@ class S3FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreatesRegularSignature()
     {
-        $c = (new S3Factory())->create([
+        $c = (new S3())->create([
             'service'   => 's3',
             'signature' => 'v4',
             'version'   => 'latest'
@@ -38,7 +38,7 @@ class S3FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCanForcePathStyleOnAllOperations()
     {
-        $c = (new S3Factory())->create([
+        $c = (new S3())->create([
             'service'          => 's3',
             'version'          => 'latest',
             'force_path_style' => true
@@ -53,7 +53,7 @@ class S3FactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidatesSignature()
     {
-        (new S3Factory())->create([
+        (new S3())->create([
             'service'   => 's3',
             'signature' => 'foo',
             'version'   => 'latest'
@@ -62,7 +62,7 @@ class S3FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testCreatesClientWithSubscribers()
     {
-        $c = (new S3Factory())->create([
+        $c = (new S3())->create([
             'service' => 's3',
             'version' => 'latest'
         ]);

--- a/tests/ClientFactory/SqsFactoryTest.php
+++ b/tests/ClientFactory/SqsFactoryTest.php
@@ -1,17 +1,17 @@
 <?php
 namespace Aws\Test\Sqs;
 
-use Aws\Sqs\SqsFactory;
+use Aws\ClientFactory\Sqs;
 use Aws\Test\SdkTest;
 
 /**
- * @covers Aws\Sqs\SqsFactory
+ * @covers Aws\ClientFactory\Sqs
  */
-class SqsFactoryTest extends \PHPUnit_Framework_TestCase
+class SqsTest extends \PHPUnit_Framework_TestCase
 {
     public function testAttachesSubscribers()
     {
-        $f = new SqsFactory();
+        $f = new Sqs();
         $client = $f->create([
             'service' => 'sqs',
             'region'  => 'us-west-2',

--- a/tests/StsClientTest.php
+++ b/tests/StsClientTest.php
@@ -6,7 +6,7 @@ use Aws\StsClient;
 
 /**
  * @covers Aws\StsClient
- * @covers Aws\Sts\StsFactory
+ * @covers Aws\ClientFactory\Sts
  */
 class StsClientTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
1. Allows us to see which clients have custom factories.
2. More consistent with how exceptions are now namespaced.