### PR TITLE
Added support for injectable cache to stream wrapper.

### DIFF
--- a/src/CacheInterface.php
+++ b/src/CacheInterface.php
@@ -1,0 +1,34 @@
+<?php
+namespace Aws;
+
+/**
+ * Represents a simple cache interface.
+ */
+interface CacheInterface
+{
+    /**
+     * Get a cache item by key.
+     *
+     * @param string $key Key to retrieve.
+     *
+     * @return mixed|null Returns the value or null if not found.
+     */
+    public function get($key);
+
+    /**
+     * Set a cache key value.
+     *
+     * @param string $key   Key to set
+     * @param mixed  $value Value to set.
+     * @param int    $ttl   Number of seconds the item is allowed to live. Set
+     *                      to 0 to allow an unlimited lifetime.
+     */
+    public function set($key, $value, $ttl = 0);
+
+    /**
+     * Remove a cache key.
+     *
+     * @param string $key Key to remove.
+     */
+    public function remove($key);
+}

--- a/src/LruArrayCache.php
+++ b/src/LruArrayCache.php
@@ -1,0 +1,74 @@
+<?php
+namespace Aws;
+
+/**
+ * Simple in-memory LRU cache that limits the number of cached entries.
+ *
+ * The LRU cache is implemented using PHP's ordered associative array. When
+ * accessing an element, the element is removed from the hash and re-added to
+ * ensure that recently used items are always at the end of the list while
+ * least recently used are at the beginning. When a value is added to the
+ * cache, if the number of cached items exceeds the allowed number, the first
+ * N number of items are removed from the array.
+ */
+class LruArrayCache implements CacheInterface
+{
+    /** @var int */
+    private $maxItems;
+
+    /** @var array */
+    private $items;
+
+    /**
+     * @param int $maxItems Maximum number of allowed cache items.
+     */
+    public function __construct($maxItems = 1000)
+    {
+        $this->maxItems = $maxItems;
+    }
+
+    public function get($key)
+    {
+        if (!isset($this->items[$key])) {
+            return null;
+        }
+
+        $entry = $this->items[$key];
+
+        // Ensure the item is not expired.
+        if (!$entry[1] || time() < $entry[1]) {
+            // LRU: remove the item and push it to the end of the array.
+            unset($this->items[$key]);
+            $this->items[$key] = $entry;
+            return $entry[0];
+        }
+
+        unset($this->items[$key]);
+        return null;
+    }
+
+    public function set($key, $value, $ttl = 0)
+    {
+        // Only call time() if the TTL is not 0/false/null
+        $ttl = $ttl ? time() + $ttl : 0;
+        $this->items[$key] = [$value, $ttl];
+
+        // Determine if there are more items in the cache than allowed.
+        $diff = count($this->items) - $this->maxItems;
+
+        // Clear out least recently used items.
+        if ($diff > 0) {
+            // Reset to the beginning of the array and begin unsetting.
+            reset($this->items);
+            for ($i = 0; $i < $diff; $i++) {
+                unset($this->items[key($this->items)]);
+                next($this->items);
+            }
+        }
+    }
+
+    public function remove($key)
+    {
+        unset($this->items[$key]);
+    }
+}

--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\S3;
 
+use Aws\CacheInterface;
+use Aws\LruArrayCache;
 use Aws\Result;
 use Aws\S3\Exception\S3Exception;
 use GuzzleHttp\Psr7;
@@ -84,38 +86,43 @@ class StreamWrapper
     /** @var string Opened bucket path */
     private $openedPath;
 
-    /** @var array LRU cache containing a hash of "time" and "value" items */
-    private static $statCache = [];
+    /** @var CacheInterface Cache for object and dir lookups */
+    private $cache;
 
     /**
      * Register the 's3://' stream wrapper
      *
-     * @param S3Client $client Client to use with the stream wrapper
+     * @param S3Client       $client   Client to use with the stream wrapper
+     * @param string         $protocol Protocol to register as.
+     * @param CacheInterface $cache    Default cache for the protocol.
      */
-    public static function register(S3Client $client)
-    {
-        if (in_array('s3', stream_get_wrappers())) {
-            stream_wrapper_unregister('s3');
+    public static function register(
+        S3Client $client,
+        $protocol = 's3',
+        CacheInterface $cache = null
+    ) {
+        if (in_array($protocol, stream_get_wrappers())) {
+            stream_wrapper_unregister($protocol);
         }
 
         // Set the client passed in as the default stream context client
-        stream_wrapper_register('s3', get_called_class(), STREAM_IS_URL);
+        stream_wrapper_register($protocol, get_called_class(), STREAM_IS_URL);
         $default = stream_context_get_options(stream_context_get_default());
-        $default['s3']['client'] = $client;
-        stream_context_set_default($default);
-    }
+        $default[$protocol]['client'] = $client;
 
-    /**
-     * Clears the internal LRU cache of the stream wrapper.
-     */
-    public static function clearCache()
-    {
-        static::$statCache = [];
+        if ($cache) {
+            $default[$protocol]['cache'] = $cache;
+        } elseif (!isset($default[$protocol]['cache'])) {
+            // Set a default cache adapter.
+            $default[$protocol]['cache'] = new LruArrayCache();
+        }
+
+        stream_context_set_default($default);
     }
 
     public function stream_close()
     {
-        $this->body = null;
+        $this->body = $this->cache = null;
     }
 
     public function stream_open($path, $mode, $options, &$opened_path)
@@ -194,7 +201,7 @@ class StreamWrapper
     public function unlink($path)
     {
         return $this->boolCall(function () use ($path) {
-            self::clearCacheKey($path);
+            $this->clearCacheKey($path);
             $this->getClient()->deleteObject($this->withPath($path));
             return true;
         });
@@ -217,14 +224,27 @@ class StreamWrapper
     public function url_stat($path, $flags)
     {
         // Some paths come through as S3:// for some reason.
-        $path = trim(str_replace('S3://', 's3://', $path));
+        $split = explode('://', $path);
+        $path = strtolower($split[0]) . '://' . $split[1];
 
         // Check if this path is in the url_stat cache
-        if ($value = self::getCache($path)) {
+        if ($value = $this->getCacheStorage()->get($path)) {
             return $value;
         }
 
+        $stat = $this->createStat($path, $flags);
+
+        if (is_array($stat)) {
+            $this->getCacheStorage()->set($path, $stat);
+        }
+
+        return $stat;
+    }
+
+    private function createStat($path, $flags)
+    {
         $parts = $this->withPath($path);
+
         if (!$parts['Key']) {
             return $this->statDirectory($parts, $path, $flags);
         }
@@ -287,7 +307,7 @@ class StreamWrapper
     public function mkdir($path, $mode, $options)
     {
         $params = $this->withPath($path);
-        self::clearCacheKey($path);
+        $this->clearCacheKey($path);
         if (!$params['Bucket']) {
             return false;
         }
@@ -303,7 +323,7 @@ class StreamWrapper
 
     public function rmdir($path, $options)
     {
-        self::clearCacheKey($path);
+        $this->clearCacheKey($path);
         $params = $this->withPath($path);
         $client = $this->getClient();
 
@@ -439,7 +459,7 @@ class StreamWrapper
 
         // Cache the object data for quick url_stat lookups used with
         // RecursiveDirectoryIterator.
-        self::setCache($key, $stat);
+        $this->getCacheStorage()->set($key, $stat);
         $this->objectIterator->next();
 
         return $result;
@@ -447,7 +467,8 @@ class StreamWrapper
 
     private function formatKey($key)
     {
-        return "s3://{$this->openedBucket}/{$key}";
+        $protocol = explode('://', $this->openedPath)[0];
+        return "{$protocol}://{$this->openedBucket}/{$key}";
     }
 
     /**
@@ -464,8 +485,8 @@ class StreamWrapper
     {
         $partsFrom = $this->withPath($path_from);
         $partsTo = $this->withPath($path_to);
-        self::clearCacheKey($path_from);
-        self::clearCacheKey($path_to);
+        $this->clearCacheKey($path_from);
+        $this->clearCacheKey($path_to);
 
         if (!$partsFrom['Key'] || !$partsTo['Key']) {
             return $this->triggerError('The Amazon S3 stream wrapper only '
@@ -581,7 +602,10 @@ class StreamWrapper
 
     private function getBucketKey($path)
     {
-        $parts = explode('/', substr($path, 5), 2);
+        // Remove the protocol
+        $parts = explode('://', $path);
+        // Get the bucket, key
+        $parts = explode('/', $parts[1], 2);
 
         return [
             'Bucket' => $parts[0],
@@ -609,13 +633,8 @@ class StreamWrapper
         $client = $this->getClient();
         $command = $client->getCommand('GetObject', $this->getOptions());
         $command['@http']['stream'] = true;
-
         $result = $client->execute($command);
         $this->body = $result['Body'];
-
-        if ($result['ContentLength']) {
-            $this->body->setSize($result['ContentLength']);
-        }
 
         // Wrap the body in a caching entity body if seeking is allowed
         if ($this->getOption('seekable') && !$this->body->isSeekable()) {
@@ -693,8 +712,6 @@ class StreamWrapper
                 // Pluck the content-length if available.
                 if (isset($result['ContentLength'])) {
                     $stat['size'] = $stat[7] = $result['ContentLength'];
-                } elseif (isset($stat['Size'])) {
-                    $stat['size'] = $stat[7] = $result['Size'];
                 }
                 if (isset($result['LastModified'])) {
                     // ListObjects or HeadObject result
@@ -722,7 +739,7 @@ class StreamWrapper
 
         return $this->boolCall(function () use ($params, $path) {
             $this->getClient()->createBucket($params);
-            self::clearCacheKey($path);
+            $this->clearCacheKey($path);
             return true;
         });
     }
@@ -751,7 +768,7 @@ class StreamWrapper
 
         return $this->boolCall(function () use ($params, $path) {
             $this->getClient()->putObject($params);
-            self::clearCacheKey($path);
+            $this->clearCacheKey($path);
             return true;
         });
     }
@@ -846,62 +863,25 @@ class StreamWrapper
     }
 
     /**
-     * Clears a specific stat cache value from the stat cache.
+     * @return LruArrayCache
+     */
+    private function getCacheStorage()
+    {
+        if (!$this->cache) {
+            $this->cache = $this->getOption('cache') ?: new LruArrayCache();
+        }
+
+        return $this->cache;
+    }
+
+    /**
+     * Clears a specific stat cache value from the stat cache and LRU cache.
      *
      * @param string $key S3 path (s3://bucket/key).
      */
-    private static function clearCacheKey($key)
+    private function clearCacheKey($key)
     {
         clearstatcache(true, $key);
-        unset(self::$statCache[$key]);
-    }
-
-    /**
-     * Gets a value from the stat cache.
-     *
-     * @param string $key S3 path (s3://bucket/key).
-     *
-     * @return array|null
-     */
-    private static function getCache($key)
-    {
-        if (isset(self::$statCache[$key])) {
-            self::$statCache[$key]['time'] = microtime(true);
-            return self::$statCache[$key]['value'];
-        }
-
-        return null;
-    }
-
-    /**
-     * Adds a value to the stat cache, marking the time it was added.
-     *
-     * @param string $key   S3 path (e.g., s3://bucket/key).
-     * @param array  $value stat() array.
-     */
-    private static function setCache($key, $value)
-    {
-        if (count(self::$statCache) === 1001) {
-            self::purgeLru();
-        }
-
-        self::$statCache[$key] = [
-            'value' => $value,
-            'time'  => microtime(true)
-        ];
-    }
-
-    /**
-     * Purges half of the items in the cache, removing the least recently used.
-     */
-    private static function purgeLru()
-    {
-        usort(self::$statCache, function ($a, $b) {
-            return $a['time'] > $b['time']
-                ? 1
-                : ($a['time'] < $b['time'] ? -1 : 0);
-        });
-
-        self::$statCache = array_slice(self::$statCache, 0, 500);
+        $this->getCacheStorage()->remove($key);
     }
 }

--- a/tests/LruArrayCacheTest.php
+++ b/tests/LruArrayCacheTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Aws\Test;
+
+use Aws\LruArrayCache;
+
+/**
+ * @covers Aws\LruArrayCache
+ */
+class LruArrayCacheTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetRemoveAndRetrieve()
+    {
+        $c = new LruArrayCache();
+        $c->set('foo', 'baz');
+        $this->assertSame('baz', $c->get('foo'));
+        $this->assertSame('baz', $c->get('foo'));
+        $c->remove('foo');
+        $this->assertNull($c->get('foo'));
+    }
+
+    public function testLimitsSize()
+    {
+        $c = new LruArrayCache(3);
+        $c->set('a', 1);
+        $c->set('b', 2);
+        $c->set('c', 3);
+        $c->set('d', 4);
+        $c->set('e', 5);
+        $this->assertNull($c->get('a'));
+        $this->assertNull($c->get('b'));
+        $this->assertSame(3, $c->get('c'));
+        $this->assertSame(4, $c->get('d'));
+        $this->assertSame(5, $c->get('e'));
+    }
+
+    public function testRemovesLru()
+    {
+        $c = new LruArrayCache(3);
+        $c->set('a', 1);
+        $c->set('b', 2);
+        $c->set('c', 3);
+        $c->get('a'); // Puts a back on the end
+        $c->set('d', 4);
+        $c->set('e', 5);
+        $this->assertNull($c->get('b'));
+        $this->assertNull($c->get('c'));
+        $this->assertSame(1, $c->get('a'));
+        $this->assertSame(4, $c->get('d'));
+        $this->assertSame(5, $c->get('e'));
+    }
+
+    public function testFiltersBasedOnTtl()
+    {
+        $c = new LruArrayCache();
+        // Create a cache item with an expired TTL
+        $c->set('a', 1, -1);
+        $this->assertNull($c->get('a'));
+    }
+}


### PR DESCRIPTION
- You can now inject a cache into the stream wrapper in a contect or in
  the default context options.
- Added a CacheInterface for simple get/set/remove caching.
- Added a single cache implementation LruArrayCache that implements an
  LRU cache using PHP's ordered associative arrays.
- Added support for creating a stream wrapper using a custom protocol.

Closes #531. Closes #536.

Example:

```php
<?php
require 'vendor/autoload.php';

$s3 = new Aws\S3\S3Client([
    'region'  => 'us-east-1',
    'version' => 'latest',
    // use debug to ensure that no requests are sent.
    'debug'   => true
]);

// Create an LRU cache
$cache = new \Aws\LruArrayCache();
// Create a dummy return value.
$cache->set('s3://t1234/test', ['size' => 123, 7 => 123]);
// Register the stream wrapper with the cache and a protocol name.
\Aws\S3\StreamWrapper::register($s3, 's3', $cache);
// Show that we got the dummy size value.
var_dump(filesize('s3://t1234/test'));
```