### PR TITLE
Calculate correct S3 Transfer key with or without prefix (fixes #653)

### DIFF
--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -323,7 +323,7 @@ class Transfer implements PromisorInterface
         );
         
         if (isset($this->s3Args['Key'])) {
-            return rtrim($this->s3Args['Key']), '/').'/'.$relative_file_path;
+            return rtrim($this->s3Args['Key'], '/').'/'.$relative_file_path;
         } else {
             return $relative_file_path;
         }

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -198,7 +198,7 @@ class Transfer implements PromisorInterface
     }
 
     /**
-     * Normalize a path so that it has a trailing slash.
+     * Normalize a path so that it has UNIX-style directory separators and no trailing /
      *
      * @param string $path
      *
@@ -317,15 +317,16 @@ class Transfer implements PromisorInterface
 
     private function createS3Key($filename)
     {
-        if (!isset($this->s3Args['Key'])) {
-            return '';
+        $relative_file_path = ltrim(
+            preg_replace('#^' . preg_quote($this->source['path']) . '#', '', $filename),
+            '/'
+        );
+        
+        if (isset($this->s3Args['Key'])) {
+            return rtrim($this->s3Args['Key']), '/').'/'.$relative_file_path;
+        } else {
+            return $relative_file_path;
         }
-
-        $args = $this->s3Args;
-        $args['Key'] = rtrim($args['Key'], '/');
-        $args['Key'] .= preg_replace('#^' . preg_quote($this->source['path']) . '#', '', $filename);
-
-        return $args['Key'];
     }
 
     private function addDebugToBefore($debug)


### PR DESCRIPTION
Resolve an issue where S3 Transfer was attempting to upload objects with an empty key when uploading to the root of an S3 bucket.

Also ensures that there is no `//` between prefix and path, to avoid uploading objects one level deeper than expected inside a directory with empty name.

This does appear to resolve the issue reported in #653 but I am unsure whether it has other implications.