### PR TITLE
Handle empty maps in JSON serializer

### DIFF
--- a/src/Api/Serializer/JsonBody.php
+++ b/src/Api/Serializer/JsonBody.php
@@ -69,11 +69,13 @@ class JsonBody
                 return $value;
 
             case 'map':
+                if (empty($value)) {
+                    return new \stdClass;
+                }
                 $values = $shape->getValue();
                 foreach ($value as &$v) {
                     $v = $this->format($values, $v);
                 }
-
                 return $value;
 
             case 'blob':

--- a/tests/Api/test_cases/protocols/input/json.json
+++ b/tests/Api/test_cases/protocols/input/json.json
@@ -297,5 +297,59 @@
         }
       }
     ]
+  },
+  {
+    "description": "Empty maps",
+    "metadata": {
+      "protocol": "json",
+      "jsonVersion": 1.1,
+      "targetPrefix": "com.amazonaws.foo"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Map": {
+            "shape": "MapType"
+          }
+        }
+      },
+      "MapType": {
+        "type": "map",
+        "key": {
+          "shape": "StringType"
+        },
+        "value": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName",
+          "http": {
+            "method": "POST"
+          }
+        },
+        "params": {
+          "Map": {}
+        },
+        "serialized": {
+          "body": "{\"Map\": {}}",
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          },
+          "uri": "/"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Added a check to the json serializers to ensure empty maps get serialized to {} instead of []