### PR TITLE
Add support for "endpoint" for forward compat w/ v3

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -188,9 +188,9 @@ Options                   Description
 ``region``                Region name (e.g., 'us-east-1', 'us-west-1', 'us-west-2', 'eu-west-1', etc.).
                           See :ref:`specify_region`.
 
-``scheme``                URI Scheme of the base URL (e.g.. 'https', 'http') used when base_url is not supplied.
+``scheme``                URI Scheme of the base URL (e.g.. 'https', 'http') used when endpoint is not supplied.
 
-``base_url``              Allows you to specify a custom endpoint instead of have the SDK build one automatically from
+``endpoint``              Allows you to specify a custom endpoint instead of have the SDK build one automatically from
                           the region and scheme.
 
 ``signature``             Overrides the signature used by the client. Clients will always choose an appropriate default
@@ -263,7 +263,7 @@ Here's an example of creating an Amazon DynamoDB client that uses the ``us-west-
 Setting a custom endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can specify a completely customized endpoint for a client using the client's ``base_url`` option. If the client you
+You can specify a completely customized endpoint for a client using the client's ``endpoint`` option. If the client you
 are using requires a region, then must still specify the name of the region using the ``region`` option. Setting a
 custom endpoint can be useful if you're using a mock web server that emulates a web service, you're testing against a
 private beta endpoint, or you are trying to a use a new region not yet supported by the SDK.
@@ -278,7 +278,7 @@ Here's an example of creating an Amazon DynamoDB client that uses a completely c
 
     // Create a client that that contacts a completely customized base URL
     $client = DynamoDbClient::factory(array(
-        'base_url' => 'http://my-custom-url',
+        'endpoint' => 'http://my-custom-url',
         'region'   => 'my-region-1',
         'key'      => 'abc',
         'secret'   => '123'

--- a/docs/service-cloudsearchdomain.rst
+++ b/docs/service-cloudsearchdomain.rst
@@ -23,11 +23,11 @@ Similar to the way other service clients are used, you can instantiate the ``Clo
 
     $client = CloudSearchDomainClient::factory(array(
         'profile'  => '<profile in your aws credentials file>',
-        'base_url' => '<your cloudsearch domain endpoint>'
+        'endpoint' => '<your cloudsearch domain endpoint>'
     ));
 
 The ``CloudSearchDomainClient`` is unlike other clients, because it does not require you to provide a region. Instead,
-you must provide the ``base_url`` option, which represents the domain's endpoint. Domain endpoints are unique to each
+you must provide the ``endpoint`` option, which represents the domain's endpoint. Domain endpoints are unique to each
 domain, and you can get it using the `DescribeDomains operation
 <http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.CloudSearch.CloudSearchClient.html#_describeDomains>`_ of the
 :doc:`Amazon CloudSearch configuration client<service-cloudsearch>`.
@@ -49,13 +49,13 @@ all clients so that you only have to specify your settings once.
     // Get the client from the builder
     $client = $aws->get('CloudSearchDomain');
 
-**Note:** This assumes that your configuration file has been setup to include the ``base_url`` option for the
+**Note:** This assumes that your configuration file has been setup to include the ``endpoint`` option for the
 CloudSearch Domain service. If it is not, you can provide it manually when calling ``get()``.
 
 .. code-block:: php
 
     $client = $aws->get('cloudsearchdomain', array(
-        'base_url' => '<your cloudsearch domain endpoint>'
+        'endpoint' => '<your cloudsearch domain endpoint>'
     ));
 
 For more information about configuration files, see :doc:`configuration`.

--- a/src/Aws/CloudSearch/CloudSearchClient.php
+++ b/src/Aws/CloudSearch/CloudSearchClient.php
@@ -95,8 +95,8 @@ class CloudSearchClient extends AbstractClient
      */
     public function getDomainClient($domainName, array $config = array())
     {
-        // Determine the Domain client's base_url
-        $config['base_url'] = $this->describeDomains(array(
+        // Determine the Domain client's endpoint
+        $config['endpoint'] = $this->describeDomains(array(
             'DomainNames' => array($domainName)
         ))->getPath('DomainStatusList/0/SearchService/Endpoint');
 

--- a/src/Aws/CloudSearchDomain/CloudSearchDomainClient.php
+++ b/src/Aws/CloudSearchDomain/CloudSearchDomainClient.php
@@ -3,7 +3,6 @@
 namespace Aws\CloudSearchDomain;
 
 use Aws\Common\Client\AbstractClient;
-use Aws\Common\Credentials\CredentialsInterface;
 use Aws\Common\Enum\ClientOptions as Options;
 use Aws\Common\Exception\BadMethodCallException;
 use Guzzle\Common\Collection;
@@ -26,7 +25,7 @@ class CloudSearchDomainClient extends AbstractClient
     /**
      * Factory method to create a new Amazon CloudSearch Domain client using an array of configuration options.
      *
-     * You must provide the `base_url` option for this client, but credentials and `region` are not needed.
+     * You must provide the `endpoint` option for this client, but credentials and `region` are not needed.
      *
      * @param array|Collection $config Client configuration data
      *

--- a/src/Aws/Common/Client/DefaultClient.php
+++ b/src/Aws/Common/Client/DefaultClient.php
@@ -42,8 +42,8 @@ class DefaultClient extends AbstractClient
      * Region and endpoint options (Some services do not require a region while others do. Check the service specific user guide documentation for details):
      *
      * - region: Region name (e.g. 'us-east-1', 'us-west-1', 'us-west-2', 'eu-west-1', etc...)
-     * - scheme: URI Scheme of the base URL (e.g. 'https', 'http') used when base_url is not supplied
-     * - base_url: Allows you to specify a custom endpoint instead of building one from the region and scheme
+     * - scheme: URI Scheme of the base URL (e.g. 'https', 'http') used when endpoint is not supplied
+     * - endpoint: Allows you to specify a custom endpoint instead of building one from the region and scheme
      *
      * Generic client options:
      *


### PR DESCRIPTION
This now shows "endpoint" only in the docs, but "base_url" will continue to be supported.