### PR TITLE
Add pre-signed URLs for CopySnapshot

### DIFF
--- a/src/Ec2/CopySnapshotSubscriber.php
+++ b/src/Ec2/CopySnapshotSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+namespace Aws\Ec2;
+
+use Aws\AwsClientInterface;
+use Aws\Signature\SignatureV4;
+use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\CommandTransaction;
+use GuzzleHttp\Command\Event\InitEvent;
+use GuzzleHttp\Event\RequestEvents;
+use GuzzleHttp\Event\SubscriberInterface;
+use GuzzleHttp\Url;
+
+/**
+ * @internal Adds computed values to the CopySnapshot operation.
+ */
+class CopySnapshotSubscriber implements SubscriberInterface
+{
+    private $endpointProvider;
+    private $requestSerializer;
+
+    public function __construct(
+        callable $endpointProvider,
+        callable $requestSerializer
+    ) {
+        $this->endpointProvider = $endpointProvider;
+        $this->requestSerializer = $requestSerializer;
+    }
+
+    public function getEvents()
+    {
+        return ['init' => ['onInit', RequestEvents::LATE]];
+    }
+
+    public function onInit(InitEvent $event)
+    {
+        $cmd = $event->getCommand();
+        if ($cmd->getName() == 'CopySnapshot') {
+            /** @var AwsClientInterface $client */
+            $client = $event->getClient();
+            $cmd['PresignedUrl'] = $this->createPresignedUrl($client, $cmd);
+            $cmd['DestinationRegion'] = $client->getRegion();
+        }
+    }
+
+    private function createPresignedUrl(
+        AwsClientInterface $client,
+        CommandInterface $cmd
+    ) {
+        $newCmd = $client->getCommand('CopySnapshot', $cmd->toArray());
+        // Serialize a request for the CopySnapshot operation.
+        $trans = new CommandTransaction($client, $newCmd);
+        $request = call_user_func($this->requestSerializer, $trans);
+        // Create the new endpoint for the target endpoint.
+        $endpoint = call_user_func($this->endpointProvider, [
+            'region'  => $cmd['SourceRegion'],
+            'service' => 'ec2'
+        ])['endpoint'];
+        // Set the request to hit the target endpoint.
+        $request->setHost(Url::fromString($endpoint)->getHost());
+        // Create a presigned URL for our generated request.
+        $signer = new SignatureV4('ec2', $cmd['SourceRegion']);
+        return $signer->createPresignedUrl(
+            SignatureV4::convertPostToGet($request),
+            $client->getCredentials(),
+            '+1 hour'
+        );
+    }
+}

--- a/src/Ec2/Ec2Factory.php
+++ b/src/Ec2/Ec2Factory.php
@@ -1,0 +1,21 @@
+<?php
+namespace Aws\Ec2;
+
+use Aws\ClientFactory;
+
+/**
+ * @internal
+ */
+class Ec2Factory extends ClientFactory
+{
+    protected function createClient(array $args)
+    {
+        $client = parent::createClient($args);
+        $client->getEmitter()->attach(new CopySnapshotSubscriber(
+            $args['endpoint_provider'],
+            $args['serializer']
+        ));
+
+        return $client;
+    }
+}

--- a/tests/Ec2/CopySnapshotSubscriberTest.php
+++ b/tests/Ec2/CopySnapshotSubscriberTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace Aws\Test\Ec2;
+
+use Aws\Ec2\Ec2Client;
+use Aws\Test\UsesServiceTrait;
+
+/**
+ * @covers Aws\Ec2\CopySnapshotSubscriber
+ */
+class CopySnapshotSubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    use UsesServiceTrait;
+
+    public function testDoesNotAddPresignedUrlForNonCopySnapshot()
+    {
+        $ec2 = Ec2Client::factory([
+            'region'  => 'us-east-1',
+            'version' => 'latest'
+        ]);
+        $this->addMockResults($ec2, [[]]);
+        $cmd = $ec2->getCommand('DescribeInstances');
+        $ec2->execute($cmd);
+        $this->assertNull($cmd['PresignedUrl']);
+    }
+
+    public function testAddsPresignedUrlForCopySnapshot()
+    {
+        $ec2 = Ec2Client::factory([
+            'region'  => 'us-east-2',
+            'version' => 'latest'
+        ]);
+        $this->addMockResults($ec2, [[]]);
+        $cmd = $ec2->getCommand('CopySnapshot', [
+            'SourceRegion'     => 'eu-west-1',
+            'SourceSnapshotId' => 'foo'
+        ]);
+        $ec2->execute($cmd);
+        $url = $cmd['PresignedUrl'];
+        $this->assertNotNull($url);
+        $this->assertContains('https://ec2.eu-west-1.amazonaws.com', $url);
+        $this->assertContains('SourceSnapshotId=foo', $url);
+        $this->assertContains('SourceRegion=eu-west-1', $url);
+        $this->assertContains('X-Amz-Signature=', $url);
+        $this->assertSame('us-east-2', $cmd['DestinationRegion']);
+    }
+}

--- a/tests/Ec2/Ec2FactoryTest.php
+++ b/tests/Ec2/Ec2FactoryTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Aws\Test\Ec2;
+
+use Aws\Ec2\CopySnapshotSubscriber;
+use Aws\Ec2\Ec2Client;
+
+class Ec2FactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAddsSubscribers()
+    {
+        $ec2 = Ec2Client::factory([
+            'region'  => 'us-east-1',
+            'version' => 'latest'
+        ]);
+
+        $this->assertNotEmpty(
+            array_filter($ec2->getEmitter()->listeners('init'), function ($e) {
+                return is_array($e) && $e[0] instanceof CopySnapshotSubscriber;
+            })
+        );
+    }
+}


### PR DESCRIPTION
I decided to pass in a serializer and endpoint provider into the subscriber rather than have the subscriber create a new client with a different endpoint and signer (like we did with v2).