### PR TITLE
Adding signature providers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "~5.1",
-        "guzzlehttp/command": "0.7.*",
+        "guzzlehttp/command": "0.8.*",
         "guzzlehttp/message-integrity-subscriber": "0.2.*",
         "guzzlehttp/retry-subscriber": "~2.0",
         "guzzlehttp/log-subscriber": "~1.0",

--- a/src/Api/Service.php
+++ b/src/Api/Service.php
@@ -188,6 +188,18 @@ class Service extends AbstractModel
     }
 
     /**
+     * Get the default signature version of the service.
+     *
+     * Note: this method assumes "v4" when not specified in the model.
+     *
+     * @return string
+     */
+    public function getSignatureVersion()
+    {
+        return $this->getMetadata('signatureVersion') ?: 'v4';
+    }
+
+    /**
      * Get the protocol used by the service.
      *
      * @return string

--- a/src/AwsClientInterface.php
+++ b/src/AwsClientInterface.php
@@ -17,13 +17,6 @@ interface AwsClientInterface extends ServiceClientInterface
     public function getCredentials();
 
     /**
-     * Returns the signature implementation used with the client.
-     *
-     * @return \Aws\Signature\SignatureInterface
-     */
-    public function getSignature();
-
-    /**
      * Get the region to which the client is configured to send requests.
      *
      * @return string

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -391,6 +391,7 @@ class ClientFactory
             );
         } elseif ($value === false) {
             $args['credentials'] = new NullCredentials();
+            $args['config']['signature_version'] = 'anonymous';
         } else {
             throw new IAE('Credentials must be an instance of '
                 . 'Aws\Credentials\CredentialsInterface, an associative '

--- a/src/Ec2/Ec2Factory.php
+++ b/src/Ec2/Ec2Factory.php
@@ -12,8 +12,7 @@ class Ec2Factory extends ClientFactory
     {
         $client = parent::createClient($args);
         $client->getEmitter()->attach(new CopySnapshotSubscriber(
-            $args['endpoint_provider'],
-            $args['serializer']
+            $args['endpoint_provider']
         ));
 
         return $client;

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -3,6 +3,7 @@ namespace Aws\S3;
 
 use Aws\AwsClient;
 use Aws\S3\Exception\S3Exception;
+use Aws\Result;
 use GuzzleHttp\Stream\AppendStream;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Command\CommandInterface;
@@ -49,7 +50,14 @@ class S3Client extends AwsClient
      */
     public function createPresignedUrl(CommandInterface $command, $expires)
     {
-        return $this->getSignature()->createPresignedUrl(
+        $signer = call_user_func(
+            $this->getSignatureProvider(),
+            $this->getConfig('signature_version'),
+            $this->getApi()->getSigningName(),
+            $this->getRegion()
+        );
+
+        return $signer->createPresignedUrl(
             $this->initTransaction($command)->request,
             $this->getCredentials(),
             $expires

--- a/src/S3/UploadBuilder.php
+++ b/src/S3/UploadBuilder.php
@@ -4,7 +4,6 @@ namespace Aws\S3;
 use Aws\Multipart\AbstractUploadBuilder;
 use Aws\Multipart\UploadState;
 use Aws\Result;
-use Aws\Signature\SignatureV4;
 use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Mimetypes;
 use GuzzleHttp\Stream\LazyOpenStream;
@@ -213,7 +212,7 @@ class UploadBuilder extends AbstractUploadBuilder
     private function decorateWithHashes(StreamInterface $stream, callable $complete)
     {
         // Determine if the checksum needs to be calculated.
-        if ($this->client->getSignature() instanceof SignatureV4) {
+        if ($this->client->getConfig('signature_version') == 'v4') {
             $type = 'sha256';
         } elseif ($this->client->getConfig('calculate_md5')) {
             $type = 'md5';

--- a/src/Signature/AnonymousSignature.php
+++ b/src/Signature/AnonymousSignature.php
@@ -1,0 +1,22 @@
+<?php
+namespace Aws\Signature;
+
+use Aws\Credentials\CredentialsInterface;
+use GuzzleHttp\Message\RequestInterface;
+
+/**
+ * Provides anonymous client access (does not sign requests).
+ */
+class AnonymousSignature implements SignatureInterface
+{
+    public function signRequest(
+        RequestInterface $request,
+        CredentialsInterface $credentials
+    ) {}
+
+    public function createPresignedUrl(
+        RequestInterface $request,
+        CredentialsInterface $credentials,
+        $expires
+    ) {}
+}

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Aws\Test;
 
-use Aws\Api\Service;
 use Aws\ClientFactory;
 use Aws\Credentials\Credentials;
 use Aws\Credentials\NullCredentials;
@@ -189,6 +188,7 @@ class ClientFactoryTest extends \PHPUnit_Framework_TestCase
             'Aws\Credentials\NullCredentials',
             $c->getCredentials()
         );
+        $this->assertEquals('anonymous', $c->getConfig('signature_version'));
     }
 
     public function testCanCreateCredentialsFromProvider()

--- a/tests/Ec2/CopySnapshotSubscriberTest.php
+++ b/tests/Ec2/CopySnapshotSubscriberTest.php
@@ -29,7 +29,7 @@ class CopySnapshotSubscriberTest extends \PHPUnit_Framework_TestCase
             'region'  => 'us-east-2',
             'version' => 'latest'
         ]);
-        $this->addMockResults($ec2, [[]]);
+        $this->addMockResults($ec2, [[], []]);
         $cmd = $ec2->getCommand('CopySnapshot', [
             'SourceRegion'     => 'eu-west-1',
             'SourceSnapshotId' => 'foo'

--- a/tests/S3/ApplyMd5SubscriberTest.php
+++ b/tests/S3/ApplyMd5SubscriberTest.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Stream\NoSeekStream;
 /**
  * @covers Aws\S3\ApplyMd5Subscriber
  */
-class ApplyMd5Test extends \PHPUnit_Framework_TestCase
+class ApplyMd5SubscriberTest extends \PHPUnit_Framework_TestCase
 {
     use UsesServiceTrait;
 
@@ -100,7 +100,7 @@ class ApplyMd5Test extends \PHPUnit_Framework_TestCase
             ],
             // Not added to upload operations when using SigV4
             [
-                ['signature' => 'v4'],
+                ['signature_version' => 'v4'],
                 'PutObject',
                 $args + ['Body' => 'baz'],
                 false,

--- a/tests/S3/S3FactoryTest.php
+++ b/tests/S3/S3FactoryTest.php
@@ -9,34 +9,6 @@ use Aws\S3\S3Factory;
  */
 class S3FactoryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testCreatesS3Signature()
-    {
-        $c = (new S3Factory())->create([
-            'service'   => 's3',
-            'signature' => 's3',
-            'version'   => 'latest'
-        ]);
-
-        $this->assertInstanceOf(
-            'Aws\Signature\S3Signature',
-            $c->getSignature()
-        );
-    }
-
-    public function testCreatesRegularSignature()
-    {
-        $c = (new S3Factory())->create([
-            'service'   => 's3',
-            'signature' => 'v4',
-            'version'   => 'latest'
-        ]);
-
-        $this->assertInstanceOf(
-            'Aws\Signature\SignatureV4',
-            $c->getSignature()
-        );
-    }
-
     public function testCanForcePathStyleOnAllOperations()
     {
         $c = (new S3Factory())->create([
@@ -84,5 +56,15 @@ class S3FactoryTest extends \PHPUnit_Framework_TestCase
             'http://test.domain.com/key',
             $c->getObjectUrl('test', 'key')
         );
+    }
+
+    public function testAddsMd5ToConfig()
+    {
+        $c = S3Client::factory([
+            'service'         => 's3',
+            'version'         => 'latest',
+            'calculate_md5'   => true
+        ]);
+        $this->assertTrue($c->getConfig('calculate_md5'));
     }
 }

--- a/tests/S3/UploadBuilderTest.php
+++ b/tests/S3/UploadBuilderTest.php
@@ -116,7 +116,7 @@ class UploadBuilderTest extends \PHPUnit_Framework_TestCase
                 null
             ],
             [
-                $this->getTestClient('s3', ['signature' => 'v4']),
+                $this->getTestClient('s3', ['signature_version' => 'v4']),
                 ['sha256', $hasher('sha256', 'foo')]
             ]
         ];

--- a/tests/Signature/AnonymousSignatureTest.php
+++ b/tests/Signature/AnonymousSignatureTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Aws\Test\Signature;
+
+use Aws\Credentials\Credentials;
+use Aws\Signature\AnonymousSignature;
+use GuzzleHttp\Message\MessageFactory;
+
+/**
+ * @covers Aws\Signature\AnonymousSignature
+ */
+class AnonymousTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDoesNotSignsRequests()
+    {
+        $creds = new Credentials('foo', 'bar', 'baz');
+        $signature = new AnonymousSignature();
+        $request = (new MessageFactory)->createRequest(
+            'PUT',
+            'http://s3.amazonaws.com/bucket/key',
+            [
+                'body'    => 'body',
+                'headers' => [
+                    'Content-Type'   => 'Baz',
+                    'X-Amz-Meta-Boo' => 'bam'
+                ]
+            ]
+        );
+        $str = (string)$request;
+
+        $signature->signRequest($request, $creds);
+        $this->assertSame($str, (string)$request);
+
+        $this->assertEquals('', $signature->createPresignedUrl(
+            $request,
+            $creds,
+            '+1 minute'
+        ));
+    }
+}

--- a/tests/Signature/ProviderTest.php
+++ b/tests/Signature/ProviderTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Aws\Test\Signature;
+
 use Aws\Signature\Provider;
 
 /**
@@ -22,29 +23,17 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreatesSignatureFromVersionString($v, $type, $service)
     {
-        $result = Provider::fromVersion($v, [
-            'service' => $service,
-            'region'  => 'baz'
-        ]);
-
+        $fn = Provider::version();
+        $result = $fn($v, $service, 'baz');
         $this->assertInstanceOf($type, $result);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage service is required
-     */
-    public function testEnsuresServiceIsProvidedForV4()
+    public function testCanMemoizeSignatures()
     {
-        Provider::fromVersion('v4', ['region' => 'foo']);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage region is required
-     */
-    public function testEnsuresRegionIsProvidedForV4()
-    {
-        Provider::fromVersion('v4', ['service' => 'foo']);
+        $fn = Provider::version();
+        $fn = Provider::memoize($fn);
+        $a = $fn('v4', 'ec2', 'us-west-2');
+        $this->assertSame($a, $fn('v4', 'ec2', 'us-west-2'));
+        $this->assertNotSame($a, $fn('v4', 'ec2', 'us-east-1'));
     }
 }

--- a/tests/UsesServiceTrait.php
+++ b/tests/UsesServiceTrait.php
@@ -29,7 +29,6 @@ trait UsesServiceTrait
         return new Sdk($args + [
             'region'      => 'us-east-1',
             'version'     => 'latest',
-            'credentials' => false,
             'retries'     => false
         ]);
     }


### PR DESCRIPTION
This commit updates clients to no longer provide a getSignature()
method, but rather utilizes an internal signature provider, that
provided a version, service, and region returns a SignatureInterface
object used to sign requests. This allows customers to inject custom
signature providers, allows customers to provide a signature version
override to use when signing requests (e.g., for S3, use v4 instead),
and allows clients to vary the signature version on a per/operation
basis (e.g., this is already a possibility as some operations are not
signed while others are signed).

This commit also updates the SDK to use a few recent Guzzle Command
changes: client options are now immutable, so some of the setOption
calls have been refactored to use a new "config" client factory
option type, which means that the option will be passed through to
the getConfig() array of a client. For example, "signature_version"
is now always available in the getConfig() array and is the
preferred signature version of the client. This information is used
in the SDK in places like the Multipart upload abstraction to know
which type of hash to add to an upload.