### PR TITLE
s3 -> S3 fix

### DIFF
--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -138,6 +138,8 @@ class Sdk
             $args['service'] = self::getEndpointPrefix($name);
         }
 
+        // Make sure class is found if the environment is case sensitive
+        $name = ucfirst($name);
         $client = "Aws\\{$name}\\{$name}Client";
 
         if (!class_exists($client)) {


### PR DESCRIPTION
Hi.

I couldn't get a new version of aws-sdk-php to work In Laravel 5.
I used the `AWS` facade & its method `createClient`. Under the hood it calls `AWS\Sdk::createClient`. Turned out that in some environments using lowercase `s` in `createClient('s3')` ends up in having an instance of the class `Aws\AwsClient` instead of `Aws\S3\S3Client`.

The system I had a problem on:
```
$ cat /proc/version
Linux version 3.19.1-x86_64-linode53 (maker@build.linode.com) (gcc version 4.4.5 (Debian 4.4.5-8) ) #1 SMP Tue Mar 10 15:30:28 EDT 2015
```