### PR TITLE
Adding forward compat for credentials array setting

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -157,27 +157,39 @@ Options                   Description
                           used to look up your credentials in your credentials file (``~/.aws/credentials``). See
                           :ref:`credential_profiles` for more information.
 
+``token.ttd``             The UNIX timestamp for when the provided credentials expire.
+
+``credentials``           An associative array containing the "key", "secret", and optional "token" key value pairs,
+                          or a credentials object (``Aws\Common\Credentials\CredentialsInterface``) can be provided
+                          instead explicit access keys and tokens.
+
 ``key``                   An AWS access key ID. Unless you are setting temporary credentials provided by AWS STS, it is
                           recommended that you avoid hard-coding credentials with this parameter. Please see
                           :doc:`credentials` for my information about credentials.
+
+                          .. note::
+
+                              ``key`` is deprecated in v3 of the AWS SDK for PHP in favor of using the ``credentials``
+                               option.
 
 ``secret``                An AWS secret access key. Unless you are setting temporary credentials provided by AWS STS, it
                           is recommended that you avoid hard-coding credentials with this parameter. Please see
                           :doc:`credentials` for my information about credentials.
 
+                          .. note::
+
+                              ``secret`` is deprecated in v3 of the AWS SDK for PHP in favor of using the
+                              ``credentials`` option.
+
 ``token``                 An AWS security token to use with request authentication. These are typically provided by the
                           AWS STS service. Please note that not all services accept temporary credentials.
                           See http://docs.aws.amazon.com/STS/latest/UsingSTS/UsingTokens.html.
 
-``token.ttd``             The UNIX timestamp for when the provided credentials expire.
+                          .. note::
 
-``credentials``           A credentials object (``Aws\Common\Credentials\CredentialsInterface``) can be provided instead
-                          explicit access keys and tokens.
+                              ``token`` is deprecated in v3 of the AWS SDK for PHP in favor of using the
+                              ``credentials`` option.
 
-``credentials.cache.key`` Optional custom cache key to use with the credentials.
-
-``credentials.client``    Pass this option to specify a custom ``Guzzle\Http\ClientInterface`` to use if your
-                          credentials require a HTTP request (e.g. ``RefreshableInstanceProfileCredentials``).
 ========================= ==============================================================================================
 
 ========================= ==============================================================================================
@@ -253,8 +265,10 @@ Here's an example of creating an Amazon DynamoDB client that uses the ``us-west-
 
     // Create a client that uses the us-west-1 region
     $client = DynamoDbClient::factory(array(
-        'key'    => 'YOUR_AWS_ACCESS_KEY_ID',
-        'secret' => 'YOUR_AWS_SECRET_ACCESS_KEY',
+        'credentials' => array(
+            'key'    => 'YOUR_AWS_ACCESS_KEY_ID',
+            'secret' => 'YOUR_AWS_SECRET_ACCESS_KEY',
+        ),
         'region' => 'us-west-1'
     ));
 
@@ -280,8 +294,10 @@ Here's an example of creating an Amazon DynamoDB client that uses a completely c
     $client = DynamoDbClient::factory(array(
         'base_url' => 'http://my-custom-url',
         'region'   => 'my-region-1',
-        'key'      => 'abc',
-        'secret'   => '123'
+        'credentials' => array(
+            'key'      => 'abc',
+            'secret'   => '123'
+        )
     ));
 
 If your custom endpoint uses signature version 4 and must be signed with custom signature scoping values, then you can

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -33,8 +33,6 @@ in a client's factory method or the configuration settings used with
 
     $aws = Aws\Common\Aws::factory(array(
         'region' => 'us-west-2',
-        'key'    => '****',
-        'secret' => '****',
         'ssl.certificate_authority' => '/path/to/updated/cacert.pem'
     ));
 

--- a/docs/feature-dynamodb-session-handler.rst
+++ b/docs/feature-dynamodb-session-handler.rst
@@ -32,11 +32,7 @@ The first step is to instantiate the Amazon DynamoDB client and register the ses
 
     use Aws\DynamoDb\DynamoDbClient;
 
-    $dynamoDb = DynamoDbClient::factory(array(
-        'key'    => '<aws access key>',
-        'secret' => '<aws secret key>',
-        'region' => '<region name>'
-    ));
+    $dynamoDb = DynamoDbClient::factory(array('region' => '<region name>'));
 
     $sessionHandler = $dynamoDb->registerSessionHandler(array(
         'table_name' => 'sessions'
@@ -52,8 +48,6 @@ You can also instantiate the ``SessionHandler`` object directly using it's ``fac
     use Aws\DynamoDb\Session\SessionHandler;
 
     $dynamoDb = DynamoDbClient::factory(array(
-        'key'    => '<aws access key>',
-        'secret' => '<aws secret key>',
         'region' => '<region name>',
     ));
 
@@ -256,8 +250,6 @@ something like the following:
     use Aws\DynamoDb\Session\SessionHandler;
 
     $dynamoDb = DynamoDbClient::factory(array(
-        'key'    => '<aws access key>',
-        'secret' => '<aws secret key>',
         'region' => '<region name>',
     ));
 

--- a/docs/migration-guide.rst
+++ b/docs/migration-guide.rst
@@ -106,8 +106,10 @@ behavior.
 .. code-block:: php
 
     $dynamodb = Aws\DynamoDb\DynamoDbClient::factory(array(
-        'key'    => 'your-aws-access-key-id',
-        'secret' => 'your-aws-secret-access-key',
+        'credentials' => array(
+            'key'    => 'your-aws-access-key-id',
+            'secret' => 'your-aws-secret-access-key',
+        ),
         'region' => 'us-west-2',
     ));
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -130,9 +130,7 @@ A simple configuration file should look something like this:
         'services' => array(
             'default_settings' => array(
                 'params' => array(
-                    'key'    => 'YOUR_AWS_ACCESS_KEY_ID',
-                    'secret' => 'YOUR_AWS_SECRET_ACCESS_KEY',
-                    // OR: 'profile' => 'my_profile',
+                    'profile' => 'my_profile',
                     'region' => 'us-west-2'
                 )
             )

--- a/docs/service-cloudfront-20120505.rst
+++ b/docs/service-cloudfront-20120505.rst
@@ -36,8 +36,6 @@ instantiate the CloudFront client. The following is an example config file that 
         'services' => array(
             'default_settings' => array(
                 'params' => array(
-                    'key'    => '<aws access key>',
-                    'secret' => '<aws secret key>',
                     'region' => 'us-west-2'
                 )
             ),

--- a/docs/service-cloudfront.rst
+++ b/docs/service-cloudfront.rst
@@ -36,8 +36,6 @@ instantiate the CloudFront client. The following is an example config file that 
         'services' => array(
             'default_settings' => array(
                 'params' => array(
-                    'key'    => '<aws access key>',
-                    'secret' => '<aws secret key>',
                     'region' => 'us-west-2'
                 )
             ),

--- a/docs/service-sts.rst
+++ b/docs/service-sts.rst
@@ -48,9 +48,11 @@ from AWS STS directly.
     $result = $client->getSessionToken();
 
     $s3 = S3Client::factory(array(
-        'key'    => $result['Credentials']['AccessKeyId'],
-        'secret' => $result['Credentials']['SecretAccessKey'],
-        'token'  => $result['Credentials']['SessionToken'],
+        'credentials' => array(
+            'key'    => $result['Credentials']['AccessKeyId'],
+            'secret' => $result['Credentials']['SecretAccessKey'],
+            'token'  => $result['Credentials']['SessionToken'],
+        )
     ));
 
 You can also construct a ``Credentials`` object and use that when instantiating the client.

--- a/docs/side-by-side.rst
+++ b/docs/side-by-side.rst
@@ -111,8 +111,6 @@ referencing the Version 1 of the SDK:
         'services' => array(
             'default_settings' => array(
                 'params' => array(
-                    'key'    => 'your-aws-access-key-id',
-                    'secret' => 'your-aws-secret-access-key',
                     'region' => 'us-west-2'
                 )
             )
@@ -145,8 +143,7 @@ configuration data, including your credentials. The ``factory()`` will work for 
 
     // Create an array of configuration options
     $config = array(
-        'key'    => 'your-aws-access-key-id',
-        'secret' => 'your-aws-secret-access-key',
+        'region' => 'us-west-2'
     );
 
     // Instantiate Amazon S3 clients from both SDKs via their factory methods

--- a/src/Aws/Common/Client/ClientBuilder.php
+++ b/src/Aws/Common/Client/ClientBuilder.php
@@ -467,7 +467,10 @@ class ClientBuilder
     protected function getCredentials(Collection $config)
     {
         $credentials = $config->get(Options::CREDENTIALS);
-        if ($credentials === false) {
+
+        if (is_array($credentials)) {
+            $credentials = Credentials::factory($credentials);
+        } elseif ($credentials === false) {
             $credentials = new NullCredentials();
         } elseif (!$credentials instanceof CredentialsInterface) {
             $credentials = Credentials::factory($config);

--- a/tests/Aws/Tests/Common/Client/ClientBuilderTest.php
+++ b/tests/Aws/Tests/Common/Client/ClientBuilderTest.php
@@ -282,6 +282,28 @@ class ClientBuilderTest extends \Guzzle\Tests\GuzzleTestCase
         putenv(Credentials::ENV_KEY); putenv(Credentials::ENV_SECRET);
     }
 
+    public function testAddsCredentialsFromArray()
+    {
+        $config = array(
+            'service' => 'dynamodb',
+            'region'  => 'us-east-1',
+            'credentials' => array(
+                'key'    => 'foo',
+                'secret' => 'bar'
+            ),
+            'service.description' => array(
+                'signatureVersion' => 'v2',
+                'regions' => array('us-east-1' => array('https' => true, 'hostname' => 'foo.com'))
+            )
+        );
+        $client = ClientBuilder::factory('Aws\\DynamoDb')
+            ->setConfig($config)
+            ->build();
+        $creds = $client->getCredentials();
+        $this->assertEquals('foo', $creds->getAccessKeyId());
+        $this->assertEquals('bar', $creds->getSecretKey());
+    }
+
     public function testAddsDefaultBackoffPluginIfNeeded()
     {
         $config = array(


### PR DESCRIPTION
This commit updates the SDK to accept a hash of options for the credentials
option so that it is forward compatible with v3. This commit also
updates the docs to favor the new format. I've removed instances of
hardcoding credentials from the docs where they are not necessary.
