### PR TITLE
Return results for GetCheckerIpRanges

### DIFF
--- a/src/data/route53/2013-04-01/api-2.json
+++ b/src/data/route53/2013-04-01/api-2.json
@@ -960,7 +960,7 @@
     },
     "CheckerIpRanges":{
       "type":"list",
-      "member":{"shape":"IPAddressCidr"}
+      "member":{"shape":"member"}
     },
     "ConflictingDomainExists":{
       "type":"structure",


### PR DESCRIPTION
This (untested) patch is analogous to #561, but for `v3`.