### PR TITLE
Check the provided cache before attempting to build credentials

### DIFF
--- a/src/Aws/Common/Credentials/CacheableCredentials.php
+++ b/src/Aws/Common/Credentials/CacheableCredentials.php
@@ -42,9 +42,10 @@ class CacheableCredentials extends AbstractRefreshableCredentials
      */
     public function __construct(CredentialsInterface $credentials, CacheAdapterInterface $cache, $cacheKey)
     {
-        $this->credentials = $credentials;
         $this->cache = $cache;
         $this->cacheKey = $cacheKey;
+
+        parent::__construct($credentials);
     }
 
     /**


### PR DESCRIPTION
If a `credentials.cache` option is passed into the `Credentials::factory` method, that cache should be checked for an instance of `CredentialsInterface` before attempting to build one from the environment. Since `CredentialsInterface` extends `Serializable`, we can rely on implementations to properly restore themselves when retrieved from cache.

/cc @mtdowling @jeremeamia 