### PR TITLE
Using older composer version syntax to support older builds of composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": ">=5.3|>=6.0.1,<7",
+        "guzzlehttp/guzzle": ">=5.3|~6.0.1|~6.1",
         "guzzlehttp/psr7": "~1.0",
         "guzzlehttp/promises": "~1.0",
         "mtdowling/jmespath.php": "~2.2"

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^5.3||^6.0.1",
-        "guzzlehttp/psr7": "^1.0",
-        "guzzlehttp/promises": "^1.0",
-        "mtdowling/jmespath.php": "^2.2"
+        "guzzlehttp/guzzle": ">=5.3|>=6.0.1,<7",
+        "guzzlehttp/psr7": "~1.0",
+        "guzzlehttp/promises": "~1.0",
+        "mtdowling/jmespath.php": "~2.2"
     },
     "require-dev": {
         "ext-openssl": "*",


### PR DESCRIPTION
This commit updates the SDK to use older composer.json syntax to support older builds of composer. This converts `^` usage to `~` and `||` usage to `|`. I'm not sure if `|` is exactly equivalent to `||`, but it seems to be based on testing it locally.

/cc @GrahamCampbell 