### PR TITLE
Return results for GetCheckerIpRanges

### DIFF
--- a/src/Aws/Route53/Resources/route53-2013-04-01.php
+++ b/src/Aws/Route53/Resources/route53-2013-04-01.php
@@ -1903,7 +1903,7 @@ return array (
                     'type' => 'array',
                     'location' => 'xml',
                     'items' => array(
-                        'name' => 'IPAddressCidr',
+                        'name' => 'member',
                         'type' => 'string',
                     ),
                 ),


### PR DESCRIPTION
Use the correct element name when extracting CIDRs from a GetCheckerIpRangesResponse.