### PR TITLE
Removing ringphp_handler option in favor of allowing a callable client option

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -38,11 +38,17 @@ that loads credentials from the ``src/data`` folder of the SDK.
 client
 ~~~~~~
 
-:Type: ``GuzzleHttp\ClientInterface``
+:Type: ``callable|GuzzleHttp\ClientInterface``
 
-Optional Guzzle client used to transfer requests over the wire. If you do not
-specify a client, the SDK will create a new client that uses a shared Ring HTTP
-handler with other clients.
+A function that accepts an array of options and returns a
+``GuzzleHttp\ClientInterface``, or a ``GuzzleHttp\ClientInterface`` client used
+to transfer requests over the wire.
+
+.. note::
+
+    If you do not specify a client and use the ``Aws\Sdk`` class to create
+    clients, then the SDK will create a new client that uses a shared Ring
+    HTTP handler.
 
 .. code-block:: php
 
@@ -57,6 +63,18 @@ handler with other clients.
         'version' => 'latest',
         'region'  => 'us-west-2',
         'client'  => $myClient
+    ]);
+
+    $clientFactory = function (array $options) {
+        return new Client([
+            // 'handler' => $myCustomHandler
+        ]);
+    };
+
+    $s3 = new S3Client([
+        'version' => 'latest',
+        'region'  => 'us-west-2',
+        'client'  => $clientFactory
     ]);
 
 
@@ -405,40 +423,6 @@ phrase, number of retries, connection time, total time, and error message.
         'version'      => '2012-08-10',
         'region'       => 'us-west-2',
         'retry_logger' => $logger
-    ]);
-
-
-ringphp_handler
-~~~~~~~~~~~~~~~
-
-:Type: ``callable``
-
-`RingPHP <http://ringphp.readthedocs.org/en/latest/>`_ handler used to
-transfer HTTP requests. Setting a custom RingPHP handler can be useful if you
-would like to mock HTTP responses or if you are using a third-party handler
-like the `React PHP handler <https://github.com/WyriHaximus/ReactGuzzleRing>`_
-for async support.
-
-.. code-block:: php
-
-    use GuzzleHttp\Ring\Client\MockHandler;
-    use Aws\S3\S3Client;
-
-    // Create a RingPHP handlers that always returns the same response.
-    // RingPHP response arrays are documented at
-    // http://ringphp.readthedocs.org/en/latest/spec.html#responses
-    $handler = new MockHandler([
-        'status'  => '200',
-        'body'    => '',
-        'headers' => [
-            'Content-Length' => ['0']
-        ]
-    ]);
-
-    $s3 = new Aws\S3\S3Client([
-        'region'          => 'us-west-2',
-        'version'         => '2006-03-01',
-        'ringphp_handler' => $handler
     ]);
 
 

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -37,7 +37,8 @@ Optimal settings
   system called `RingPHP <http://ringphp.readthedocs.org/en/latest/>`_ to allow
   Guzzle to utilize any sort of underlying transport (whether it's cURL, PHP
   sockets, PHP stream wrappers, etc.). You can configure which handler is used
-  by the SDK using the ``ringphp_handler`` client constructor option.
+  by the SDK using the ``client`` client constructor option and supplying a
+  custom "handler" option to the created client.
 
 `OPCache <http://php.net/manual/en/book.opcache.php>`_
   Using the OPcache extension improves PHP performance by storing precompiled

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -76,6 +76,16 @@ class Sdk
     public function __construct(array $args = [])
     {
         $this->args = $args;
+
+        if (!isset($args['client'])) {
+            $this->args['client'] = static function () {
+                static $handler;
+                if (!$handler) {
+                    $handler = Client::getDefaultHandler();
+                }
+                return new Client(['handler' => $handler]);
+            };
+        }
     }
 
     public function __call($name, array $args = [])
@@ -116,8 +126,6 @@ class Sdk
      */
     public function createClient($name, array $args = [])
     {
-        $this->createSharedHandlerIfNeeded($args);
-
         // Merge provided args with stored args
         if (isset($this->args[$name])) {
             $args += $this->args[$name];
@@ -136,15 +144,5 @@ class Sdk
         }
 
         return new $client($args);
-    }
-
-    private function createSharedHandlerIfNeeded(array $args)
-    {
-        if (!isset($this->args['ringphp_handler'])
-            && !isset($args['client'])
-            && !isset($args['ringphp_handler'])
-        ) {
-            $this->args['ringphp_handler'] = Client::getDefaultHandler();
-        }
     }
 }

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -353,34 +353,22 @@ EOT;
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage You cannot provide both a client option and a ringphp_handler option.
-     */
-    public function testCannotProvideClientAndHandler()
-    {
-        $r = new ClientResolver(ClientResolver::getDefaultArguments());
-        $r->resolve([
-            'service' => 'dynamodb',
-            'region'  => 'x',
-            'version' => 'latest',
-            'client'  => new Client(),
-            'ringphp_handler' => function () {}
-        ], new Emitter());
-    }
-
-    /**
      * @expectedException \GuzzleHttp\Exception\RequestException
      * @expectedExceptionMessage foo
      */
-    public function testCanProvideRingPHPHandler()
+    public function testCanProvideCallableClient()
     {
         $r = new ClientResolver(ClientResolver::getDefaultArguments());
         $conf = $r->resolve([
             'service' => 'dynamodb',
             'region'  => 'x',
             'version' => 'latest',
-            'ringphp_handler' => function () {
-                throw new \UnexpectedValueException('foo');
+            'client' => function (array $args) {
+                return new Client([
+                    'handler' => function () {
+                        throw new \UnexpectedValueException('foo');
+                    }
+                ]);
             }
         ], new Emitter());
 

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -3,6 +3,7 @@ namespace Aws\Test;
 
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use GuzzleHttp\Client;
 use GuzzleHttp\Message\Response;
 use GuzzleHttp\Ring\Client\MockHandler;
 
@@ -39,19 +40,23 @@ class WaiterTest extends \PHPUnit_Framework_TestCase
     {
         $i = 0;
         $client = $this->getTestClient('DynamoDb', [
-            'ringphp_handler' => new MockHandler(function () use (&$i) {
-                if ($i++) {
-                    return [
-                        'status' => 200,
-                        'body' => '{"Table":{"TableStatus":"ACTIVE"}}'
-                    ];
-                } else {
-                    return [
-                        'status' => 200,
-                        'body' => '{"Table":{"TableStatus":"CREATING"}}'
-                    ];
-                }
-            })
+            'client' => function () {
+                return new Client([
+                    'handler' => new MockHandler(function () use (&$i) {
+                        if ($i++) {
+                            return [
+                                'status' => 200,
+                                'body' => '{"Table":{"TableStatus":"ACTIVE"}}'
+                            ];
+                        } else {
+                            return [
+                                'status' => 200,
+                                'body' => '{"Table":{"TableStatus":"CREATING"}}'
+                            ];
+                        }
+                    })
+                ]);
+            }
         ]);
 
         $client->waitUntil(


### PR DESCRIPTION
This PR allows the `client` option to be a callable that returns a Client instance. This removes the ringphp_handler argument which helps to better decouple the SDK from a Guzzle implementation detail.