### PR TITLE
Method name fix for creating PresignedUrl

### DIFF
--- a/src/Aws/Common/Signature/SignatureV4.php
+++ b/src/Aws/Common/Signature/SignatureV4.php
@@ -270,7 +270,7 @@ class SignatureV4 extends AbstractSignature implements EndpointSignatureInterfac
         RequestInterface $request,
         CredentialsInterface $credentials
     ) {
-        $sr = RequestFactory::getInstance()->cloneRequestWithMethod($request, 'GET');
+        $sr = RequestFactory::getInstance()->cloneRequestWithMethod($request, $request->getMethod());
 
         // Move POST fields to the query if they are present
         if ($request instanceof EntityEnclosingRequestInterface) {


### PR DESCRIPTION
If presigned url created for PutObject using V4 Signature ( e.g. V4 is required for eu-central-1 region ), url not working because presigned url created with 'GET' mehtod name.