### PR TITLE
Fix S3 NoSuchTagSetException

### DIFF
--- a/src/Aws/S3/Exception/NoSuchTagSetException.php
+++ b/src/Aws/S3/Exception/NoSuchTagSetException.php
@@ -19,4 +19,4 @@ namespace Aws\S3\Exception;
 /**
  * There is no TagSet associated with the bucket.
  */
-class NoSuchTagSetErrorException extends S3Exception {}
+class NoSuchTagSetException extends S3Exception {}


### PR DESCRIPTION
This exception was never thrown because of the wrong name.