### PR TITLE
Adding a Utils class and using less dir buffering

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,69 @@
+<?php
+namespace Aws;
+
+use transducers as t;
+
+final class Utils
+{
+    /**
+     * Iterates over the files in a directory and works with custom wrappers.
+     *
+     * @param string   $path Path to open (e.g., "s3://foo/bar").
+     * @param resource $context Stream wrapper context.
+     *
+     * @return \Generator Yields relative filename strings.
+     */
+    public static function dirIterator($path, $context = null)
+    {
+        $dh = $context ? opendir($path, $context) : opendir($path);
+        if (!$dh) {
+            throw new \InvalidArgumentException('File not found: ' . $path);
+        }
+        while (($file = readdir($dh)) !== false) {
+            yield $file;
+        }
+        closedir($dh);
+    }
+
+    /**
+     * Returns a recursive directory iterator that yields absolute filenames.
+     *
+     * This iterator is not broken like PHP's built-in DirectoryIterator (which
+     * will read the first file from a stream wrapper, then rewind, then read
+     * it again).
+     *
+     * @param string   $path    Path to traverse (e.g., s3://bucket/key, /tmp)
+     * @param resource $context Stream context options.
+     *
+     * @return \Generator Yields absolute filenames.
+     */
+    public static function recursiveDirIterator($path, $context = null)
+    {
+        $invalid = ['.' => true, '..' => true];
+        $pathLen = strlen($path) + 1;
+        $iterator = self::dirIterator($path, $context);
+        $queue = [];
+        do {
+            while ($iterator->valid()) {
+                $file = $iterator->current();
+                $iterator->next();
+                if (isset($invalid[basename($file)])) {
+                    continue;
+                }
+                $fullPath = "{$path}/{$file}";
+                yield $fullPath;
+                if (is_dir($fullPath)) {
+                    $queue[] = $iterator;
+                    $iterator = t\to_iter(
+                        self::dirIterator($fullPath, $context),
+                        t\map(function ($file) use ($fullPath, $pathLen) {
+                            return substr("{$fullPath}/{$file}", $pathLen);
+                        })
+                    );
+                    continue;
+                }
+            }
+            $iterator = array_pop($queue);
+        } while ($iterator);
+    }
+}

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -68,14 +68,6 @@ class TransferTest extends \PHPUnit_Framework_TestCase
         (new Transfer($s3, false, 's3://foo/bar'));
     }
 
-    public function testCreatesFileIteratorThatContainsStrings()
-    {
-        $iter = Transfer::recursiveDirIterator(__DIR__);
-        $this->assertInstanceOf('Iterator', $iter);
-        $files = iterator_to_array($iter);
-        $this->assertContains(__FILE__, $files);
-    }
-
     public function testUsesFileIteratorIfStringIsProvided()
     {
         $s3 = $this->getTestClient('s3');

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Aws\Test;
+
+use Aws\Utils;
+
+/**
+ * @covers Aws\Utils
+ */
+class UtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreatesRecursiveDirIterator()
+    {
+        $iter = Utils::recursiveDirIterator(__DIR__);
+        $this->assertInstanceOf('Iterator', $iter);
+        $files = iterator_to_array($iter);
+        $this->assertContains(__FILE__, $files);
+    }
+
+    public function testCreatesNonRecursiveDirIterator()
+    {
+        $iter = Utils::dirIterator(__DIR__);
+        $this->assertInstanceOf('Iterator', $iter);
+        $files = iterator_to_array($iter);
+        $this->assertContains('UtilsTest.php', $files);
+    }
+}


### PR DESCRIPTION
This commit adds a Utils class where we can place useful and generic
functionality (e.g., a directory iterator that doesn't call readdir()
and rewinddir() when constructed).

This commit also updates the recursive directory iterator to not require
each level of directory traversal be cached in memory.