### PR TITLE
Temporary credentials with cross-region CopySnapshot

### DIFF
--- a/src/Aws/Ec2/CopySnapshotListener.php
+++ b/src/Aws/Ec2/CopySnapshotListener.php
@@ -59,10 +59,9 @@ class CopySnapshotListener implements EventSubscriberInterface
     ) {
         // Create a temporary client used to generate the presigned URL
         $newClient = Ec2Client::factory(array(
-            'region'    => $command['SourceRegion'],
-            'signature' => 'v4',
-            'key'       => $client->getCredentials()->getAccessKeyId(),
-            'secret'    => $client->getCredentials()->getSecretKey()
+            'region'      => $command['SourceRegion'],
+            'signature'   => 'v4',
+            'credentials' => $client->getCredentials(),
         ));
 
         $preCommand = $newClient->getCommand(

--- a/tests/Aws/Tests/Ec2/CopySnapshotListenerTest.php
+++ b/tests/Aws/Tests/Ec2/CopySnapshotListenerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Aws\Tests\Ec2;
+use Aws\Common\Credentials\Credentials;
 
 /**
  * @covers \Aws\Ec2\CopySnapshotListener
@@ -9,8 +10,11 @@ class CopySnapshotListenerTest extends \Guzzle\Tests\GuzzleTestCase
 {
     public function testAddsPresignedUrlBeforeSending()
     {
-        $client = $this->getServiceBuilder()->get('ec2');
-        $client->setRegion('us-east-1');
+        $client = $this->getServiceBuilder()->get('ec2', array(
+            'credentials' => new Credentials('foo', 'bar', 'baz', strtotime('+1 hour')),
+            'region'      => 'us-east-1'
+        ));
+
         $command = $client->getCommand('CopySnapshot', array(
             'SourceRegion'     => 'eu-west-1',
             'SourceSnapshotId' => 'foo'
@@ -20,6 +24,7 @@ class CopySnapshotListenerTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertContains('DestinationRegion=us-east-1', $r);
         $this->assertContains('SourceRegion%3Deu-west-1', $r);
         $this->assertContains('PresignedUrl=https%3A%2F%2Fec2.eu-west-1.amazonaws.com', $r);
+        $this->assertContains('X-Amz-Security-Token%3Dbaz', $r);
     }
 
     public function testIgnoresOtherOperations()


### PR DESCRIPTION
Fixes a bug in the EC2 CopySnapshotListener so it works with temporary credentials.