### PR TITLE
Adding an LRU cache to the stream wrapper

### DIFF
--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -766,4 +766,27 @@ EOT;
         $r = opendir('s3://bucket', $context);
         closedir($r);
     }
+
+    public function testCanClearStatCache()
+    {
+        StreamWrapper::clearCache();
+        $this->assertEmpty($this->readAttribute('Aws\S3\StreamWrapper', 'statCache'));
+        $results = [
+            [
+                'IsTruncated' => false,
+                'Delimiter'   => '/',
+                'Name'        => 'bucket',
+                'Prefix'      => '',
+                'MaxKeys'     => 1000,
+                'Contents'    => [['Key' => 'a'], ['Key' => 'b']],
+            ]
+        ];
+
+        $this->addMockResults($this->client, $results);
+        $dir = 's3://bucket/key/';
+        $r = opendir($dir);
+        while (($file = readdir($r)) !== false);
+        $this->assertNotEmpty($this->readAttribute('Aws\S3\StreamWrapper', 'statCache'));
+        closedir($r);
+    }
 }


### PR DESCRIPTION
This PR adds an LRU cache to the S3 stream wrapper so that listing files in S3 buckets is cached for subsequent is_file, is_dir, stat, etc. calls. When the cache size exceeds 1000 entries, the cache is halved by removing the least recently used items from the cache.

I thought that I could leverage PHP's built-in clearstatcache() related functionality, but unfortunately it doesn't seem you can seed the internal stat cache from within a function calls that was triggered from a custom stream wrapper function.