### PR TITLE
Fixes #479. Affects serialization for specific ELB and CFN operations.

### DIFF
--- a/src/Aws/Common/Command/AwsQueryVisitor.php
+++ b/src/Aws/Common/Command/AwsQueryVisitor.php
@@ -99,6 +99,9 @@ class AwsQueryVisitor extends AbstractRequestVisitor
         // For BC, serialize empty lists for specific operations
         if (!$value) {
             if (isset($serializeEmpty[$this->fqname])) {
+                if (substr($prefix, -7) === '.member') {
+                    $prefix = substr($prefix, 0, -7);
+                }
                 $query[$prefix] = '';
             }
             return;

--- a/tests/Aws/Tests/Common/Command/AwsQueryVisitorTest.php
+++ b/tests/Aws/Tests/Common/Command/AwsQueryVisitorTest.php
@@ -259,7 +259,15 @@ class AwsQueryVisitorTest extends \Guzzle\Tests\GuzzleTestCase
             'type' => 'object',
             'location' => 'aws.query',
             'properties' => array(
-                'test' => array(
+                'test1' => array(
+                    'type' => 'array',
+                    'sentAs' => 'test1.member'
+                ),
+                'test2' => array(
+                    'type' => 'array',
+                    'sentAs' => 'blah'
+                ),
+                'test3' => array(
                     'type' => 'array'
                 ),
                 'bar' => array(
@@ -275,13 +283,15 @@ class AwsQueryVisitorTest extends \Guzzle\Tests\GuzzleTestCase
                 )
             )
         )), array(
-            'test' => array(),
+            'test1' => array(),
+            'test2' => array(),
+            'test3' => array(),
             'bar' => array(
                 'bam' => array(),
                 'boo' => 'hi'
             )
         ));
         $fields = $request->getPostFields();
-        $this->assertEquals('foo.test=&foo.bar.bam=&foo.bar.boo=hi', (string) $fields);
+        $this->assertEquals('foo.test1=&foo.blah=&foo.test3=&foo.bar.bam=&foo.bar.boo=hi', (string) $fields);
     }
 }


### PR DESCRIPTION
Fixes how empty lists are serialized in some cases.

/cc @mtdowling 