### PR TITLE
Adding a signature provider

### DIFF
--- a/src/S3/S3Factory.php
+++ b/src/S3/S3Factory.php
@@ -3,8 +3,6 @@ namespace Aws\S3;
 
 use Aws\ClientFactory;
 use Aws\Retry\S3TimeoutFilter;
-use Aws\Signature\S3Signature;
-use Aws\Signature\S3SignatureV4;
 use Aws\Signature\SignatureV4;
 use Aws\Subscriber\SaveAs;
 use Aws\Subscriber\SourceFile;
@@ -66,18 +64,6 @@ class S3Factory extends ClientFactory
         $emitter->attach(new SaveAs());
 
         return $client;
-    }
-
-    protected function createSignature($version, $signingName, $region)
-    {
-        if ($version == 's3') {
-            return new S3Signature();
-        } elseif ($version == 'v4') {
-            return new S3SignatureV4($signingName, $region);
-        }
-
-        throw new \InvalidArgumentException('Amazon S3 supports signature '
-            . 'version "s3" or "v4"');
     }
 
     protected function getRetryOptions(array $args)

--- a/src/Signature/Provider.php
+++ b/src/Signature/Provider.php
@@ -1,0 +1,52 @@
+<?php
+namespace Aws\Signature;
+
+/**
+ * Signature provider functions.
+ */
+class Provider
+{
+    /**
+     * Creates a Signature object from a signature version name.
+     *
+     * This provider currently supports: v2, v4, and s3 signature versions. The
+     * $config array supports the following values:
+     *
+     * - service: The service name that the signer is signing for.
+     * - region: The region name that the signer is signing for.
+     *
+     * @param string $signatureVersion Signature version to create.
+     * @param array  $config           Associative array of signature options.
+     *
+     * @return SignatureInterface
+     */
+    public static function fromVersion($signatureVersion, array $config = [])
+    {
+        switch ($signatureVersion) {
+            case 'v4':
+                return self::createV4($config);
+            case 's3':
+                return new S3Signature();
+            case 'v2':
+                return new SignatureV2();
+        }
+
+        throw new \InvalidArgumentException("Unknown signature version: $signatureVersion");
+    }
+
+    private static function createV4(array $config)
+    {
+        foreach (['service', 'region'] as $key) {
+            if (!isset($config[$key])) {
+                throw new \InvalidArgumentException("{$key} is required");
+            }
+        }
+
+        switch ($config['service']) {
+            case 's3':
+                return new S3SignatureV4($config['service'], $config['region']);
+            default:
+                return new SignatureV4($config['service'], $config['region']);
+        }
+    }
+}

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -426,35 +426,31 @@ EOT;
         ));
     }
 
-    public function signatureVersionProvider()
-    {
-        return [
-            ['v2', 'Aws\Signature\SignatureV2'],
-            ['v4', 'Aws\Signature\SignatureV4'],
-            ['v1', 'InvalidArgumentException']
-        ];
-    }
-
     /**
-     * @dataProvider signatureVersionProvider
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid signature option: bool(true)
      */
-    public function testCreatesSignatures($version, $class)
+    public function testValidatesSignature()
     {
         $f = new ClientFactory();
+        $f->create([
+            'service'  => 'sqs',
+            'region'   => 'x',
+            'signature' => true,
+            'version'  => 'latest'
+        ]);
+    }
 
-        $m = new \ReflectionMethod($f, 'createSignature');
-        $m->setAccessible(true);
-
-        try {
-            $result = $m->invoke($f, $version, 'foo', 'bar');
-        } catch (\Exception $e) {
-            $result = $e;
-        }
-
-        $this->assertInstanceOf($class, $result);
-        if (method_exists($result, 'getRegion')) {
-            $this->assertEquals('bar', $result->getRegion());
-        }
+    public function testCreatesSignatureFromString()
+    {
+        $f = new ClientFactory();
+        $c = $f->create([
+            'service'   => 'sqs',
+            'region'    => 'x',
+            'signature' => 'v2',
+            'version'   => 'latest'
+        ]);
+        $this->assertInstanceOf('Aws\Signature\SignatureV2', $c->getSignature());
     }
 
     public function testDoesNotMessWithExistingResults()

--- a/tests/S3/S3FactoryTest.php
+++ b/tests/S3/S3FactoryTest.php
@@ -47,19 +47,6 @@ class S3FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($command['PathStyle']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Amazon S3 supports signature version "s3" or "v4"
-     */
-    public function testValidatesSignature()
-    {
-        (new S3Factory())->create([
-            'service'   => 's3',
-            'signature' => 'foo',
-            'version'   => 'latest'
-        ]);
-    }
-
     public function testCreatesClientWithSubscribers()
     {
         $c = (new S3Factory())->create([

--- a/tests/Signature/ProviderTest.php
+++ b/tests/Signature/ProviderTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Aws\Test\Signature;
+use Aws\Signature\Provider;
+
+/**
+ * @covers Aws\Signature\Provider
+ */
+class ProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function versionProvider()
+    {
+        return [
+            ['v2', 'Aws\Signature\SignatureV2', 'foo'],
+            ['v4', 'Aws\Signature\SignatureV4', 'foo'],
+            ['s3', 'Aws\Signature\S3Signature', 'foo'],
+            ['v4', 'Aws\Signature\S3SignatureV4', 's3'],
+        ];
+    }
+
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testCreatesSignatureFromVersionString($v, $type, $service)
+    {
+        $result = Provider::fromVersion($v, [
+            'service' => $service,
+            'region'  => 'baz'
+        ]);
+
+        $this->assertInstanceOf($type, $result);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage service is required
+     */
+    public function testEnsuresServiceIsProvidedForV4()
+    {
+        Provider::fromVersion('v4', ['region' => 'foo']);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage region is required
+     */
+    public function testEnsuresRegionIsProvidedForV4()
+    {
+        Provider::fromVersion('v4', ['service' => 'foo']);
+    }
+}

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -134,6 +134,7 @@ class WaiterTest extends \PHPUnit_Framework_TestCase
                 return [
                     'operations' => ['DescribeTable' => ['input' => []]],
                     'metadata' => [
+                        'endpointPrefix' => 'foo',
                         'protocol' => 'json',
                         'signatureVersion' => 'v4'
                     ],


### PR DESCRIPTION
This PR adds a signature provider that can be used to create signature objects by name. This is now utilized in the ClientFactory, and could be utilized by customers to create custom signature objects to, for example, create a presigned URL.