### PR TITLE
Now converting timestamps to DateTimeResult objects

### DIFF
--- a/build/docs/classes/ExampleBuilder.php
+++ b/build/docs/classes/ExampleBuilder.php
@@ -89,7 +89,9 @@ class ExampleBuilder
             case 'stream':
                 return '<Psr\\Http\\Message\\StreamableInterface>';
             case 'timestamp':
-                return '<integer || string || DateTime>';
+                return $this->isInput
+                    ? '<integer || string || DateTime>'
+                    : '<DateTime>';
             case 'float':
                 return '<float>';
             default:

--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -1,0 +1,41 @@
+<?php
+namespace Aws\Api;
+
+/**
+ * DateTime overrides that make DateTime work more seamlessly as a string,
+ * with JSON documents, and with JMESPath.
+ */
+class DateTimeResult extends \DateTime implements \JsonSerializable
+{
+    /**
+     * Create a new DateTimeResult from a unix timestamp.
+     *
+     * @param $unixTimestamp
+     *
+     * @return DateTimeResult
+     */
+    public static function fromEpoch($unixTimestamp)
+    {
+        return new self(gmdate('c', $unixTimestamp));
+    }
+
+    /**
+     * Serialize the DateTimeResult as an ISO 8601 date string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * Serialize the date as an ISO 8601 date when serializing as JSON.
+     *
+     * @return mixed|string
+     */
+    public function jsonSerialize()
+    {
+        return (string) $this;
+    }
+}

--- a/src/Api/Parser/JsonParser.php
+++ b/src/Api/Parser/JsonParser.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Api\Parser;
 
+use Aws\Api\DateTimeResult;
 use Aws\Api\Shape;
 
 /**
@@ -36,6 +37,12 @@ class JsonParser
                     $target[$k] = $this->parse($values, $v);
                 }
                 return $target;
+
+            case 'timestamp':
+                // The Unix epoch (or Unix time or POSIX time or Unix
+                // timestamp) is the number of seconds that have elapsed since
+                // January 1, 1970 (midnight UTC/GMT).
+                return DateTimeResult::fromEpoch($value);
 
             case 'blob':
                 return base64_decode($value);

--- a/src/Api/Parser/XmlParser.php
+++ b/src/Api/Parser/XmlParser.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Api\Parser;
 
+use Aws\Api\DateTimeResult;
 use Aws\Api\ListShape;
 use Aws\Api\MapShape;
 use Aws\Api\Shape;
@@ -26,7 +27,8 @@ class XmlParser
             'boolean'   => 'parse_boolean',
             'integer'   => 'parse_integer',
             'float'     => 'parse_float',
-            'double'    => 'parse_float'
+            'double'    => 'parse_float',
+            'timestamp' => 'parse_timestamp',
         ];
 
         $type = $shape['type'];
@@ -119,5 +121,10 @@ class XmlParser
     private function parse_boolean(Shape $shape, $value)
     {
         return $value == 'true' ? true : false;
+    }
+
+    private function parse_timestamp(Shape $shape, $value)
+    {
+        return new DateTimeResult($value);
     }
 }

--- a/tests/Api/DateTimeResultTest.php
+++ b/tests/Api/DateTimeResultTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Aws\Test\Api;
+
+use Aws\Api\DateTimeResult;
+
+/**
+ * @covers \Aws\Api\DateTimeResult
+ */
+class DateTimeResultTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreatesFromEpoch()
+    {
+        $t = time();
+        $d = DateTimeResult::fromEpoch($t);
+        $this->assertEquals($t, $d->format('U'));
+    }
+
+    public function testCastToIso8601String()
+    {
+        $t = time();
+        $d = DateTimeResult::fromEpoch($t);
+        $this->assertSame(gmdate('c', $t), (string) $d);
+    }
+
+    public function testJsonSerialzesAsIso8601()
+    {
+        $t = time();
+        $d = DateTimeResult::fromEpoch($t);
+        $this->assertSame('"' . gmdate('c', $t). '"', json_encode($d));
+    }
+}

--- a/tests/Api/Parser/ComplianceTest.php
+++ b/tests/Api/Parser/ComplianceTest.php
@@ -99,9 +99,8 @@ class ComplianceTest extends \PHPUnit_Framework_TestCase
                 }
                 break;
             case 'Aws\Api\TimestampShape':
-                if (is_string($data)) {
-                    $data = strtotime($data);
-                }
+                // Format the DateTimeResult as a Unix timestamp.
+                $data = $data->format('U');
                 break;
         }
     }


### PR DESCRIPTION
This change updates the SDK to parse timestamp shapes into custom DateTimeResult objects. These objects extend DateTime and implement `__toString` and `JsonSerializable`. This allows the object to work with JMESPath as well.

This is a good change because it normalizes the timestamp result type across different protocols but still allows users to work with it as if it is an ISO 8601 date string.