### PR TITLE
Updating handler list to allow names.

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -315,6 +315,7 @@ class AwsClient implements AwsClientInterface
         // Sign requests. This may need to be modified later to support
         // variable signatures per/operation.
         $this->handlerList->append(
+            'sign:signer',
             Middleware::signer(
                 $this->credentials,
                 Utils::constantly(SignatureProvider::resolve(
@@ -323,8 +324,7 @@ class AwsClient implements AwsClientInterface
                     $this->api->getSigningName(),
                     $this->region
                 ))
-            ),
-            ['step' => 'sign']
+            )
         );
     }
 

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -324,7 +324,7 @@ class ClientResolver
     {
         if ($value) {
             $decider = RetryMiddleware::createDefaultDecider($value);
-            $list->append(Middleware::retry($decider), ['step' => 'sign']);
+            $list->append('sign:retry', Middleware::retry($decider));
         }
     }
 
@@ -360,9 +360,7 @@ class ClientResolver
         $args['serializer'] = Service::createSerializer($api, $args['endpoint']);
         $args['parser'] = Service::createParser($api);
         $args['error_parser'] = Service::createErrorParser($api->getProtocol());
-        $list->prepend(Middleware::requestBuilder($args['serializer']), [
-            'step' => 'build'
-        ]);
+        $list->prepend('build:builder', Middleware::requestBuilder($args['serializer']));
     }
 
     public static function _apply_endpoint_provider(callable $value, array &$args)
@@ -399,8 +397,8 @@ class ClientResolver
     {
         if ($value === true) {
             $list->append(
-                Middleware::validation($args['api'], new Validator()),
-                ['step' => 'init']
+                'init:validation',
+                Middleware::validation($args['api'], new Validator())
             );
         }
     }

--- a/src/DynamoDb/DynamoDbClient.php
+++ b/src/DynamoDb/DynamoDbClient.php
@@ -47,6 +47,7 @@ class DynamoDbClient extends AwsClient
         }
 
         $list->append(
+            'sign:retry',
             Middleware::retry(
                 RetryMiddleware::createDefaultDecider($value),
                 function ($retries) {
@@ -54,8 +55,7 @@ class DynamoDbClient extends AwsClient
                         ? (50 * (int) pow(2, $retries - 1)) / 1000
                         : 0;
                 }
-            ),
-            ['step' => 'sign']
+            )
         );
     }
 

--- a/src/Ec2/Ec2Client.php
+++ b/src/Ec2/Ec2Client.php
@@ -12,11 +12,11 @@ class Ec2Client extends AwsClient
     {
         $args['with_resolved'] = function (array $args) {
             $this->getHandlerList()->append(
+                'init:ec2.copy_snapshot',
                 CopySnapshotMiddleware::wrap(
                     $this,
                     $args['endpoint_provider']
-                ),
-                ['step' => 'init']
+                )
             );
         };
 

--- a/src/Route53/Route53Client.php
+++ b/src/Route53/Route53Client.php
@@ -13,7 +13,7 @@ class Route53Client extends AwsClient
     public function __construct(array $args)
     {
         parent::__construct($args);
-        $this->getHandlerList()->append($this->cleanIdFn(), ['step' => 'init']);
+        $this->getHandlerList()->append('init:route53.clean_id', $this->cleanIdFn());
     }
 
     private function cleanIdFn()

--- a/src/S3/ApplyMd5Middleware.php
+++ b/src/S3/ApplyMd5Middleware.php
@@ -49,8 +49,10 @@ class ApplyMd5Middleware
         $this->byDefault = $calculateMd5;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface $request)
-    {
+    public function __invoke(
+        CommandInterface $command,
+        RequestInterface $request
+    ) {
         $name = $command->getName();
 
         if (!$request->hasHeader('Content-MD5')

--- a/src/S3/SSECMiddleware.php
+++ b/src/S3/SSECMiddleware.php
@@ -32,8 +32,10 @@ class SSECMiddleware
         $this->endpointScheme = $endpointScheme;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface $request = null)
-    {
+    public function __invoke(
+        CommandInterface $command,
+        RequestInterface $request = null
+    ) {
         // Allows only HTTPS connections when using SSE-C
         if ($command['SSECustomerKey'] ||
             $command['CopySourceSSECustomerKey']

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -15,8 +15,9 @@ class SqsClient extends AwsClient
     public function __construct(array $config)
     {
         parent::__construct($config);
-        $this->getHandlerList()->append($this->queueUrl(), ['step' => 'build']);
-        $this->getHandlerList()->append($this->validateMd5(), ['step' => 'sign']);
+        $list = $this->getHandlerList();
+        $list->append('build:sqs.queue_url', $this->queueUrl());
+        $list->append('sign:sqs.md5', $this->validateMd5());
     }
 
     /**

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -46,19 +46,19 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         $c = new Command('foo', ['bar' => 'baz', 'qux' => 'boo']);
         $data = iterator_to_array($c);
-        $this->assertEquals(['bar' => 'baz', 'qux' => 'boo'], $data);
+        $this->assertEquals(['bar' => 'baz', 'qux' => 'boo', '@http' => []], $data);
     }
 
     public function testConvertToArray()
     {
         $c = new Command('foo', ['bar' => 'baz', 'qux' => 'boo']);
-        $this->assertEquals(['bar' => 'baz', 'qux' => 'boo'], $c->toArray());
+        $this->assertEquals(['bar' => 'baz', 'qux' => 'boo', '@http' => []], $c->toArray());
     }
 
     public function testCanCount()
     {
         $c = new Command('foo', ['bar' => 'baz', 'qux' => 'boo']);
-        $this->assertCount(2, $c);
+        $this->assertCount(3, $c);
     }
 
     public function testCanAccessLikeArray()

--- a/tests/DynamoDb/StandardSessionConnectionTest.php
+++ b/tests/DynamoDb/StandardSessionConnectionTest.php
@@ -24,13 +24,13 @@ class StandardSessionConnectionTest extends \PHPUnit_Framework_TestCase
             ]]),
         ]);
         $client->getHandlerList()->append(
+            'build',
             Middleware::tap(function ($command) {
                 $this->assertEquals(
                     ['sessionid' => ['S' => 'session1']],
                     $command['Key']
                 );
-            }),
-            ['step' => 'build']
+            })
         );
         $connection = new StandardSessionConnection($client, [
             'hash_key' => 'sessionid',
@@ -60,13 +60,13 @@ class StandardSessionConnectionTest extends \PHPUnit_Framework_TestCase
         $client = $this->getTestSdk()->createDynamoDb();
         $this->addMockResults($client, [new Result([])]);
         $client->getHandlerList()->append(
+            'build',
             Middleware::tap(function ($command) {
                 $updates = $command['AttributeUpdates'];
                 $this->assertArrayHasKey('expires', $updates);
                 $this->assertArrayHasKey('lock', $updates);
                 $this->assertArrayHasKey('data', $updates);
-            }),
-            ['step' => 'build']
+            })
         );
         $connection = new StandardSessionConnection($client);
         $return = $connection->write('s1', serialize(['foo' => 'bar']), true);
@@ -80,13 +80,13 @@ class StandardSessionConnectionTest extends \PHPUnit_Framework_TestCase
             $this->createMockAwsException('ERROR', 'Aws\DynamoDb\Exception\DynamoDbException')
         ]);
         $client->getHandlerList()->append(
+            'build',
             Middleware::tap(function ($command) {
                 $this->assertEquals(
                     ['Action' => 'DELETE'],
                     $command['AttributeUpdates']['data']
                 );
-            }),
-            ['step' => 'build']
+            })
         );
         $connection = new StandardSessionConnection($client);
         $return = $connection->write('s1', '', true);
@@ -124,6 +124,7 @@ class StandardSessionConnectionTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $client->getHandlerList()->append(
+            'build',
             Middleware::tap(function (CommandInterface $command) {
                 static $called = 0;
                 if (++$called === 1) {
@@ -133,8 +134,7 @@ class StandardSessionConnectionTest extends \PHPUnit_Framework_TestCase
                 } else {
                     $this->fail('Unexpected state.');
                 }
-            }),
-            ['step' => 'build']
+            })
         );
 
         (new StandardSessionConnection($client))->deleteExpired();

--- a/tests/DynamoDb/WriteRequestBatchTest.php
+++ b/tests/DynamoDb/WriteRequestBatchTest.php
@@ -65,7 +65,7 @@ class WriteRequestBatchTest extends \PHPUnit_Framework_TestCase
         $commandCount = [];
 
         $client = $this->getTestClient('DynamoDb');
-        $client->getHandlerList()->append(\Aws\Middleware::tap(
+        $client->getHandlerList()->append('sign', \Aws\Middleware::tap(
             function (CommandInterface $command) use (&$commandCount) {
                 if ($command->getName() == 'BatchWriteItem') {
                     $commandCount[] = count($command['RequestItems']);

--- a/tests/HandlerListTest.php
+++ b/tests/HandlerListTest.php
@@ -4,6 +4,8 @@ namespace Aws\Test;
 use Aws\Command;
 use Aws\CommandInterface;
 use Aws\HandlerList;
+use Aws\Middleware;
+use GuzzleHttp\Psr7\Request;
 
 /**
  * @covers Aws\HandlerList
@@ -37,14 +39,42 @@ class HandlerListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($handler, $list->resolve());
     }
 
+    public function testCanPrependWithName()
+    {
+        $list = new HandlerList();
+        $list->prepend('init:foo', function () {});
+        $this->assertCount(1, $list);
+    }
+
     public function testCanRemoveByInstance()
     {
         $handler = function () {};
         $list = new HandlerList($handler);
         $middleware = function () { return function () {}; };
-        $list->append($middleware);
+        $list->append('init', $middleware);
+        $this->assertCount(1, $list);
         $this->assertNotSame($handler, $list->resolve());
         $list->remove($middleware);
+        $this->assertCount(0, $list);
+        $this->assertSame($handler, $list->resolve());
+    }
+
+    public function testIgnoreWhenNameNotFound()
+    {
+        $list = new HandlerList();
+        $list->remove('foo');
+    }
+
+    public function testCanRemoveByName()
+    {
+        $handler = function () {};
+        $list = new HandlerList($handler);
+        $middleware = function () { return function () {}; };
+        $list->append('init:foo', $middleware);
+        $this->assertCount(1, $list);
+        $this->assertNotSame($handler, $list->resolve());
+        $list->remove('foo');
+        $this->assertCount(0, $list);
         $this->assertSame($handler, $list->resolve());
     }
 
@@ -68,7 +98,7 @@ class HandlerListTest extends \PHPUnit_Framework_TestCase
         $steps = ['init', 'validate', 'build', 'sign'];
         foreach ($steps as $step) {
             $m = $this->createMiddleware($h, $step);
-            $list->append($m, ['step' => $step]);
+            $list->append($step, $m);
         }
         $built = $list->resolve();
         $cmd = new Command('foo');
@@ -86,7 +116,7 @@ class HandlerListTest extends \PHPUnit_Framework_TestCase
         $steps = ['init', 'validate', 'build', 'sign'];
         foreach ($steps as $step) {
             $m = $this->createMiddleware($h, $step);
-            $list->prepend($m, ['step' => $step]);
+            $list->prepend($step, $m);
         }
         $built = $list->resolve();
         $cmd = new Command('foo');
@@ -97,48 +127,93 @@ class HandlerListTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testValidatesStep()
+    public function testValidatesAppendStep()
     {
         $list = new HandlerList();
-        $list->append(function () {}, ['step' => 'nope']);
+        $list->append('nope', function () {});
     }
 
-    public function testCanStickToFront()
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testValidatesPrependStep()
     {
-        $handler = function (CommandInterface $cmd, $request = null) {
-            return 'baz';
-        };
-        $list = new HandlerList($handler);
-        $h = [];
+        $list = new HandlerList();
+        $list->prepend('nope', function () {});
+    }
 
-        $m = $this->createMiddleware($h, 'a');
-        $list->prepend($m, ['step' => 'init', 'sticky' => true]);
+    public function testCanPrintStack()
+    {
+        $list = new HandlerList();
+        $list->append('init:foo', function () {});
+        $list->append('init:bar', [$this, 'bar']);
+        $list->append('validate', __CLASS__ . '::foo');
+        $list->append('sign:baz', [Middleware::class, 'tap']);
+        $list->setHandler(function () {});
+        $lines = explode("\n", (string) $list);
+        $this->assertCount(6, $lines);
+        $this->assertContains('0) Step: init, Name: foo, Function: callable(', $lines[0]);
+        $this->assertEquals("1) Step: init, Name: bar, Function: callable(['Aws\\Test\\HandlerListTest', 'bar'])", $lines[1]);
+        $this->assertEquals('2) Step: validate, Function: callable(Aws\Test\HandlerListTest::foo)', $lines[2]);
+        $this->assertEquals("3) Step: sign, Name: baz, Function: callable(['Aws\\Middleware', 'tap'])", $lines[3]);
+        $this->assertContains('4) Handler: callable(', $lines[4]);
+    }
 
-        $m = $this->createMiddleware($h, 'b');
-        $list->prepend($m, ['step' => 'init']);
+    public static function foo() {}
+    public function bar() {}
 
-        $m = $this->createMiddleware($h, 'c');
-        $list->append($m, ['step' => 'init', 'sticky' => true]);
+    public function testCanAddBefore()
+    {
+        $list = new HandlerList();
+        $list->append('init', function () {});
+        $list->append('build:test', function () {});
+        $list->before('test', 'a', function () {});
+        $lines = explode("\n", (string) $list);
+        $this->assertContains("1) Step: build, Name: a", $lines[1]);
+        $this->assertContains("2) Step: build, Name: test", $lines[2]);
+    }
 
-        $m = $this->createMiddleware($h, 'd');
-        $list->append($m, ['step' => 'init']);
+    public function testCanAddAfter()
+    {
+        $list = new HandlerList();
+        $list->append('build:test', function () {});
+        $list->append('build:after_test', function () {});
+        $list->append('init', function () {});
+        $list->after('test', 'a', function () {});
+        $lines = explode("\n", (string) $list);
+        $this->assertContains("1) Step: build, Name: test", $lines[1]);
+        $this->assertContains("2) Step: build, Name: a", $lines[2]);
+        $this->assertContains("3) Step: build, Name: after_test", $lines[3]);
+    }
 
-        $m = $this->createMiddleware($h, '0');
-        $list->prepend($m);
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMustExistByNameToPrependOrAppend()
+    {
+        $list = new HandlerList();
+        $list->before('foo', '', function () {});
+    }
 
-        $m = $this->createMiddleware($h, '-1');
-        $list->prepend($m, ['sticky' => true]);
+    public function testCanInterposeMiddleware()
+    {
+        $list = new HandlerList(function () {});
+        $list->append('init:a', Middleware::tap(function () {}));
+        $list->append('validate:b', Middleware::tap(function () {}));
+        $list->append('build:c', Middleware::tap(function () {}));
+        $list->append('sign:d', Middleware::tap(function () {}));
 
-        $m = $this->createMiddleware($h, '999');
-        $list->append($m, ['sticky' => true]);
+        $list->interpose(function ($step, $name) use (&$res) {
+            return function (callable $h) use ($step, $name, &$res) {
+                return function ($c, $r) use ($h, $step, $name, &$res) {
+                    $res[] = "$step:$name";
+                    return $h($c, $r);
+                };
+            };
+        });
 
-        $m = $this->createMiddleware($h, '998');
-        $list->append($m, ['sticky']);
-
-        $built = $list->resolve();
-        $cmd = new Command('foo');
-        $this->assertEquals('baz', $built($cmd));
-
-        $this->assertEquals(['-1', '0', 'a', 'b', 'd', 'c', '998', '999'], $h);
+        $handler = $list->resolve();
+        $handler(new Command('foo'), new Request('GET', 'http://foo.com'));
+        $this->assertEquals(['init:a', 'validate:b', 'build:c', 'sign:d'], $res);
     }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -23,7 +23,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $list = new HandlerList();
         $list->setHandler(new MockHandler([new Result()]));
-        $list->append(Middleware::tap(function () use (&$called) {
+        $list->append('sign', Middleware::tap(function () use (&$called) {
             $called = func_get_args();
         }));
         $handler = $list->resolve();
@@ -37,7 +37,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $list = new HandlerList();
         $list->setHandler(new MockHandler([new Result()]));
-        $list->append(Middleware::retry(function () use (&$called) {
+        $list->append('sign', Middleware::retry(function () use (&$called) {
             $called = true;
         }));
         $handler = $list->resolve();
@@ -54,7 +54,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         ]);
         $this->assertCount(2, $mock);
         $list->setHandler($mock);
-        $list->append(Middleware::retry());
+        $list->append('sign', Middleware::retry());
         $handler = $list->resolve();
         $handler(new Command('foo'), new Request('GET', 'http://exmaple.com'));
         $this->assertCount(0, $mock);
@@ -72,7 +72,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $list->setHandler($mock);
         $creds = new Credentials('foo', 'bar');
         $signature = new SignatureV4('a', 'b');
-        $list->append(Middleware::signer($creds, Utils::constantly($signature)));
+        $list->append('sign', Middleware::signer($creds, Utils::constantly($signature)));
         $handler = $list->resolve();
         $handler(new Command('foo'), new Request('GET', 'http://exmaple.com'));
         $this->assertTrue($req->hasHeader('Authorization'));
@@ -87,7 +87,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         };
         $list = new HandlerList();
         $list->setHandler(new MockHandler([new Result()]));
-        $list->append(Middleware::requestBuilder($serializer));
+        $list->append('sign', Middleware::requestBuilder($serializer));
         $handler = $list->resolve();
         $handler(new Command('foo'));
         $this->assertTrue($called);
@@ -124,7 +124,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
             'a',
             'b'
         );
-        $list->append(Middleware::validation($api));
+        $list->append('validate', Middleware::validation($api));
         $handler = $list->resolve();
 
         try {
@@ -146,7 +146,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         });
         $provider = ApiProvider::defaultProvider();
         $service = new Service($provider, 's3', 'latest');
-        $list->append(Middleware::sourceFile($service));
+        $list->append('init', Middleware::sourceFile($service));
         $handler = $list->resolve();
         $handler(new Command('PutObject', [
             'Bucket'     => 'test',

--- a/tests/Sqs/SqsClientTest.php
+++ b/tests/Sqs/SqsClientTest.php
@@ -59,7 +59,7 @@ class SqsClientTest extends \PHPUnit_Framework_TestCase
             'version' => 'latest'
         ]);
         $this->addMockResults($client, [[]]);
-        $client->getHandlerList()->append(Middleware::tap(function ($c, $r) use ($newUrl) {
+        $client->getHandlerList()->append('sign', Middleware::tap(function ($c, $r) use ($newUrl) {
             $this->assertEquals($newUrl, $r->getUri());
         }));
         $client->receiveMessage(['QueueUrl' => $newUrl]);


### PR DESCRIPTION
This commit updates the handler list to remove the "sticky" attribute
and instead now has a "name" that can be associated with a middleware by
providing a ":name" after a step (e.g., "init:name"). A step is now
required when calling append and prepend, and you can optionally provide
a name for any middleware. Providing a name allows you to add middleware
before or after another middleware by name or remove a middleware by
name.

In addition to naming middleware, this commit adds more introspection
into the HandlerList: you can now print the list for debugging purposes
and you can provide an interpose function (a function that is triggered
before each middleware is invoked). Interposing is useful for things
like debugging and tracing through a middleware invocation.