### PR TITLE
Always using Unix style paths for Windows compat.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,6 @@ install:
   - export AWS_SECRET_ACCESS_KEY=bar
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 
-script: make test
+script:
+  - make test
+  - [ -z "$COMPOSER_OPTS" ] && make package

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ integ:
 
 # Packages the phar and zip
 package:
-	time php build/packager.php $(SERVICE)
+	php build/packager.php $(SERVICE)
 
 guide:
 	cd docs && make html

--- a/build/test-phar.php
+++ b/build/test-phar.php
@@ -7,7 +7,11 @@ $conf = [
     'version'     => 'latest'
 ];
 
-new Aws\S3\S3Client($conf);
+// Ensure that a client can be created.
+$s3 = new Aws\S3\S3Client($conf);
+// Ensure that waiters can be found.
+$s3->getPaginator('ListObjects');
+
 // Legacy factory instantiation.
 Aws\DynamoDb\DynamoDbClient::factory($conf);
 

--- a/tests/JsonCompilerTest.php
+++ b/tests/JsonCompilerTest.php
@@ -69,6 +69,7 @@ class JsonCompilerTest extends \PHPUnit_Framework_TestCase
         $c->load($this->models . '/endpoints.json');
         $entries = array_diff(scandir($c->getCacheDir()), ['.', '..']);
         $this->assertNotEmpty($entries);
+        $this->assertEquals(['data_endpoints.json.php'], array_values($entries));
         $c->purge();
         $entries = array_diff(scandir($c->getCacheDir()), ['.', '..']);
         $this->assertEmpty($entries);
@@ -87,6 +88,10 @@ class JsonCompilerTest extends \PHPUnit_Framework_TestCase
             // Relative with no leading slash
             ['foo/baz/../bar.qux', 'foo/bar.qux'],
             ['\\foo\\baz\\..\\.\\bar.qux', '/foo/bar.qux'],
+            // Phar path
+            ['phar://foo.phar/foo/bar/../baz.qux', 'phar://foo.phar/foo/baz.qux'],
+            // Phar path with windows mixed in
+            ['phar://foo.phar\\foo\\bar\\..\\baz.qux', 'phar://foo.phar/foo/baz.qux'],
         ];
     }
 


### PR DESCRIPTION
Closes #610.

This commit updates the JsonCompiler class to normalize paths to always
use "/" instead of using DIRECTORY_SEPARATOR. This works for all SDK
usage because the SDK uses relative paths for everything, and any
absolute paths that would have been mangled through this transformation
(e.g., 'C:/path/to/sdk/foo/bar.json.php') are modified to remove the base
directory of the SDK from the path (e.g., 'foo/bar.json.php' ->
'foo_bar.json.php).

This commit also removes a duplicate call to normalizePath().

Phar testing has been updated to include loading a paginator.

Phars are now built and tests on every Travis build.