### PR TITLE
Added configuration profile parameter to customize credential file location

### DIFF
--- a/src/Aws/Common/Credentials/Credentials.php
+++ b/src/Aws/Common/Credentials/Credentials.php
@@ -275,6 +275,8 @@ class Credentials implements CredentialsInterface, FromConfigInterface
         $home = self::getHomeDir();
         if ($home && file_exists("{$home}/.aws/credentials")) {
             return self::fromIni($config[Options::PROFILE], "{$home}/.aws/credentials");
+        } elseif (file_exists($config[Options::CREDENTIALS_FILE])) {
+            return self::fromIni($config[Options::PROFILE], $config[Options::CREDENTIALS_FILE]);
         }
 
         // Use instance profile credentials (available on EC2 instances)

--- a/src/Aws/Common/Enum/ClientOptions.php
+++ b/src/Aws/Common/Enum/ClientOptions.php
@@ -39,6 +39,11 @@ class ClientOptions extends Enum
     const CREDENTIALS = 'credentials';
 
     /**
+     * @var string The path of a credential file to read from
+     */
+    const CREDENTIALS = 'credentials.file';
+
+    /**
      * @var string Name of a credential profile to read from your ~/.aws/credentials file
      */
     const PROFILE = 'profile';

--- a/src/Aws/Common/Enum/ClientOptions.php
+++ b/src/Aws/Common/Enum/ClientOptions.php
@@ -41,7 +41,7 @@ class ClientOptions extends Enum
     /**
      * @var string The path of a credential file to read from
      */
-    const CREDENTIALS = 'credentials.file';
+    const CREDENTIALS_FILE = 'credentials.file';
 
     /**
      * @var string Name of a credential profile to read from your ~/.aws/credentials file


### PR DESCRIPTION
Hi,

The current version of the AWS PHP SDK assumes the credential file to be located in `$HOME/.aws/credentails` which is problematic when running the code for an underprivileged user like apache because they have no $HOME setup. As a result, credentials in profile will fail to load upon instantiating of AWS services with error 
````
Error retrieving credentials from the instance profile metadata server. When you are not running inside of Amazon EC2, you must provide your AWS access key ID and secret access key in the "key" and "secret" options when creating a client or provide an instantiated Aws\Common\Credentials\CredentialsInterface object. (Client error response [status code] 404 [reason phrase] Not Found [url] http://169.254.169.254/latest/meta-data/iam/security-credentials/)
````

This pull request adds a new parameter in configuration to load credential file in arbitrary location since `Aws\Common\Credentials\Credentials::fromIni()` method has already been wired to take a file path for configuration file.

The code has been tested with a stand-along test script like this:

````php
<?php
require_once 'vendor/autoload.php';
use Aws\Sqs\SqsClient;

define('SQS_CREDENTIAL_FILE', '/aws/credentials');
define('SQS_PROFILE', 'aws-sqs');
define('SQS_REGION', 'us-east-1');
define('SQS_CUSTOMER_QUEUE_URL', 'https://sqs.us-east-1.amazonaws.com/XXXXXXX/Test-Queue');

$awsProfile = array(
    'credentials.file' => SQS_CREDENTIAL_FILE,
    'profile' => SQS_PROFILE,
    'region' => SQS_REGION
);

$sqsClient = SqsClient::factory($awsProfile);
$messageBody = 'TEST MESSAGE FROM Localhost';
$result = $sqsClient->sendMessage(array(
            'QueueUrl' => SQS_CUSTOMER_QUEUE_URL,
            'MessageBody' => $messageBody,
            'DelaySeconds' => 0 
));

echo "MessageId: {$result->get('MessageId')} RequestId: {$result->getPath('ResponseMetadata/RequestId')} \n" ;
````