### PR TITLE
Make PHP 7 failures fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 matrix:
   allow_failures:
     - php: hhvm
-    - php: 7
   fast_finish: true
 
 install:


### PR DESCRIPTION
PHP 7 has moved from alpha to beta, and our test suite is currently green on Travis. 