### PR TITLE
Reimplemented waiters using promise coroutines.

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -258,16 +258,17 @@ class AwsClient implements AwsClientInterface
         return new ResultPaginator($this, $name, $args, $config);
     }
 
-    public function getWaiter($name, array $args = [], array $config = [])
+    public function waitUntil($name, array $args = [], array $config = [])
     {
         // Create the waiter. If async, then waiting begins immediately.
         $config += $this->api->getWaiterConfig($name);
-        return new Waiter($this, $name, $args, $config);
-    }
+        $promise = (new Waiter($this, $name, $args, $config))->promise();
 
-    public function waitUntil($name, array $args = [], array $config = [])
-    {
-        $this->getWaiter($name, $args, $config)->wait();
+        if (isset($args['@future']) && $args['@future']) {
+            return $promise;
+        } else {
+            return $promise->wait();
+        }
     }
 
     public function serialize(CommandInterface $command)

--- a/tests/UsesServiceTrait.php
+++ b/tests/UsesServiceTrait.php
@@ -42,13 +42,13 @@ trait UsesServiceTrait
         // Disable network access. If the INTEGRATION envvar is set, then this
         // disabling is not done.
         if (!isset($_SERVER['INTEGRATION'])
-            && !isset($args['client'])
             && !isset($args['handler'])
+            && !isset($args['http_handler'])
         ) {
             $args['handler'] = new MockHandler([]);
         }
 
-        return $this->getTestSdk()->createClient($service, $args);
+        return $this->getTestSdk($args)->createClient($service);
     }
 
     /**
@@ -113,7 +113,7 @@ trait UsesServiceTrait
 
         return new $type(
             $message ?: 'Test error',
-            $this->getMock('GuzzleHttp\Command\CommandInterface'),
+            $this->getMock('Aws\CommandInterface'),
             [
                 'message' => $message ?: 'Test error',
                 'code'    => $code


### PR DESCRIPTION
Here's the waiter's coroutine implementation. Unit and integ tests (at least for the waiters themselves) are passing with 100% coverage. I wanted to get this up here so you can see it.

### Current Usage

#### Blocking Usage

```php
$client->waitUntil('TableExists', ['TableName' => 'Foo']);
```

#### Non-blocking Usage

```php
$promise = $client->waitUntil('TableExists', [
    'TableName' => 'Foo',
    '@future' => true
]);
```