### PR TITLE
[v3] Signature::presign and S3Client::getPresignedRequest

### DIFF
--- a/src/Ec2/CopySnapshotMiddleware.php
+++ b/src/Ec2/CopySnapshotMiddleware.php
@@ -69,10 +69,10 @@ class CopySnapshotMiddleware
         // Create a presigned URL for our generated request.
         $signer = new SignatureV4('ec2', $cmd['SourceRegion']);
 
-        return $signer->createPresignedUrl(
+        return (string) $signer->presign(
             SignatureV4::convertPostToGet($request),
             $client->getCredentials(),
             '+1 hour'
-        );
+        )->getUri();
     }
 }

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -14,6 +14,7 @@ use Aws\S3\Exception\S3Exception;
 use Aws\ResultInterface;
 use Aws\CommandInterface;
 use GuzzleHttp\Psr7;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -176,11 +177,13 @@ class S3Client extends AwsClient
      *                                      expire. This can be a Unix
      *                                      timestamp, a PHP DateTime object,
      *                                      or a string that can be evaluated
-     *                                      by strtotime
-     * @return string
+     *                                      by strtotime().
+     *
+     * @return RequestInterface
      */
-    public function createPresignedUrl(CommandInterface $command, $expires)
+    public function createPresignedRequest(CommandInterface $command, $expires)
     {
+        /** @var \Aws\Signature\SignatureInterface $signer */
         $signer = call_user_func(
             $this->getSignatureProvider(),
             $this->getConfig('signature_version'),
@@ -188,7 +191,7 @@ class S3Client extends AwsClient
             $this->getRegion()
         );
 
-        return $signer->createPresignedUrl(
+        return $signer->presign(
             $this->serialize($command),
             $this->getCredentials(),
             $expires
@@ -200,7 +203,8 @@ class S3Client extends AwsClient
      *
      * The URL returned by this method is not signed nor does it ensure the the
      * bucket and key given to the method exist. If you need a signed URL, then
-     * use the {@see \Aws\S3\S3Client::createPresignedUrl} method.
+     * use the {@see \Aws\S3\S3Client::createPresignedRequest} method and get
+     * the URI of the signed request.
      *
      * @param string $bucket  The name of the bucket where the object is located
      * @param string $key     The key of the object

--- a/src/Signature/AnonymousSignature.php
+++ b/src/Signature/AnonymousSignature.php
@@ -16,11 +16,11 @@ class AnonymousSignature implements SignatureInterface
         return $request;
     }
 
-    public function createPresignedUrl(
+    public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
         $expires
     ) {
-        return '';
+        return $request;
     }
 }

--- a/src/Signature/S3Signature.php
+++ b/src/Signature/S3Signature.php
@@ -50,7 +50,7 @@ class S3Signature implements SignatureInterface
         return $request->withHeader('Authorization', $auth);
     }
 
-    public function createPresignedUrl(
+    public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
         $expires
@@ -92,7 +92,7 @@ class S3Signature implements SignatureInterface
 
         $queryString = http_build_query($query, null, '&', PHP_QUERY_RFC3986);
 
-        return (string) $request->getUri()->withQuery($queryString);
+        return $request->withUri($request->getUri()->withQuery($queryString));
     }
 
     /**

--- a/src/Signature/SignatureInterface.php
+++ b/src/Signature/SignatureInterface.php
@@ -26,17 +26,17 @@ interface SignatureInterface
     );
 
     /**
-     * Create a pre-signed URL
+     * Create a pre-signed request.
      *
-     * @param RequestInterface     $request Request to sign
+     * @param RequestInterface     $request     Request to sign
      * @param CredentialsInterface $credentials Credentials used to sign
      * @param int|string|\DateTime $expires The time at which the URL should
      *     expire. This can be a Unix timestamp, a PHP DateTime object, or a
      *     string that can be evaluated by strtotime.
      *
-     * @return string
+     * @return RequestInterface
      */
-    public function createPresignedUrl(
+    public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
         $expires

--- a/src/Signature/SignatureV2.php
+++ b/src/Signature/SignatureV2.php
@@ -43,7 +43,7 @@ class SignatureV2 implements SignatureInterface
         return $request->withBody(Psr7\stream_for(http_build_query($params)));
     }
 
-    public function createPresignedUrl(
+    public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
         $expires

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -69,7 +69,7 @@ class SignatureV4 implements SignatureInterface
         return $this->buildRequest($parsed);
     }
 
-    public function createPresignedUrl(
+    public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
         $expires
@@ -95,7 +95,7 @@ class SignatureV4 implements SignatureInterface
         );
         $parsed['query']['X-Amz-Signature'] = hash_hmac('sha256', $stringToSign, $key);
 
-        return (string) $this->buildRequest($parsed)->getUri();
+        return $this->buildRequest($parsed);
     }
 
     /**

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -89,7 +89,7 @@ class S3ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($valid, S3Client::isBucketDnsCompatible($bucket));
     }
 
-    public function testCreatesPresignedUrls()
+    public function testCreatesPresignedRequests()
     {
         /** @var S3Client $client */
         $client = $this->getTestClient('S3', [
@@ -97,7 +97,7 @@ class S3ClientTest extends \PHPUnit_Framework_TestCase
             'credentials' => ['key' => 'foo', 'secret' => 'bar']
         ]);
         $command = $client->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'bar']);
-        $url = $client->createPresignedUrl($command, 1342138769);
+        $url = (string) $client->createPresignedRequest($command, 1342138769)->getUri();
         $this->assertContains(
             'https://foo.s3.amazonaws.com/bar?AWSAccessKeyId=',
             $url
@@ -117,7 +117,7 @@ class S3ClientTest extends \PHPUnit_Framework_TestCase
             'Bucket' => 'foobar test: abc',
             'Key'    => '+%.a'
         ]);
-        $url = $client->createPresignedUrl($command, 1342138769);
+        $url = (string) $client->createPresignedRequest($command, 1342138769)->getUri();
         $this->assertContains(
             'https://s3.amazonaws.com/foobar%20test%3A%20abc/%2B%25.a?AWSAccessKeyId=',
             $url

--- a/tests/Signature/AnonymousSignatureTest.php
+++ b/tests/Signature/AnonymousSignatureTest.php
@@ -25,9 +25,9 @@ class AnonymousTest extends \PHPUnit_Framework_TestCase
         );
 
         $result = $signature->signRequest($request, $creds);
-        $this->assertSame($result, $request);
+        $this->assertSame($request, $result);
 
-        $this->assertEquals('', $signature->createPresignedUrl(
+        $this->assertEquals($request, $signature->presign(
             $request,
             $creds,
             '+1 minute'

--- a/tests/Signature/S3SignatureTest.php
+++ b/tests/Signature/S3SignatureTest.php
@@ -61,11 +61,11 @@ class S3SignatureTest extends \PHPUnit_Framework_TestCase
         $signature = new S3Signature();
         $req = Psr7\parse_request($message);
         // Try with string
-        $res = $signature->createPresignedUrl($req, $creds, $dt);
-        $this->assertSame($url, $res);
+        $res = $signature->presign($req, $creds, $dt);
+        $this->assertSame($url, (string) $res->getUri());
         // Try with timestamp
-        $res = $signature->createPresignedUrl($req, $creds, new \DateTime($dt));
-        $this->assertSame($url, $res);
+        $res = $signature->presign($req, $creds, new \DateTime($dt));
+        $this->assertSame($url, (string) $res->getUri());
     }
 
     public function signatureDataProvider()
@@ -304,11 +304,11 @@ class S3SignatureTest extends \PHPUnit_Framework_TestCase
             $meth->invoke($signature, $request, time())
         );
 
-        $result = $signature->createPresignedUrl(
+        $result = (string) $signature->presign(
             $request,
             new Credentials('foo', 'bar', 'baz'),
             time()
-        );
+        )->getUri();
 
         $this->assertContains('&x-amz-acl=public-read', $result);
         $this->assertContains('x-amz-foo=bar', $result);

--- a/tests/Signature/S3SignatureV4Test.php
+++ b/tests/Signature/S3SignatureV4Test.php
@@ -68,33 +68,33 @@ class S3SignatureV4Test extends \PHPUnit_Framework_TestCase
     public function testCreatesPresignedDatesFromDateTime()
     {
         list($request, $credentials, $signature) = $this->getFixtures();
-        $url = $signature->createPresignedUrl(
+        $url = (string) $signature->presign(
             $request,
             $credentials,
             new \DateTime('December 11, 2013 00:00:00 UTC')
-        );
+        )->getUri();
         $this->assertContains('X-Amz-Expires=518400', $url);
     }
 
     public function testCreatesPresignedDatesFromUnixTimestamp()
     {
         list($request, $credentials, $signature) = $this->getFixtures();
-        $url = $signature->createPresignedUrl(
+        $url = (string) $signature->presign(
             $request,
             $credentials,
             1386720000
-        );
+        )->getUri();
         $this->assertContains('X-Amz-Expires=518400', $url);
     }
 
     public function testCreatesPresignedDateFromStrtotime()
     {
         list($request, $credentials, $signature) = $this->getFixtures();
-        $url = $signature->createPresignedUrl(
+        $url = (string) $signature->presign(
             $request,
             $credentials,
             'December 11, 2013 00:00:00 UTC'
-        );
+        )->getUri();
         $this->assertContains('X-Amz-Expires=518400', $url);
     }
 
@@ -106,11 +106,11 @@ class S3SignatureV4Test extends \PHPUnit_Framework_TestCase
             $credentials->getSecretKey(),
             '123'
         );
-        $url = $signature->createPresignedUrl(
+        $url = (string) $signature->presign(
             $request,
             $credentials,
             1386720000
-        );
+        )->getUri();
         $this->assertContains('X-Amz-Security-Token=123', $url);
         $this->assertContains('X-Amz-Expires=518400', $url);
     }
@@ -121,10 +121,10 @@ class S3SignatureV4Test extends \PHPUnit_Framework_TestCase
     public function testEnsuresSigV4DurationIsLessThanOneWeek()
     {
         list($request, $credentials, $signature) = $this->getFixtures();
-        $signature->createPresignedUrl(
+        $signature->presign(
             $request,
             $credentials,
             'December 31, 2026 00:00:00 UTC'
-        );
+        )->getUri();
     }
 }

--- a/tests/Signature/SignatureV2Test.php
+++ b/tests/Signature/SignatureV2Test.php
@@ -44,6 +44,6 @@ class SignatureV2Test extends \PHPUnit_Framework_TestCase
         $mock = $sig = new SignatureV2();
         $request = new Request('GET', 'http://foo.com');
         $credentials = new Credentials('foo', 'bar');
-        $mock->createPresignedUrl($request, $credentials, '+10 minutes');
+        $mock->presign($request, $credentials, '+10 minutes');
     }
 }

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -127,7 +127,7 @@ class SignatureV4Test extends \PHPUnit_Framework_TestCase
         $_SERVER['override_v4_time'] = true;
         list($request, $credentials, $signature) = $this->getFixtures();
         $credentials = new Credentials('foo', 'bar', '123');
-        $url = $signature->createPresignedUrl($request, $credentials, 1386720000);
+        $url = (string) $signature->presign($request, $credentials, 1386720000)->getUri();
         $this->assertContains('X-Amz-Security-Token=123', $url);
         $this->assertContains('X-Amz-Expires=518400', $url);
     }
@@ -139,7 +139,7 @@ class SignatureV4Test extends \PHPUnit_Framework_TestCase
     {
         $_SERVER['override_v4_time'] = true;
         list($request, $credentials, $signature) = $this->getFixtures();
-        $signature->createPresignedUrl($request, $credentials, 'December 31, 2013 00:00:00 UTC');
+        $signature->presign($request, $credentials, 'December 31, 2013 00:00:00 UTC');
     }
 
     public function testConvertsPostToGet()


### PR DESCRIPTION
Updated the SignatureInterface to change createPresignedUrl to presign. Changed S3's createPresignedUrl to createPresignedRequest.

Consumers can get the presigned URL (and other information like headers) from the presigned request object. Formerly, only the URLs were returned, and getting the header values needed to actually make requests to the presigned URLs was not possible with custom middleware.