### PR TITLE
Updating waiters (and docs) and paginators.

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -255,20 +255,21 @@ class AwsClient implements AwsClientInterface
         return new \ArrayIterator((array) $result);
     }
 
-    public function getPaginator($name, array $args = [], array $config = [])
+    public function getPaginator($name, array $args = [])
     {
-        $config += $this->api->getPaginatorConfig($name);
+        $config = $this->api->getPaginatorConfig($name);
 
         return new ResultPaginator($this, $name, $args, $config);
     }
 
-    public function waitUntil($name, array $args = [], array $config = [])
+    public function waitUntil($name, array $args = [])
     {
-        return $this->getWaiter($name, $args, $config)->promise()->wait();
+        return $this->getWaiter($name, $args)->promise()->wait();
     }
 
-    public function getWaiter($name, array $args = [], array $config = [])
+    public function getWaiter($name, array $args = [])
     {
+        $config = isset($args['@waiter']) ? $args['@waiter'] : [];
         $config += $this->api->getWaiterConfig($name);
 
         return new Waiter($this, $name, $args, $config);

--- a/src/AwsClientInterface.php
+++ b/src/AwsClientInterface.php
@@ -133,12 +133,11 @@ interface AwsClientInterface
      *
      * @param string $name   Name of the operation used for iterator
      * @param array  $args   Command args to be used with each command
-     * @param array  $config Hash of paginator options.
      *
      * @return \Aws\ResultPaginator
      * @throws \UnexpectedValueException if the iterator config is invalid.
      */
-    public function getPaginator($name, array $args = [], array $config = []);
+    public function getPaginator($name, array $args = []);
 
     /**
      * Wait until a resource is in a particular state.
@@ -146,14 +145,13 @@ interface AwsClientInterface
      * @param string|callable $name Name of the waiter that defines the wait
      *                              configuration and conditions.
      * @param array  $args          Args to be used with each command executed
-     *                              by the waiter.
-     * @param array  $config        Waiter configuration. Use this to override
-     *                              the defaults for the specified waiter.
-     *
+     *                              by the waiter. Waiter configuration options
+     *                              can be provided in an associative array in
+     *                              the @waiter key.
      * @return void
      * @throws \UnexpectedValueException if the waiter is invalid.
      */
-    public function waitUntil($name, array $args = [], array $config = []);
+    public function waitUntil($name, array $args = []);
 
     /**
      * Get a waiter that waits until a resource is in a particular state.
@@ -166,12 +164,11 @@ interface AwsClientInterface
      * @param string|callable $name Name of the waiter that defines the wait
      *                              configuration and conditions.
      * @param array  $args          Args to be used with each command executed
-     *                              by the waiter.
-     * @param array  $config        Waiter configuration. Use this to override
-     *                              the defaults for the specified waiter.
-     *
+     *                              by the waiter. Waiter configuration options
+     *                              can be provided in an associative array in
+     *                              the @waiter key.
      * @return \Aws\Waiter
      * @throws \UnexpectedValueException if the waiter is invalid.
      */
-    public function getWaiter($name, array $args = [], array $config = []);
+    public function getWaiter($name, array $args = []);
 }


### PR DESCRIPTION
- Adding waiter documentation.
- Waiters are now fulfilled with the command that last succeeded. This
  provides a relatively useful indicator of which waiter succeeded when
  working with multiple promises and pairs well with the addition of the
  before argument.
- Waiters now accept a "before" callback that takes the command about
  the be executed and the number of attempts.
- Removed the "retry" callback from waiters.
- Custom waiter configs are now injected in the `@waiter` key value pair
  of the `$args` parameter for `getWaiter()` and `waitUntil()`.
- Removed the `$config` array from paginators as this does not have a
  valid use case.