### PR TITLE
Use late static binding for self instantiating the DynamoDb SessionHandler

### DIFF
--- a/src/DynamoDb/SessionHandler.php
+++ b/src/DynamoDb/SessionHandler.php
@@ -66,7 +66,7 @@ class SessionHandler implements \SessionHandlerInterface
             $connection = new StandardSessionConnection($client, $config);
         }
 
-        return new self($connection);
+        return new static($connection);
     }
 
     /**


### PR DESCRIPTION
Otherwise fromClient() does not work correctly from objects that extend Aws\DynamoDb\SessionHandler

This change should not effect existing functionality of those who call fromClient() directly on Aws\DynamoDb\SessionHandler.