### PR TITLE
Making the step name part of the method for HandlerList

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -305,8 +305,7 @@ class AwsClient implements AwsClientInterface
     {
         // Sign requests. This may need to be modified later to support
         // variable signatures per/operation.
-        $this->handlerList->append(
-            'sign:signer',
+        $this->handlerList->appendSign(
             Middleware::signer(
                 $this->credentialProvider,
                 constantly(SignatureProvider::resolve(
@@ -315,7 +314,8 @@ class AwsClient implements AwsClientInterface
                     $this->api->getSigningName(),
                     $this->region
                 ))
-            )
+            ),
+            'signer'
         );
     }
 

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -323,7 +323,7 @@ class ClientResolver
     {
         if ($value) {
             $decider = RetryMiddleware::createDefaultDecider($value);
-            $list->append('sign:retry', Middleware::retry($decider));
+            $list->appendSign(Middleware::retry($decider), 'retry');
         }
     }
 
@@ -372,7 +372,7 @@ class ClientResolver
         $args['serializer'] = Service::createSerializer($api, $args['endpoint']);
         $args['parser'] = Service::createParser($api);
         $args['error_parser'] = Service::createErrorParser($api->getProtocol());
-        $list->prepend('build:builder', Middleware::requestBuilder($args['serializer']));
+        $list->prependBuild(Middleware::requestBuilder($args['serializer']), 'builder');
     }
 
     public static function _apply_endpoint_provider(callable $value, array &$args)
@@ -408,9 +408,9 @@ class ClientResolver
     public static function _apply_validate($value, array &$args, HandlerList $list)
     {
         if ($value === true) {
-            $list->append(
-                'init:validation',
-                Middleware::validation($args['api'], new Validator())
+            $list->appendValidate(
+                Middleware::validation($args['api'], new Validator()),
+                'validation'
             );
         }
     }

--- a/src/DynamoDb/DynamoDbClient.php
+++ b/src/DynamoDb/DynamoDbClient.php
@@ -46,8 +46,7 @@ class DynamoDbClient extends AwsClient
             return;
         }
 
-        $list->append(
-            'sign:retry',
+        $list->appendSign(
             Middleware::retry(
                 RetryMiddleware::createDefaultDecider($value),
                 function ($retries) {
@@ -55,7 +54,8 @@ class DynamoDbClient extends AwsClient
                         ? (50 * (int) pow(2, $retries - 1)) / 1000
                         : 0;
                 }
-            )
+            ),
+            'retry'
         );
     }
 

--- a/src/Ec2/Ec2Client.php
+++ b/src/Ec2/Ec2Client.php
@@ -14,12 +14,12 @@ class Ec2Client extends AwsClient
     public function __construct(array $args)
     {
         $args['with_resolved'] = function (array $args) {
-            $this->getHandlerList()->append(
-                'init:ec2.copy_snapshot',
+            $this->getHandlerList()->appendInit(
                 CopySnapshotMiddleware::wrap(
                     $this,
                     $args['endpoint_provider']
-                )
+                ),
+                'ec2.copy_snapshot'
             );
         };
 

--- a/src/Glacier/GlacierClient.php
+++ b/src/Glacier/GlacierClient.php
@@ -23,15 +23,15 @@ class GlacierClient extends AwsClient
 
         // Setup middleware.
         $stack = $this->getHandlerList();
-        $stack->append('build:glacier.api_version',$this->getApiVersionMiddleware());
-        $stack->append('build:glacier.checksum', $this->getChecksumsMiddleware());
-        $stack->append(
-            'build:glacier.content_type',
-            Middleware::contentType(['UploadArchive', 'UploadPart'])
+        $stack->appendBuild($this->getApiVersionMiddleware(), 'glacier.api_version');
+        $stack->appendBuild($this->getChecksumsMiddleware(), 'glacier.checksum');
+        $stack->appendBuild(
+            Middleware::contentType(['UploadArchive', 'UploadPart']),
+            'glacier.content_type'
         );
-        $stack->append(
-            'init:glacier.source_file',
-            Middleware::sourceFile($this->getApi(), 'body', 'sourceFile')
+        $stack->appendInit(
+            Middleware::sourceFile($this->getApi(), 'body', 'sourceFile'),
+            'glacier.source_file'
         );
     }
 

--- a/src/Multipart/AbstractUploader.php
+++ b/src/Multipart/AbstractUploader.php
@@ -363,7 +363,7 @@ abstract class AbstractUploader implements Promise\PromisorInterface
                     $this->info['command']['upload'],
                     $data + $this->state->getId()
                 );
-                $command->getHandlerList()->append('sign:mup', $resultHandler);
+                $command->getHandlerList()->appendSign($resultHandler, 'mup');
                 yield $command;
                 if ($this->source->tell() > $partStartPos) {
                     continue;

--- a/src/Route53/Route53Client.php
+++ b/src/Route53/Route53Client.php
@@ -13,7 +13,7 @@ class Route53Client extends AwsClient
     public function __construct(array $args)
     {
         parent::__construct($args);
-        $this->getHandlerList()->append('init:route53.clean_id', $this->cleanIdFn());
+        $this->getHandlerList()->appendInit($this->cleanIdFn(), 'route53.clean_id');
     }
 
     private function cleanIdFn()

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -16,8 +16,8 @@ class SqsClient extends AwsClient
     {
         parent::__construct($config);
         $list = $this->getHandlerList();
-        $list->append('build:sqs.queue_url', $this->queueUrl());
-        $list->append('sign:sqs.md5', $this->validateMd5());
+        $list->appendBuild($this->queueUrl(), 'sqs.queue_url');
+        $list->appendSign($this->validateMd5(), 'sqs.md5');
     }
 
     /**

--- a/tests/DynamoDb/WriteRequestBatchTest.php
+++ b/tests/DynamoDb/WriteRequestBatchTest.php
@@ -74,7 +74,7 @@ class WriteRequestBatchTest extends \PHPUnit_Framework_TestCase
         $commandCount = [];
 
         $client = $this->getTestClient('DynamoDb');
-        $client->getHandlerList()->append('sign', \Aws\Middleware::tap(
+        $client->getHandlerList()->appendSign(\Aws\Middleware::tap(
             function (CommandInterface $command) use (&$commandCount) {
                 if ($command->getName() == 'BatchWriteItem') {
                     $commandCount[] = count($command['RequestItems']);

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -33,7 +33,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $list = new HandlerList();
         $list->setHandler(new MockHandler([new Result()]));
-        $list->append('sign', Middleware::tap(function () use (&$called) {
+        $list->appendSign(Middleware::tap(function () use (&$called) {
             $called = func_get_args();
         }));
         $handler = $list->resolve();
@@ -48,7 +48,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $list = new HandlerList();
         $list->setHandler(new MockHandler([new Result()]));
-        $list->append('sign', Middleware::retry(function () use (&$called) {
+        $list->appendSign(Middleware::retry(function () use (&$called) {
             $called = true;
         }));
         $handler = $list->resolve();
@@ -66,7 +66,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         ]);
         $this->assertCount(2, $mock);
         $list->setHandler($mock);
-        $list->append('sign', Middleware::retry());
+        $list->appendSign(Middleware::retry());
         $handler = $list->resolve();
         $handler(new Command('foo'), new Request('GET', 'http://127.0.0.1'))->wait();
         $this->assertCount(0, $mock);
@@ -84,7 +84,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $list->setHandler($mock);
         $creds = CredentialProvider::fromCredentials(new Credentials('foo', 'bar'));
         $signature = new SignatureV4('a', 'b');
-        $list->append('sign', Middleware::signer($creds, Aws\constantly($signature)));
+        $list->appendSign(Middleware::signer($creds, Aws\constantly($signature)));
         $handler = $list->resolve();
         $handler(new Command('foo'), new Request('GET', 'http://exmaple.com'));
         Promise\queue()->run();
@@ -100,7 +100,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         };
         $list = new HandlerList();
         $list->setHandler(new MockHandler([new Result()]));
-        $list->append('sign', Middleware::requestBuilder($serializer));
+        $list->appendSign(Middleware::requestBuilder($serializer));
         $handler = $list->resolve();
         $handler(new Command('foo'));
         $this->assertTrue($called);
@@ -138,7 +138,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
             ],
             function () { return []; }
         );
-        $list->append('validate', Middleware::validation($api));
+        $list->appendValidate(Middleware::validation($api));
         $handler = $list->resolve();
 
         try {
@@ -161,7 +161,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $provider = ApiProvider::defaultProvider();
         $data = $provider('api', 's3', 'latest');
         $service = new Service($data, $provider);
-        $list->append('init', Middleware::sourceFile($service));
+        $list->appendInit(Middleware::sourceFile($service));
         $handler = $list->resolve();
         $handler(new Command('PutObject', [
             'Bucket'     => 'test',
@@ -177,7 +177,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $h = new Aws\History();
         $mock = new MockHandler([new Result()]);
         $list = new HandlerList($mock);
-        $list->append('sign', Middleware::history($h));
+        $list->appendSign(Middleware::history($h));
         $handler = $list->resolve();
         $req = new Request('GET', 'http://www.foo.com');
         $cmd = new Command('foo');
@@ -191,8 +191,8 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $h = new Aws\History();
         $list = new HandlerList();
         $list->setHandler(new MockHandler([new Result()]));
-        $list->append('build', Middleware::contentType(['Foo']));
-        $list->append('sign', Middleware::history($h));
+        $list->appendBuild(Middleware::contentType(['Foo']));
+        $list->appendSign(Middleware::history($h));
         $handler = $list->resolve();
         $payload = Psr7\stream_for(fopen(__DIR__ . '/../docs/_static/logo.png', 'r'));
         $request = new Request('PUT', 'http://exmaple.com', [], $payload);
@@ -209,7 +209,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $list = new HandlerList();
         $mock = new MockHandler([new Result()]);
         $list->setHandler($mock);
-        $list->append('init', Middleware::mapCommand(function (CommandInterface $c) {
+        $list->appendInit(Middleware::mapCommand(function (CommandInterface $c) {
             $c['Hi'] = 'test';
             return $c;
         }));
@@ -224,7 +224,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $list = new HandlerList();
         $mock = new MockHandler([new Result()]);
         $list->setHandler($mock);
-        $list->append('init', Middleware::mapRequest(function (RequestInterface $r) {
+        $list->appendInit(Middleware::mapRequest(function (RequestInterface $r) {
             return $r->withHeader('X-Foo', 'Bar');
         }));
         $handler = $list->resolve();
@@ -238,7 +238,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $list = new HandlerList();
         $mock = new MockHandler([new Result()]);
         $list->setHandler($mock);
-        $list->append('sign', Middleware::mapResult(function (ResultInterface $r) {
+        $list->appendSign(Middleware::mapResult(function (ResultInterface $r) {
             $r['Test'] = 'hi';
             return $r;
         }));

--- a/tests/S3/ApplyMd5MiddlewareTest.php
+++ b/tests/S3/ApplyMd5MiddlewareTest.php
@@ -35,8 +35,7 @@ class ApplyMd5MiddlewareTest extends \PHPUnit_Framework_TestCase
         $s3 = $this->getTestClient('s3', $options);
         $this->addMockResults($s3, [[]]);
         $command = $s3->getCommand($operation, $args);
-        $command->getHandlerList()->append(
-            'build',
+        $command->getHandlerList()->appendBuild(
             Middleware::tap(function ($cmd, RequestInterface $request) use ($md5Added, $md5Value) {
                 $this->assertSame($md5Added, $request->hasHeader('Content-MD5'));
                 if ($md5Value !== 'SKIP') {

--- a/tests/S3/BucketStyleMiddlewareTest.php
+++ b/tests/S3/BucketStyleMiddlewareTest.php
@@ -20,8 +20,7 @@ class BucketStyleTest extends \PHPUnit_Framework_TestCase
             'Bucket' => 'test.123',
             'Key'    => 'Bar'
         ]);
-        $command->getHandlerList()->append(
-            'sign',
+        $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, RequestInterface $req) {
                 $this->assertEquals('s3.amazonaws.com', $req->getUri()->getHost());
                 $this->assertEquals('/test.123/Bar', $req->getRequestTarget());
@@ -38,8 +37,7 @@ class BucketStyleTest extends \PHPUnit_Framework_TestCase
             'Bucket' => '_baz_!',
             'Key'    => 'Bar'
         ]);
-        $command->getHandlerList()->append(
-            'sign',
+        $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
                 $this->assertEquals('s3.amazonaws.com', $req->getUri()->getHost());
                 $this->assertEquals('/_baz_%21/Bar', $req->getRequestTarget());
@@ -56,8 +54,7 @@ class BucketStyleTest extends \PHPUnit_Framework_TestCase
             'Bucket' => 'foo',
             'Key'    => 'Bar'
         ]);
-        $command->getHandlerList()->append(
-            'sign',
+        $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
                 $this->assertEquals('s3.amazonaws.com', $req->getUri()->getHost());
                 $this->assertEquals('/foo/Bar', $req->getRequestTarget());
@@ -71,8 +68,7 @@ class BucketStyleTest extends \PHPUnit_Framework_TestCase
         $s3 = $this->getTestClient('s3');
         $this->addMockResults($s3, [[]]);
         $command = $s3->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'Bar/Baz']);
-        $command->getHandlerList()->append(
-            'sign',
+        $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
                 $this->assertEquals('foo.s3.amazonaws.com', $req->getUri()->getHost());
                 $this->assertEquals('/Bar/Baz', $req->getRequestTarget());
@@ -86,8 +82,7 @@ class BucketStyleTest extends \PHPUnit_Framework_TestCase
         $s3 = $this->getTestClient('s3');
         $this->addMockResults($s3, [[]]);
         $command = $s3->getCommand('GetBucketLocation', ['Bucket' => 'foo']);
-        $command->getHandlerList()->append(
-            'sign',
+        $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
                 $this->assertEquals('s3.amazonaws.com', $req->getUri()->getHost());
                 $this->assertEquals('/foo?location', $req->getRequestTarget());
@@ -107,8 +102,7 @@ class BucketStyleTest extends \PHPUnit_Framework_TestCase
             'Bucket' => 'test',
             'Key'    => 'key'
         ]);
-        $command->getHandlerList()->append(
-            'sign',
+        $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
                 $this->assertEquals('test.domain.com', $req->getUri()->getHost());
                 $this->assertEquals('/key', $req->getRequestTarget());

--- a/tests/S3/SSECMiddlewareTest.php
+++ b/tests/S3/SSECMiddlewareTest.php
@@ -20,8 +20,7 @@ class SseCpkListenerTest extends \PHPUnit_Framework_TestCase
         $s3 = $this->getTestClient('s3');
         $this->addMockResults($s3, [[]]);
         $cmd = $s3->getCommand($operation, $params);
-        $cmd->getHandlerList()->append(
-            'init',
+        $cmd->getHandlerList()->appendInit(
             Middleware::tap(function ($cmd, $req) use ($expectedResults) {
                 foreach ($expectedResults as $key => $value) {
                     $this->assertEquals($value, $cmd[$key]);

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -154,7 +154,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanOpenWriteOnlyStreams()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result()]);
         $s = fopen('s3://bucket/key', 'w');
         $this->assertEquals(4, fwrite($s, 'test'));
@@ -186,7 +186,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanOpenAppendStreamsWithOriginalFile()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
 
         // Queue the 200 response that will load the original, and queue the
         // 204 flush response
@@ -228,7 +228,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanUnlinkFiles()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [
             new Result(['@metadata' => ['statusCode' => 204]])
         ]);
@@ -280,7 +280,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCreatingBucketsSetsAclBasedOnPermissions()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
 
         $this->addMockResults($this->client, [
             function ($cmd, $r) { return new S3Exception('404', $cmd); },
@@ -313,7 +313,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCreatesNestedSubfolder()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
 
         $this->addMockResults($this->client, [
             function ($cmd, $r) { return new S3Exception('404', $cmd); },
@@ -352,7 +352,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanDeleteBucketWithRmDir()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result()]);
         $this->assertTrue(rmdir('s3://bucket'));
         $this->assertEquals(1, count($history));
@@ -376,7 +376,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanDeleteObjectWithRmDir($path)
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result(), new Result()]);
         $this->assertTrue(rmdir($path));
         $this->assertCount(1, $history);
@@ -388,7 +388,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanDeleteNestedFolderWithRmDir()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [
             new Result([
                 'Name' => 'foo',
@@ -431,7 +431,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanRenameObjects()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [
             new Result(),
             new Result()
@@ -458,7 +458,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testCanRenameObjectsWithCustomSettings()
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [
             new Result(), // 204
             new Result()  // 204
@@ -617,7 +617,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
     public function testDeterminesIfFileOrDir($uri, $queue, $result)
     {
         $history = new History();
-        $this->client->getHandlerList()->append('sign', Middleware::history($history));
+        $this->client->getHandlerList()->appendSign(Middleware::history($history));
 
         if ($queue) {
             $this->addMockResults($this->client, $queue);
@@ -735,8 +735,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
 
         $this->addMockResults($this->client, array_merge($results, $results));
 
-        $this->client->getHandlerList()->append(
-            'build',
+        $this->client->getHandlerList()->appendBuild(
             Middleware::tap(function (CommandInterface $c, $req) {
                 $this->assertEquals('bucket', $c['Bucket']);
                 $this->assertEquals('/', $c['Delimiter']);
@@ -778,8 +777,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->client->getHandlerList()->append(
-            'build',
+        $this->client->getHandlerList()->appendBuild(
             Middleware::tap(function (CommandInterface $c, $req) {
                 $this->assertEquals('bucket', $c['Bucket']);
                 $this->assertEquals('', $c['Delimiter']);

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -89,12 +89,12 @@ class TransferTest extends \PHPUnit_Framework_TestCase
     public function testCanSetBeforeOptionForUploadsAndUsedWithDebug()
     {
         $s3 = $this->getTestClient('s3');
-        $s3->getHandlerList()->append(
-            'sign:s3.test',
+        $s3->getHandlerList()->appendSign(
             $this->mockResult(function() {
                 return new Result();
-            }
-        ));
+            }),
+            's3.test'
+        );
 
         $c = [];
         $i = \Aws\recursive_dir_iterator(__DIR__);

--- a/tests/Sqs/SqsClientTest.php
+++ b/tests/Sqs/SqsClientTest.php
@@ -59,7 +59,7 @@ class SqsClientTest extends \PHPUnit_Framework_TestCase
             'version' => 'latest'
         ]);
         $this->addMockResults($client, [[]]);
-        $client->getHandlerList()->append('sign', Middleware::tap(function ($c, $r) use ($newUrl) {
+        $client->getHandlerList()->appendSign(Middleware::tap(function ($c, $r) use ($newUrl) {
             $this->assertEquals($newUrl, $r->getUri());
         }));
         $client->receiveMessage(['QueueUrl' => $newUrl]);

--- a/tests/TraceMiddlewareTest.php
+++ b/tests/TraceMiddlewareTest.php
@@ -27,13 +27,13 @@ class TraceMiddlewareTest extends \PHPUnit_Framework_TestCase
                 'bam' => 'qux'
             ]));
         });
-        $list->append('init', function ($handler) {
+        $list->appendInit(function ($handler) {
             return function ($cmd, $req = null) use ($handler) {
                 $req = $req->withHeader('foo', 'bar');
                 return $handler($cmd, $req);
             };
         });
-        $list->append('validate', function ($handler) {
+        $list->appendValidate(function ($handler) {
             return function ($cmd, $req = null) use ($handler) {
                 unset($cmd['b']);
                 return $handler($cmd, $req);
@@ -64,13 +64,13 @@ class TraceMiddlewareTest extends \PHPUnit_Framework_TestCase
         $list->setHandler(function ($cmd, $req) {
             return \GuzzleHttp\Promise\promise_for(new Result());
         });
-        $list->append('init', function ($handler) {
+        $list->appendInit(function ($handler) {
             return function ($cmd, $req = null) use ($handler) {
                 $req = $req->withHeader('foo', 'bar');
                 return $handler($cmd, $req);
             };
         });
-        $list->append('validate', function ($handler) {
+        $list->appendValidate(function ($handler) {
             return function ($cmd, $req = null) use ($handler) {
                 return new RejectedPromise(new AwsException('error', $cmd, [
                     'request'  => $req,
@@ -99,7 +99,7 @@ class TraceMiddlewareTest extends \PHPUnit_Framework_TestCase
             return \GuzzleHttp\Promise\promise_for(new Result());
         });
 
-        $list->append('init', function ($handler) {
+        $list->appendInit(function ($handler) {
             return function ($cmd, $req) use ($handler) {
                 return $handler($cmd, $req);
             };


### PR DESCRIPTION
This commit updates the HandlerList to include the step name as part of
adding a middleware to a handler. This adds methods for each step
prefixed with "append" or "prepend". I believe this to be a better API
as it does not require string parsing (e.g., "init:foo") and makes the
steps explicit and auto-completable.