### PR TITLE
Fix bool typecasting of request param values

### DIFF
--- a/src/Api/Serializer/QueryParamBuilder.php
+++ b/src/Api/Serializer/QueryParamBuilder.php
@@ -133,4 +133,9 @@ class QueryParamBuilder
     ) {
         $query[$prefix] = TimestampShape::format($value, 'iso8601');
     }
+
+    protected function format_boolean(Shape $shape, $value, $prefix, array &$query)
+    {
+        $query[$prefix] = ($value) ? 'true' : 'false';
+    }
 }


### PR DESCRIPTION
As via gitter.im - I had a problem with `ElasticBeanstalk::describeEnvironments` when passing through `IncludeDeleted => false` as param.

Currently it would typecast it into a string, which PHP will just make a empty string out of it. With this path it will check if value is a boolean and replace it with actual 'true' or 'false' strings.

