### PR TITLE
Adding retries

### DIFF
--- a/src/Api/ErrorParser/XmlErrorParser.php
+++ b/src/Api/ErrorParser/XmlErrorParser.php
@@ -32,6 +32,10 @@ class XmlErrorParser
 
     private function parseHeaders(ResponseInterface $response, array &$data)
     {
+        if ($response->getStatusCode() == '404') {
+            $data['code'] = 'NotFound';
+        }
+
         $data['message'] = $response->getStatusCode() . ' '
             . $response->getReasonPhrase();
 

--- a/src/Api/Parser/Crc32ValidatingParser.php
+++ b/src/Api/Parser/Crc32ValidatingParser.php
@@ -29,28 +29,19 @@ class Crc32ValidatingParser extends AbstractParser
         if ($expected = $response->getHeader('x-amz-crc32')) {
             $hash = hexdec(Psr7\hash($response->getBody(), 'crc32b'));
             if ((int) $expected !== $hash) {
-                $this->throwMismatch($command, $response, $expected, $hash);
+                throw new AwsException(
+                    "crc32 mismatch. Expected {$expected}, found {$hash}.",
+                    $command,
+                    [
+                        'code'             => 'ClientChecksumMismatch',
+                        'connection_error' => true,
+                        'response'         => $response
+                    ]
+                );
             }
         }
 
         $fn = $this->parser;
         return $fn($command, $response);
-    }
-
-    private function throwMismatch(
-        CommandInterface $command,
-        ResponseInterface $response,
-        $expected,
-        $actual
-    ) {
-        throw new AwsException(
-            "crc32 mismatch. Expected {$expected}, found {$actual}.",
-            $command,
-            [
-                'code'             => 'ClientChecksumMismatch',
-                'connection_error' => true,
-                'response'         => $response
-            ]
-        );
     }
 }

--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -91,9 +91,6 @@ class AwsClient implements AwsClientInterface
      *   available regions.
      * - retries: (int, default=int(3)) Configures the maximum number of
      *   allowed retries for a client (pass 0 to disable retries).
-     * - retry_logger: (string|Psr\Log\LoggerInterface) When the string
-     *   "debug" is provided, all retries will be logged to STDOUT. Provide a
-     *   PSR-3 logger to log retries to a specific logger instance.
      * - scheme: (string, default=string(5) "https") URI scheme to use when
      *   connecting connect. The SDK will utilize "https" endpoints (i.e.,
      *   utilize SSL/TLS connections) by default. You can attempt to connect to

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -109,11 +109,6 @@ class ClientResolver
             'fn'      => [__CLASS__, '_apply_credentials'],
             'default' => [__CLASS__, '_default_credentials'],
         ],
-        'retry_logger' => [
-            'type'  => 'value',
-            'valid' => ['string', 'Psr\Log\LoggerInterface'],
-            'doc'   => 'When the string "debug" is provided, all retries will be logged to STDOUT. Provide a PSR-3 logger to log retries to a specific logger instance.'
-        ],
         'retries' => [
             'type'    => 'value',
             'valid'   => ['int'],
@@ -325,22 +320,12 @@ class ClientResolver
         throw new IAE($msg);
     }
 
-    public static function _apply_retries($value, array &$args)
+    public static function _apply_retries($value, array &$args, HandlerList $list)
     {
-        /*
         if ($value) {
-            $retry = new RetrySubscriber(self::_wrapDebugLogger($args, [
-                'max'    => $value,
-                'delay'  => 'GuzzleHttp\Subscriber\Retry\RetrySubscriber::exponentialDelay',
-                'filter' => RetrySubscriber::createChainFilter([
-                    new ThrottlingFilter($args['error_parser']),
-                    RetrySubscriber::createStatusFilter(),
-                    RetrySubscriber::createConnectFilter()
-                ])
-            ]));
-            $args['client']->getEmitter()->attach($retry);
+            $decider = RetryMiddleware::createDefaultDecider($value);
+            $list->append(Middleware::retry($decider), ['step' => 'sign']);
         }
-        */
     }
 
     public static function _apply_credentials($value, array &$args)
@@ -507,22 +492,5 @@ A "region" configuration value is required for the "{$service}" service
 (e.g., "us-west-2"). A list of available public regions and endpoints can be
 found at http://docs.aws.amazon.com/general/latest/gr/rande.html.
 EOT;
-    }
-
-    public static function _wrapDebugLogger(array $clientArgs, array $conf)
-    {
-        /*
-        // Add retry logger
-        if (isset($clientArgs['retry_logger'])) {
-            $conf['delay'] = RetrySubscriber::createLoggingDelay(
-                $conf['delay'],
-                ($clientArgs['retry_logger'] === 'debug')
-                    ? new SimpleLogger()
-                    : $clientArgs['retry_logger']
-            );
-        }
-        */
-
-        return $conf;
     }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -148,4 +148,29 @@ final class Middleware
             };
         };
     }
+
+    /**
+     * Middleware wrapper function that retries requests based on the boolean
+     * result of invoking the provided "decider" function.
+     *
+     * If no delay function is provided, a simple implementation of exponential
+     * backoff will be utilized.
+     *
+     * @param callable $decider Function that accepts the number of retries,
+     *                          a request, [result], and [exception] and
+     *                          returns true if the command is to be retried.
+     * @param callable $delay   Function that accepts the number of retries and
+     *                          returns the number of milliseconds to delay.
+     *
+     * @return callable
+     */
+    public static function retry(callable $decider = null, callable $delay = null)
+    {
+        $decider = $decider ?: RetryMiddleware::createDefaultDecider();
+        $delay = $delay ?: [RetryMiddleware::class, 'exponentialDelay'];
+
+        return function (callable $handler) use ($decider, $delay) {
+            return new RetryMiddleware($decider, $delay, $handler);
+        };
+    }
 }

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -1,0 +1,122 @@
+<?php
+namespace Aws;
+
+use Aws\Exception\AwsException;
+use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7;
+
+/**
+ * @internal Middleware that retries failures.
+ */
+class RetryMiddleware
+{
+    private static $retryStatusCodes = [
+        500 => true,
+        503 => true
+    ];
+
+    private static $retryCodes = [
+        'RequestLimitExceeded'                   => true,
+        'Throttling'                             => true,
+        'ThrottlingException'                    => true,
+        'ProvisionedThroughputExceededException' => true,
+        'RequestThrottled'                       => true,
+    ];
+
+    private $decider;
+    private $delay;
+    private $nextHandler;
+
+    public function __construct(
+        callable $decider,
+        callable $delay,
+        callable $nextHandler
+    ) {
+        $this->decider = $decider;
+        $this->delay = $delay;
+        $this->nextHandler = $nextHandler;
+    }
+
+    /**
+     * Creates a default AWS retry decider function.
+     *
+     * @param int $maxRetries
+     *
+     * @return callable
+     */
+    public static function createDefaultDecider($maxRetries = 3)
+    {
+        return function (
+            $retries,
+            CommandInterface $command,
+            RequestInterface $request,
+            ResultInterface $result = null,
+            $error = null
+        ) use ($maxRetries) {
+            if ($retries >= $maxRetries) {
+                return false;
+            } elseif (!$error) {
+                return isset(self::$retryStatusCodes[$result['@metadata']['statusCode']]);
+            } elseif (!($error instanceof AwsException)) {
+                return false;
+            } elseif ($error->isConnectionError()) {
+                return true;
+            } elseif (isset(self::$retryCodes[$error->getAwsErrorCode()])) {
+                return true;
+            } elseif (isset(self::$retryStatusCodes[$error->getStatusCode()])) {
+                return true;
+            } else {
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Delay function that calculates an exponential delay.
+     *
+     * @param $retries
+     *
+     * @return int
+     */
+    public static function exponentialDelay($retries)
+    {
+        return (int) pow(2, $retries - 1);
+    }
+
+    /**
+     * @param CommandInterface $command
+     * @param RequestInterface $request
+     *
+     * @return PromiseInterface
+     */
+    public function __invoke(
+        CommandInterface $command,
+        RequestInterface $request = null
+    ) {
+        if (!isset($options['retries'])) {
+            $options['retries'] = 0;
+        }
+
+        $retries = 0;
+        $handler = $this->nextHandler;
+        $decider = $this->decider;
+        $delay = $this->delay;
+
+        $g = function ($value) use ($handler, $decider, $delay, $command, $request, &$retries) {
+            if ($value instanceof \Exception) {
+                if (!$decider($retries, $command, $request, null, $value)) {
+                    return \GuzzleHttp\Promise\rejection_for($value);
+                }
+            } elseif (!$decider($retries, $command, $request, $value, null)) {
+                return $value;
+            }
+
+            // Delay fn is called with 0, 1, ... so increment after the call.
+            $command['@http']['delay'] = $delay($retries++);
+            return $handler($command, $request);
+        };
+
+        return $handler($command, $request)->then($g, $g);
+    }
+}

--- a/tests/Api/ErrorParser/XmlErrorParserTest.php
+++ b/tests/Api/ErrorParser/XmlErrorParserTest.php
@@ -88,4 +88,14 @@ class XmlErrorParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('400 Bad Request (Request-ID: Foo)', $result['message']);
         $this->assertEquals('Foo', $result['request_id']);
     }
+
+    public function testUsesNotFoundWhen404()
+    {
+        $response = $response = Psr7\parse_response(
+            "HTTP/1.1 404 Not Found\r\nX-Amz-Request-ID: Foo\r\n\r\n"
+        );
+        $parser = new XmlErrorParser();
+        $result = $parser($response);
+        $this->assertEquals('NotFound', $result['code']);
+    }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Aws\Test;
+
+use Aws\Command;
+use Aws\HandlerList;
+use Aws\Middleware;
+use Aws\MockHandler;
+use Aws\Result;
+use GuzzleHttp\Psr7\Request;
+
+/**
+ * @covers Aws\Middleware
+ */
+class MiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWrapsWithRetryMiddleware()
+    {
+        $list = new HandlerList();
+        $list->setHandler(new MockHandler([new Result()]));
+        $list->append(Middleware::retry(function () use (&$called) {
+            $called = true;
+        }));
+        $handler = $list->resolve();
+        $handler(new Command('foo'), new Request('GET', 'http://exmaple.com'));
+        $this->assertTrue($called);
+    }
+}

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -1,0 +1,209 @@
+<?php
+namespace Aws\Test;
+
+use Aws\Command;
+use Aws\Exception\AwsException;
+use Aws\MockHandler;
+use Aws\Result;
+use Aws\RetryMiddleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * @covers Aws\RetryMiddleware
+ */
+class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDeciderRetriesWhenStatusCodeMatches()
+    {
+        $decider = RetryMiddleware::createDefaultDecider();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $result = new Result(['@metadata' => ['statusCode' => '500']]);
+        $this->assertTrue($decider(0, $command, $request, $result, null));
+        $result = new Result(['@metadata' => ['statusCode' => '503']]);
+        $this->assertTrue($decider(0, $command, $request, $result, null));
+    }
+
+    public function testDeciderRetriesWhenConnectionError()
+    {
+        $decider = RetryMiddleware::createDefaultDecider();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $err = new AwsException('e', $command, ['connection_error' => true]);
+        $this->assertTrue($decider(0, $command, $request, null, $err));
+        $err = new AwsException('e', $command, ['connection_error' => false]);
+        $this->assertFalse($decider(0, $command, $request, null, $err));
+    }
+
+    public function testDeciderIgnoresNonAwsExceptions()
+    {
+        $decider = RetryMiddleware::createDefaultDecider();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $err = new \Exception('e');
+        $this->assertFalse($decider(0, $command, $request, null, $err));
+    }
+
+    public function testDeciderRetriesWhenAwsErrorCodeMatches()
+    {
+        $decider = RetryMiddleware::createDefaultDecider();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $err = new AwsException('e', $command, ['code' => 'RequestLimitExceeded']);
+        $this->assertTrue($decider(0, $command, $request, null, $err));
+        $err = new AwsException('e', $command, ['code' => 'Foo']);
+        $this->assertFalse($decider(0, $command, $request, null, $err));
+    }
+
+    public function testDeciderRetriesWhenExceptionStatusCodeMatches()
+    {
+        $decider = RetryMiddleware::createDefaultDecider();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $err = new AwsException('e', $command, ['response' => new Response(500)]);
+        $this->assertTrue($decider(0, $command, $request, null, $err));
+        $err = new AwsException('e', $command, ['response' => new Response(503)]);
+        $this->assertTrue($decider(0, $command, $request, null, $err));
+        $err = new AwsException('e', $command, ['response' => new Response(403)]);
+        $this->assertFalse($decider(0, $command, $request, null, $err));
+    }
+
+    public function testDeciderDoesNotRetryAfterMaxAttempts()
+    {
+        $decider = RetryMiddleware::createDefaultDecider();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $err = new AwsException('e', $command, ['code' => 'RequestLimitExceeded']);
+        $this->assertTrue($decider(0, $command, $request, null, $err));
+        $this->assertFalse($decider(3, $command, $request, null, $err));
+    }
+
+    public function testDelaysExponentially()
+    {
+        $this->assertEquals(0, RetryMiddleware::exponentialDelay(0));
+        $this->assertEquals(1, RetryMiddleware::exponentialDelay(1));
+        $this->assertEquals(2, RetryMiddleware::exponentialDelay(2));
+        $this->assertEquals(4, RetryMiddleware::exponentialDelay(3));
+        $this->assertEquals(8, RetryMiddleware::exponentialDelay(4));
+    }
+
+    public function testRetriesWhenResultMatches()
+    {
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $res1 = new Result(['@metadata' => ['statusCode' => '503']]);
+        $res2 = new Result(['@metadata' => ['statusCode' => '200']]);
+        $mock = new MockHandler(
+            [
+                function ($command, $request) use ($res1) {
+                    $this->assertFalse(isset($command['@http']['delay']));
+                    return $res1;
+                },
+                function ($command, $request) use ($res2) {
+                    $this->assertSame(0, $command['@http']['delay']);
+                    return $res2;
+                },
+            ],
+            function () use (&$called) { $called[] = func_get_args(); }
+        );
+
+        $wrapped = new RetryMiddleware(
+            RetryMiddleware::createDefaultDecider(),
+            [RetryMiddleware::class, 'exponentialDelay'],
+            $mock
+        );
+
+        $result = $wrapped($command, $request)->wait();
+        $this->assertSame($res2, $result);
+        $this->assertCount(2, $called);
+        $this->assertSame([$res1], $called[0]);
+        $this->assertSame([$res2], $called[1]);
+    }
+
+    public function testRetriesWhenExceptionMatches()
+    {
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $mock = new MockHandler(
+            [
+                function ($command, $request) {
+                    $this->assertFalse(isset($command['@http']['delay']));
+                    return new AwsException('foo', $command, [
+                        'connection_error' => true
+                    ]);
+                },
+                function ($command, $request) {
+                    $this->assertSame(0, $command['@http']['delay']);
+                    return new Result();
+                },
+            ],
+            function () use (&$called) { $called[] = func_get_args(); },
+            function () use (&$called) { $called[] = func_get_args(); }
+        );
+
+        $wrapped = new RetryMiddleware(
+            RetryMiddleware::createDefaultDecider(),
+            [RetryMiddleware::class, 'exponentialDelay'],
+            $mock
+        );
+
+        $result = $wrapped($command, $request)->wait();
+        $this->assertInstanceOf('Aws\ResultInterface', $result);
+        $this->assertCount(2, $called);
+        $this->assertInstanceOf('Aws\Exception\AwsException', $called[0][0]);
+        $this->assertInstanceOf('Aws\ResultInterface', $called[1][0]);
+    }
+
+    public function testForwardRejectionWhenExceptionDoesNotMatch()
+    {
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $mock = new MockHandler(
+            [
+                function ($command, $request) {
+                    $this->assertFalse(isset($command['@http']['delay']));
+                    return new AwsException('foo', $command);
+                }
+            ],
+            function () use (&$called) { $called[] = func_get_args(); },
+            function () use (&$called) { $called[] = func_get_args(); }
+        );
+
+        $wrapped = new RetryMiddleware(
+            RetryMiddleware::createDefaultDecider(),
+            [RetryMiddleware::class, 'exponentialDelay'],
+            $mock
+        );
+
+        try {
+            $wrapped($command, $request)->wait();
+            $this->fail();
+        } catch (AwsException $e) {
+            $this->assertCount(1, $called);
+            $this->assertContains('foo', $e->getMessage());
+        }
+    }
+
+    public function testForwardValueWhenResultDoesNotMatch()
+    {
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $res1 = new Result();
+        $mock = new MockHandler(
+            [$res1],
+            function () use (&$called) { $called[] = func_get_args(); },
+            function () use (&$called) { $called[] = func_get_args(); }
+        );
+
+        $wrapped = new RetryMiddleware(
+            RetryMiddleware::createDefaultDecider(),
+            [RetryMiddleware::class, 'exponentialDelay'],
+            $mock
+        );
+
+        $result = $wrapped($command, $request)->wait();
+        $this->assertSame($res1, $result);
+        $this->assertCount(1, $called);
+    }
+}

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -5,7 +5,6 @@ use Aws\Credentials\NullCredentials;
 use Aws\Result;
 use Aws\S3\S3Client;
 use Aws\Test\UsesServiceTrait;
-use GuzzleHttp\Command\Event\PreparedEvent;
 use GuzzleHttp\Stream\FnStream;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Stream\StreamInterface;


### PR DESCRIPTION
- Removed retry_logger option. This can be done using a custom
  middleware if needed.
- Updating the XML error parser to set the error code to "NotFound" when
  there is no body and the status code is 404. Removed custom S3 error
  parsing for bucket vs object not found.
- Updated DynamoDB to uses a response parser that ensures the response
  x-amz-crc32 header is valid.