### PR TITLE
Fix assuming tests are run from the project root.

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,7 +54,7 @@ if (!isset($_SERVER['PREFIX']) || $_SERVER['PREFIX'] == 'hostname') {
 }
 
 // Instantiate the service builder
-$aws = Aws\Common\Aws::factory(isset($_SERVER['CONFIG']) ? $_SERVER['CONFIG'] : (__DIR__) . '/../test_services.dist.json');
+$aws = Aws\Common\Aws::factory(isset($_SERVER['CONFIG']) ? $_SERVER['CONFIG'] : __DIR__ . '/../test_services.dist.json');
 
 // Turn on wire logging if configured
 $aws->getEventDispatcher()->addListener('service_builder.create_client', function (\Guzzle\Common\Event $event) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,7 +54,7 @@ if (!isset($_SERVER['PREFIX']) || $_SERVER['PREFIX'] == 'hostname') {
 }
 
 // Instantiate the service builder
-$aws = Aws\Common\Aws::factory(isset($_SERVER['CONFIG']) ? $_SERVER['CONFIG'] : 'test_services.dist.json');
+$aws = Aws\Common\Aws::factory(isset($_SERVER['CONFIG']) ? $_SERVER['CONFIG'] : (__DIR__) . '/../test_services.dist.json');
 
 // Turn on wire logging if configured
 $aws->getEventDispatcher()->addListener('service_builder.create_client', function (\Guzzle\Common\Event $event) {


### PR DESCRIPTION
When running individual tests in PHPStorm, the cwd is set to the path of the file you are testing. This fixes not being able to resolve `test_services.dist.json`.