### PR TITLE
Various enhancements related to #604

### DIFF
--- a/src/Exception/CouldNotCreateChecksumException.php
+++ b/src/Exception/CouldNotCreateChecksumException.php
@@ -3,7 +3,7 @@ namespace Aws\Exception;
 
 class CouldNotCreateChecksumException extends \RuntimeException
 {
-    public function __construct($algorithm)
+    public function __construct($algorithm, \Exception $previous = null)
     {
         $prefix = $algorithm === 'md5' ? "An" : "A";
         parent::__construct("{$prefix} {$algorithm} checksum could not be "
@@ -14,6 +14,6 @@ class CouldNotCreateChecksumException extends \RuntimeException
             . "stream in a GuzzleHttp\\Stream\\CachingStream object. You "
             . "should be careful though and remember that the CachingStream "
             . "utilizes PHP temp streams. This means that the stream will be "
-            . "temporarily stored on the local disk.");
+            . "temporarily stored on the local disk.", 0, $previous);
     }
 }

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -142,7 +142,11 @@ class SignatureV4 implements SignatureInterface
             throw new CouldNotCreateChecksumException('sha256');
         }
 
-        return Psr7\hash($request->getBody(), 'sha256');
+        try {
+            return Psr7\hash($request->getBody(), 'sha256');
+        } catch (\Exception $e) {
+            throw new CouldNotCreateChecksumException('sha256', $e);
+        }
     }
 
     protected function getPresignedPayload(RequestInterface $request)

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -188,6 +188,21 @@ class SignatureV4Test extends \PHPUnit_Framework_TestCase
         $signature->signRequest($request, $credentials);
     }
 
+    /**
+     * @expectedException \Aws\Exception\CouldNotCreateChecksumException
+     */
+    public function testEnsuresContentSha256CanBeCalculatedWhenSeekFails()
+    {
+        list($request, $credentials, $signature) = $this->getFixtures();
+        $stream = Psr7\FnStream::decorate(Psr7\stream_for('foo'), [
+            'seek' => function () {
+                throw new \Exception('Could not seek');
+            }
+        ]);
+        $request = $request->withBody($stream);
+        $signature->signRequest($request, $credentials);
+    }
+
     public function testProvider()
     {
         return [


### PR DESCRIPTION
This commit makes a few enhancements to the SDK based on #604:

1. Context parameters like cache and client are now removed from the
   parameters that are sent when executing commands in the S3 stream
   wrapper. When these parameters were present, they resulted in
   lengthy debug messages with the TraceMiddleware, and even caused
   stream resources to enter an invalid state after dumping them.
2. Updated TraceMiddleware to better provide debug information about
   exceptions. These debug messages previously var_dump'd the exception,
   causing a massive dump to the debug output. This is now handled by
   extracting specific pieces of information from exceptions and
   formatting in a more readable way.
3. Added a try/catch to the signature version 4 signer such that if a
   stream claims it's readable, but creating the hash fails for some
   reason, and CouldNotCreateChecksumException will still be thrown,
   which will provide more context as to why the checksum failed to
   create.