### PR TITLE
Pass the same uri object url to the canned policy creation

### DIFF
--- a/src/CloudFront/UrlSigner.php
+++ b/src/CloudFront/UrlSigner.php
@@ -69,16 +69,16 @@ class UrlSigner
 
         // Get the real scheme by removing wildcards from the scheme
         $scheme = str_replace('*', '', $urlSections[0]);
+        $uri = new Uri($scheme . '://' . $urlSections[1]);
 
         if ($policy) {
             $isCustom = true;
         } else {
             $isCustom = false;
-            $policy = $this->createCannedPolicy($scheme, $url, $expires);
+            $policy = $this->createCannedPolicy($scheme, $uri->__toString(), $expires);
         }
 
         $policy = str_replace(' ', '', $policy);
-        $uri = new Uri($scheme . '://' . $urlSections[1]);
         parse_str($uri->getQuery(), $query);
         $query = $this->prepareQuery($isCustom, $policy, $query, $expires);
         $uri = $uri->withQuery(http_build_query($query, null, '&', PHP_QUERY_RFC3986));


### PR DESCRIPTION
When using the CloudFront component for url signing, if a url contains non RFC compliant characters, the url passed to the canned policy creation will not match the actual url generated by the GuzzleHttp\Psr7\Uri component, resulting in the generation of an invalid signed url. This pr simply passes the correct url, which may have characters encoded in some use cases, to the createCannedPolicy method.