### PR TITLE
Defer inspection of memoized credential provider

### DIFF
--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -126,28 +126,26 @@ class CredentialProvider
             static $result;
             static $isConstant;
 
+            // Constant credentials will be returned constantly.
+            if ($isConstant) {
+                return $result;
+            }
+
             // Create the initial promise that will be used as the cached value
             // until it expires.
             if (null === $result) {
                 $result = $provider();
             }
 
-            // Constant credentials will be returned constantly.
-            if ($isConstant) {
-                return $result;
-            }
-
-            // Determine if these are constant credentials.
-            if ($result->getState() === Promise\PromiseInterface::FULFILLED
-                && !$result->wait()->getExpiration()
-            ) {
-                $isConstant = true;
-                return $result;
-            }
-
             // Return credentials that could expire and refresh when needed.
             return $result
-                ->then(function (CredentialsInterface $creds) use ($provider, &$result) {
+                ->then(function (CredentialsInterface $creds) use ($provider, &$isConstant, &$result) {
+                    // Determine if these are constant credentials.
+                    if (!$creds->getExpiration()) {
+                        $isConstant = true;
+                        return $creds;
+                    }
+
                     // Refresh expired credentials.
                     if (!$creds->isExpired()) {
                         return $creds;

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -122,12 +122,16 @@ class CredentialProvider
      */
     public static function memoize(callable $provider)
     {
-        // Create the initial promise that will be used as the cached value
-        // until it expires.
-        $result = $provider();
-        $isConstant = false;
+        return function () use ($provider) {
+            static $result;
+            static $isConstant;
 
-        return function () use (&$result, &$isConstant, $provider) {
+            // Create the initial promise that will be used as the cached value
+            // until it expires.
+            if (null === $result) {
+                $result = $provider();
+            }
+
             // Constant credentials will be returned constantly.
             if ($isConstant) {
                 return $result;


### PR DESCRIPTION
Enclosing over a pending call `$provider` seems to prevent variables accessible to the promise (but not the value with which it is fulfilled) from being eligible for garbage collection. In the case of `Aws\CredentialProvider::defaultProvider`, this included an instance of `Aws\HandlerList`, an instance of `Aws\Api\ShapeMap`, and all of their member properties.