### PR TITLE
Adding the ability to trace through state changes between middlewares

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -60,9 +60,15 @@ class AwsClient implements AwsClientInterface
      *   credentials or return null. See Aws\Credentials\CredentialProvider for
      *   a list of built-in credentials providers. If no credentials are
      *   provided, the SDK will attempt to load them from the environment.
-     * - debug: (bool|resource) Set to true to display debug information
-     *   when sending requests. Provide a stream resource to write debug
-     *   information to a specific resource.
+     * - debug: (bool|array) Set to true to display debug information when
+     *   sending requests. Alternatively, you can provide an associative array
+     *   with the following keys: logfn: (callable) Function that is invoked
+     *   with log messages; stream_size: (int) When the size of a stream is
+     *   greater than this number, the stream data will not be logged (set to
+     *   "0" to not log any stream data); scrub_auth: (bool) Set to false to
+     *   disable the scrubbing of auth data from the logged messages; http:
+     *   (bool) Set to false to disable the "debug" feature of lower level HTTP
+     *   adapters (e.g., verbose curl output).
      * - endpoint: (string) The full URI of the webservice. This is only
      *   required when connecting to a custom endpoint (e.g., a local version
      *   of S3).
@@ -72,15 +78,17 @@ class AwsClient implements AwsClientInterface
      *   is required. See Aws\Endpoint\EndpointProvider for a list of built-in
      *   providers.
      * - handler: (callable) A handler that accepts a command object,
-     *   request object and returns a promise that is fulfilled with a result
-     *   object or an AWS exception. A handler does not accept a next handler
-     *   as it is terminal and expected to fulfill a request.
+     *   request object and returns a promise that is fulfilled with an
+     *   Aws\ResultInterface object or rejected with an
+     *   Aws\Exception\AwsException. A handler does not accept a next handler
+     *   as it is terminal and expected to fulfill a command. If no handler is
+     *   provided, a default Guzzle handler will be utilized.
      * - http: (array, default=array(0)) Set to an array of SDK request
      *   options to apply to each request (e.g., proxy, verify, etc.).
-     * - http_handler: (callable) An HTTP handler that accepts a request
-     *   object and returns a promise that is fulfilled with a response object
-     *   or array of exception data. This option supersedes any provided
-     *   "handler" option.
+     * - http_handler: (callable) An HTTP handler is a function that
+     *   accepts a PSR-7 request object and returns a promise that is fulfilled
+     *   with a PSR-7 response object or rejected with an array of exception
+     *   data. NOTE: This option supersedes any provided "handler" option.
      * - profile: (string) Allows you to specify which profile to use when
      *   credentials are created from the AWS credentials file in your HOME
      *   directory. This setting overrides the AWS_PROFILE environment

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -125,8 +125,8 @@ class ClientResolver
         ],
         'debug' => [
             'type'  => 'value',
-            'valid' => ['bool', 'resource'],
-            'doc'   => 'Set to true to display debug information when sending requests. Provide a stream resource to write debug information to a specific resource.',
+            'valid' => ['bool', 'array'],
+            'doc'   => 'Set to true to display debug information when sending requests. Alternatively, you can provide an associative array with the following keys: logfn: (callable) Function that is invoked with log messages; stream_size: (int) When the size of a stream is greater than this number, the stream data will not be logged (set to "0" to not log any stream data); scrub_auth: (bool) Set to false to disable the scrubbing of auth data from the logged messages; http: (bool) Set to false to disable the "debug" feature of lower level HTTP adapters (e.g., verbose curl output).',
             'fn'    => [__CLASS__, '_apply_debug'],
         ],
         'http' => [
@@ -381,10 +381,10 @@ class ClientResolver
         }
     }
 
-    public static function _apply_debug($value, $_, HandlerList $list)
+    public static function _apply_debug($value, array &$args, HandlerList $list)
     {
         if ($value !== false) {
-
+            $list->interpose(new TraceMiddleware($value === true ? [] : $value));
         }
     }
 

--- a/src/TraceMiddleware.php
+++ b/src/TraceMiddleware.php
@@ -68,7 +68,8 @@ class TraceMiddleware
                         ]);
                         return $value;
                     },
-                    function ($reason) use ($step, $name, $start) {
+                    function ($reason) use ($step, $name, $start, $command) {
+                        $this->flushHttpDebug($command);
                         $this->stepOutput($start, [
                             'step'   => $step,
                             'name'   => $name,

--- a/src/TraceMiddleware.php
+++ b/src/TraceMiddleware.php
@@ -1,0 +1,247 @@
+<?php
+namespace Aws;
+
+use Aws\Exception\AwsException;
+use GuzzleHttp\Promise\RejectedPromise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamableInterface;
+
+/**
+ * Traces state changes between middlewares.
+ */
+class TraceMiddleware
+{
+    private $prevOutput;
+    private $prevInput;
+    private $config;
+
+    /**
+     * Configuration array can contain the following key value pairs.
+     *
+     * - logfn: (callable) Function that is invoked with log messages. By
+     *   default, PHP's "printf" function will be utilized.
+     * - stream_size: (int) When the size of a stream is greater than this
+     *   number, the stream data will not be logged. Set to "0" to not log any
+     *   stream data.
+     * - scrub_auth: (bool) Set to false to disable the scrubbing of auth data
+     *   from the logged messages.
+     * - http: (bool) Set to false to disable the "debug" feature of lower
+     *   level HTTP adapters (e.g., verbose curl output).
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = $config + [
+            'logfn'       => 'printf',
+            'stream_size' => 524288,
+            'scrub_auth'  => true,
+            'http'        => true
+        ];
+    }
+
+    public function __invoke($step, $name)
+    {
+        $this->prevOutput = $this->prevInput = [];
+
+        return function (callable $next) use ($step, $name) {
+            return function (
+                CommandInterface $command,
+                RequestInterface $request = null
+            ) use ($next, $step, $name) {
+                $this->createHttpDebug($command);
+                $start = microtime(true);
+                $this->stepInput([
+                    'step'    => $step,
+                    'name'    => $name,
+                    'request' => $this->requestArray($request),
+                    'command' => $this->commandArray($command)
+                ]);
+
+                return $next($command, $request)->then(
+                    function ($value) use ($step, $name, $command, $start) {
+                        $this->flushHttpDebug($command);
+                        $this->stepOutput($start, [
+                            'step'   => $step,
+                            'name'   => $name,
+                            'result' => $this->resultArray($value),
+                            'error'  => null
+                        ]);
+                        return $value;
+                    },
+                    function ($reason) use ($step, $name, $start) {
+                        $this->stepOutput($start, [
+                            'step'   => $step,
+                            'name'   => $name,
+                            'result' => null,
+                            'error'  => $this->exceptionArray($reason)
+                        ]);
+                        return new RejectedPromise($reason);
+                    }
+                );
+            };
+        };
+    }
+
+    private function stepInput($entry)
+    {
+        static $keys = ['command', 'request'];
+        $this->compareStep($this->prevInput, $entry, '-> Entering', $keys);
+        $this->write("\n");
+        $this->prevInput = $entry;
+    }
+
+    private function stepOutput($start, $entry)
+    {
+        static $keys = ['result', 'error'];
+        $this->compareStep($this->prevOutput, $entry, '<- Leaving', $keys);
+        $totalTime = microtime(true) - $start;
+        $this->write("  Inclusive step time: " . $totalTime . "\n\n");
+        $this->prevOutput = $entry;
+    }
+
+    private function compareStep(array $a, array $b, $title, array $keys)
+    {
+        $changes = [];
+        foreach ($keys as $key) {
+            $av = isset($a[$key]) ? $a[$key] : null;
+            $bv = isset($b[$key]) ? $b[$key] : null;
+            $this->compareArray($av, $bv, $key, $changes);
+        }
+        $str = "\n{$title} step {$b['step']}, name '{$b['name']}'";
+        $str .= "\n" . str_repeat('-', strlen($str) - 1) . "\n\n  ";
+        $str .= $changes
+            ? implode("\n  ", str_replace("\n", "\n  ", $changes))
+            : 'no changes';
+        $this->write($str . "\n");
+    }
+
+    private function commandArray(CommandInterface $cmd)
+    {
+        return [
+            'instance' => spl_object_hash($cmd),
+            'name'     => $cmd->getName(),
+            'params'   => $cmd->toArray()
+        ];
+    }
+
+    private function requestArray(RequestInterface $request = null)
+    {
+        return !$request ? [] : array_filter([
+            'instance' => spl_object_hash($request),
+            'method'   => $request->getMethod(),
+            'headers'  => $request->getHeaders(),
+            'body'     => $this->streamStr($request->getBody()),
+            'scheme'   => $request->getUri()->getScheme(),
+            'port'     => $request->getUri()->getPath(),
+            'path'     => $request->getUri()->getPath(),
+            'query'    => $request->getUri()->getQuery(),
+        ]);
+    }
+
+    private function responseArray(ResponseInterface $response = null)
+    {
+        return !$response ? [] : [
+            'instance'   => spl_object_hash($response),
+            'statusCode' => $response->getStatusCode(),
+            'headers'    => $response->getHeaders(),
+            'body'       => $this->streamStr($response->getBody())
+        ];
+    }
+
+    private function resultArray($value)
+    {
+        return $value instanceof ResultInterface
+            ? [
+                'instance' => spl_object_hash($value),
+                'data'     => $value->toArray()
+            ] : $value;
+    }
+
+    private function exceptionArray($e)
+    {
+        if (!($e instanceof AwsException)) {
+            return $e;
+        }
+
+        return [
+            'instance'   => spl_object_hash($e),
+            'class'      => get_class($e),
+            'message'    => $e->getMessage(),
+            'type'       => $e->getAwsErrorType(),
+            'code'       => $e->getAwsErrorCode(),
+            'requestId'  => $e->getAwsRequestId(),
+            'statusCode' => $e->getStatusCode(),
+            'result'     => $this->resultArray($e->getResult()),
+            'request'    => $this->requestArray($e->getRequest()),
+            'response'   => $this->responseArray($e->getResponse())
+        ];
+    }
+
+    private function compareArray($a, $b, $path, array &$diff)
+    {
+        if ($a === $b) {
+            return;
+        } elseif (is_array($a)) {
+            $b = (array) $b;
+            $keys = array_unique(array_merge(array_keys($a), array_keys($b)));
+            foreach ($keys as $k) {
+                if (!array_key_exists($k, $a)) {
+                    $this->compareArray(null, $b[$k], "{$path}.{$k}", $diff);
+                } elseif (!array_key_exists($k, $b)) {
+                    $this->compareArray($a[$k], null, "{$path}.{$k}", $diff);
+                } else {
+                    $this->compareArray($a[$k], $b[$k], "{$path}.{$k}", $diff);
+                }
+            }
+        } elseif ($a !== null && $b === null) {
+            $diff[] = "{$path} was unset";
+        } elseif ($a === null && $b !== null) {
+            $diff[] = sprintf("%s was set to %s", $path, $this->str($b));
+        } else {
+            $diff[] = sprintf("%s changed from %s to %s", $path, $this->str($a), $this->str($b));
+        }
+    }
+
+    private function str($value)
+    {
+        return is_scalar($value) ? (string) $value : var_export($value, true);
+    }
+
+    private function streamStr(StreamableInterface $body)
+    {
+        return $body->getSize() < $this->config['stream_size']
+            ? (string) $body
+            : 'stream(size=' . $body->getSize() . ')';
+    }
+
+    private function createHttpDebug(CommandInterface $command)
+    {
+        if ($this->config['http']) {
+            $command['@http']['debug'] = fopen('php://temp', 'w+');
+        }
+    }
+
+    private function flushHttpDebug(CommandInterface $command)
+    {
+        if ($res = $command['@http']['debug']) {
+            rewind($res);
+            $this->write(stream_get_contents($res));
+            fclose($res);
+            $command['@http']['debug'] = null;
+        }
+    }
+
+    private function write($value)
+    {
+        if ($this->config['scrub_auth']) {
+            // SignatureV2 query string and S3Signature
+            $value = preg_replace('/AWSAccessKeyId=AKI.+&/i', 'AWSAccessKeyId=AKI****&', $value);
+            // SignatureV4 Signature and S3Signature
+            $value = preg_replace('/Signature=.+/i', 'Signature=****', $value);
+            // SignatureV4 access key ID
+            $value = preg_replace('/Credential=AKI.+\//i', 'Credential=AKI***/', $value);
+        }
+
+        call_user_func($this->config['logfn'], $value);
+    }
+}

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -389,4 +389,19 @@ EOT;
         $r = new ClientResolver(['region' => $args]);
         $r->resolve(['service' => 'foo'], new HandlerList());
     }
+
+    public function testAddsTraceMiddleware()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $list = new HandlerList();
+        $r->resolve([
+            'service'     => 'sqs',
+            'region'      => 'x',
+            'credentials' => ['key' => 'a', 'secret' => 'b'],
+            'version'     => 'latest',
+            'debug'       => ['logfn' => function ($value) use (&$str) { $str .= $value; }]
+        ], $list);
+        $value = $this->readAttribute($list, 'interposeFn');
+        $this->assertTrue(is_callable($value));
+    }
 }

--- a/tests/TraceMiddlewareTest.php
+++ b/tests/TraceMiddlewareTest.php
@@ -1,0 +1,115 @@
+<?php
+namespace Aws\Tests;
+
+use Aws\Command;
+use Aws\Exception\AwsException;
+use Aws\HandlerList;
+use Aws\Result;
+use Aws\TraceMiddleware;
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * @covers Aws\TraceMiddleware
+ */
+class TraceMiddlewareTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmitsDebugInfo()
+    {
+        $str = '';
+        $logfn = function ($value) use (&$str) { $str .= $value; };
+        $list = new HandlerList();
+        $list->setHandler(function ($cmd, $req) {
+            return \GuzzleHttp\Promise\promise_for(new Result([
+                'baz' => 'bar',
+                'bam' => 'qux'
+            ]));
+        });
+        $list->append('init', function ($handler) {
+            return function ($cmd, $req = null) use ($handler) {
+                $req = $req->withHeader('foo', 'bar');
+                return $handler($cmd, $req);
+            };
+        });
+        $list->append('validate', function ($handler) {
+            return function ($cmd, $req = null) use ($handler) {
+                unset($cmd['b']);
+                return $handler($cmd, $req);
+            };
+        });
+        $list->interpose(new TraceMiddleware(['logfn' => $logfn]));
+        $handler = $list->resolve();
+        $command = new Command('foo', ['a' => '1', 'b' => '2']);
+        $request = new Request('GET', 'http://foo.com');
+        $handler($command, $request);
+        $this->assertContains("-> Entering step init, name ''", $str);
+        $this->assertContains('command was set to array', $str);
+        $this->assertContains('request was set to array', $str);
+        $this->assertContains("<- Leaving step init, name ''", $str);
+        $this->assertContains('result was set to array', $str);
+        $this->assertContains('Inclusive step time: ', $str);
+        $this->assertContains('command.params.b was unset', $str);
+        $this->assertContains('no changes', $str);
+        $this->assertContains("<- Leaving step validate, name ''", $str);
+    }
+
+    public function testTracksExceptions()
+    {
+        $str = '';
+        $logfn = function ($value) use (&$str) { $str .= $value; };
+        $list = new HandlerList();
+        $list->setHandler(function ($cmd, $req) {
+            return \GuzzleHttp\Promise\promise_for(new Result());
+        });
+        $list->append('init', function ($handler) {
+            return function ($cmd, $req = null) use ($handler) {
+                $req = $req->withHeader('foo', 'bar');
+                return $handler($cmd, $req);
+            };
+        });
+        $list->append('validate', function ($handler) {
+            return function ($cmd, $req = null) use ($handler) {
+                return new RejectedPromise(new AwsException('error', $cmd, [
+                    'request'  => $req,
+                    'response' => new Response(200)
+                ]));
+            };
+        });
+        $list->interpose(new TraceMiddleware(['logfn' => $logfn]));
+        $handler = $list->resolve();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://foo.com');
+        $handler($command, $request);
+        $this->assertContains('error was set to array', $str);
+    }
+
+    public function testScrubsAuthStrings()
+    {
+        $str = '';
+        $logfn = function ($value) use (&$str) { $str .= $value; };
+        $list = new HandlerList();
+
+        $list->setHandler(function ($cmd, $req) {
+            // ensure that http level debug information is filtered as well.
+            fwrite($cmd['@http']['debug'], "Credential=AKI123/...\n");
+            return \GuzzleHttp\Promise\promise_for(new Result());
+        });
+
+        $list->append('init', function ($handler) {
+            return function ($cmd, $req) use ($handler) {
+                return $handler($cmd, $req);
+            };
+        });
+        $list->interpose(new TraceMiddleware(['logfn' => $logfn]));
+        $handler = $list->resolve();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://foo.com?Signature=abc&AWSAccessKeyId=AKI123', [
+            'Authorization' => 'Credential=AKI123/..., Signature=abcdef'
+        ]);
+        $handler($command, $request);
+        $this->assertContains("'Credential=AKI***/..., Signature=****", $str);
+        $this->assertNotContains('AKI123', $str);
+        $this->assertNotContains('abcdef', $str);
+    }
+}


### PR DESCRIPTION
This change outputs state changes between middlewares. For example, here's the output from encountering an error:

```
-> Entering step init, name 'validation'
----------------------------------------

  command was set to array (
    'instance' => '00000000476c214f000000016d19c25b',
    'name' => 'PutItem',
    'params' => 
    array (
      'TableName' => 'foo',
      'Item' => 
      array (
        'bar' => 
        array (
          'S' => 'baz',
        ),
      ),
      '@http' => 
      array (
        'headers' => 
        array (
          'User-Agent' => 'aws-sdk-php/3.0.0-beta.1',
        ),
        'debug' => NULL,
      ),
    ),
  )
  request was set to array (
  )


-> Entering step build, name 'builder'
--------------------------------------

  command.params.@http.debug changed from NULL to NULL
  request.instance was set to 00000000476c2178000000016d19c25b
  request.method was set to POST
  request.headers was set to array (
    'Host' => 
    array (
      0 => 'dynamodb.us-east-1.amazonaws.com',
    ),
    'X-Amz-Target' => 
    array (
      0 => 'DynamoDB_20120810.PutItem',
    ),
    'Content-Type' => 
    array (
      0 => 'application/x-amz-json-1.0',
    ),
  )
  request.body was set to {"TableName":"foo","Item":{"bar":{"S":"baz"}}}
  request.scheme was set to https


-> Entering step sign, name 'retry'
-----------------------------------

  command.params.@http.debug changed from NULL to NULL


-> Entering step sign, name 'signer'
------------------------------------

  command.params.@http.debug changed from NULL to NULL
  request.instance changed from 00000000476c2178000000016d19c25b to 00000000476c2104000000016d19c25b
  request.headers.X-Amz-Date was set to array (
    0 => '20150321T202102Z',
  )
  request.headers.Authorization was set to array (
    0 => 'AWS4-HMAC-SHA256 Credential=AKI***/aws4_request, SignedHeaders=host;x-amz-date;x-amz-target, Signature=****
  )

* Rebuilt URL to: https://dynamodb.us-east-1.amazonaws.com/
* Hostname was NOT found in DNS cache
*   Trying 72.21.195.244...
* Connected to dynamodb.us-east-1.amazonaws.com (72.21.195.244) port 443 (#0)
* TLS 1.0 connection using TLS_RSA_WITH_RC4_128_MD5
* Server certificate: dynamodb.us-east-1.amazonaws.com
* Server certificate: VeriSign Class 3 Secure Server CA - G3
* Server certificate: VeriSign Class 3 Public Primary Certification Authority - G5
* Server certificate: Class 3 Public Primary Certification Authority
> POST / HTTP/1.1
Host: dynamodb.us-east-1.amazonaws.com
X-Amz-Target: DynamoDB_20120810.PutItem
Content-Type: application/x-amz-json-1.0
X-Amz-Date: 20150321T202102Z
Authorization: AWS4-HMAC-SHA256 Credential=AKI***/aws4_request, SignedHeaders=host;x-amz-date;x-amz-target, Signature=****
user-agent: Guzzle/5.2.0 curl/7.39.0 PHP/5.6.3
Content-Length: 46

* upload completely sent off: 46 out of 46 bytes
< HTTP/1.1 400 Bad Request
< x-amzn-RequestId: FIQCSV81GMF3EN5Q8SEJ1OI667VV4KQNSO5AEMVJF66Q9ASUAAJG
< x-amz-crc32: 3737639027
< Content-Type: application/x-amz-json-1.0
< Content-Length: 112
< Date: Sat, 21 Mar 2015 20:21:00 GMT
< 
* Connection #0 to host dynamodb.us-east-1.amazonaws.com left intact

<- Leaving step sign, name 'signer'
-----------------------------------

  error was set to array (
    'instance' => '00000000476c21df000000016d672f83',
    'class' => 'Aws\\DynamoDb\\Exception\\DynamoDbException',
    'message' => 'Error executing "PutItem" on "https://dynamodb.us-east-1.amazonaws.com"; AWS HTTP error: Client error response [url] https://dynamodb.us-east-1.amazonaws.com [status code] 400 [reason phrase] Bad Request ResourceNotFoundException (client): Requested resource not found - {"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested resource not found"}',
    'type' => 'client',
    'code' => 'ResourceNotFoundException',
    'requestId' => 'FIQCSV81GMF3EN5Q8SEJ1OI667VV4KQNSO5AEMVJF66Q9ASUAAJG',
    'statusCode' => 400,
    'result' => NULL,
    'request' => 
    array (
      'instance' => '00000000476c2104000000016d19c25b',
      'method' => 'POST',
      'headers' => 
      array (
        'Host' => 
        array (
          0 => 'dynamodb.us-east-1.amazonaws.com',
        ),
        'X-Amz-Target' => 
        array (
          0 => 'DynamoDB_20120810.PutItem',
        ),
        'Content-Type' => 
        array (
          0 => 'application/x-amz-json-1.0',
        ),
        'X-Amz-Date' => 
        array (
          0 => '20150321T202102Z',
        ),
        'Authorization' => 
        array (
          0 => 'AWS4-HMAC-SHA256 Credential=AKI***/aws4_request, SignedHeaders=host;x-amz-date;x-amz-target, Signature=****
        ),
      ),
      'body' => '{"TableName":"foo","Item":{"bar":{"S":"baz"}}}',
      'scheme' => 'https',
    ),
    'response' => 
    array (
      'instance' => '00000000476c21d0000000016d19c25b',
      'statusCode' => 400,
      'headers' => 
      array (
        'x-amzn-RequestId' => 
        array (
          0 => 'FIQCSV81GMF3EN5Q8SEJ1OI667VV4KQNSO5AEMVJF66Q9ASUAAJG',
        ),
        'x-amz-crc32' => 
        array (
          0 => '3737639027',
        ),
        'Content-Type' => 
        array (
          0 => 'application/x-amz-json-1.0',
        ),
        'Content-Length' => 
        array (
          0 => '112',
        ),
        'Date' => 
        array (
          0 => 'Sat, 21 Mar 2015 20:21:00 GMT',
        ),
      ),
      'body' => '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested resource not found"}',
    ),
  )
  Inclusive step time: 0.6523380279541


<- Leaving step sign, name 'retry'
----------------------------------

  no changes
  Inclusive step time: 0.65371894836426


<- Leaving step build, name 'builder'
-------------------------------------

  no changes
  Inclusive step time: 0.65477585792542


<- Leaving step init, name 'validation'
---------------------------------------

  no changes
  Inclusive step time: 0.65802502632141
```