### PR TITLE
Update Marshaler.php

### DIFF
--- a/src/Aws/DynamoDb/Marshaler.php
+++ b/src/Aws/DynamoDb/Marshaler.php
@@ -52,7 +52,7 @@ class Marshaler
      * @return array Formatted like `array(TYPE => VALUE)`.
      * @throws \UnexpectedValueException if the value cannot be marshaled.
      */
-    private function marshalValue($value)
+    protected function marshalValue($value)
     {
         $type = gettype($value);
         if ($type === 'string' && $value !== '') {

--- a/src/Aws/DynamoDb/Marshaler.php
+++ b/src/Aws/DynamoDb/Marshaler.php
@@ -52,7 +52,7 @@ class Marshaler
      * @return array Formatted like `array(TYPE => VALUE)`.
      * @throws \UnexpectedValueException if the value cannot be marshaled.
      */
-    protected function marshalValue($value)
+    public function marshalValue($value)
     {
         $type = gettype($value);
         if ($type === 'string' && $value !== '') {
@@ -132,7 +132,7 @@ class Marshaler
      * @return mixed
      * @throws \UnexpectedValueException
      */
-    private function unmarshalValue(array $value, $mapAsObject = false)
+    public function unmarshalValue(array $value, $mapAsObject = false)
     {
         list($type, $value) = each($value);
         switch ($type) {


### PR DESCRIPTION
Suggestion: Change this method to protected so it can be easily extended. Sometimes in JSON we can have empty strings and an exception will be thrown. In my implementation, it is ok to mark that value as NULL instead. Or, maybe, add a config param to marshalItem/marshalJSON to automatically do this when encountered.