### PR TITLE
Ensure that fopen calls return false when errors are encountered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 5.6
   - hhvm
 
+sudo: false
+
 before_script:
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
   - composer self-update

--- a/src/Aws/S3/StreamWrapper.php
+++ b/src/Aws/S3/StreamWrapper.php
@@ -178,15 +178,15 @@ class StreamWrapper
 
         if (!$errors) {
             if ($mode == 'r') {
-                $this->openReadStream($params, $errors);
+                return $this->openReadStream($params, $errors);
             } elseif ($mode == 'a') {
-                $this->openAppendStream($params, $errors);
+                return $this->openAppendStream($params, $errors);
             } else {
-                $this->openWriteStream($params, $errors);
+                return $this->openWriteStream($params, $errors);
             }
         }
 
-        return $errors ? $this->triggerError($errors) : true;
+        return $this->triggerError($errors);
     }
 
     /**
@@ -723,6 +723,8 @@ class StreamWrapper
     protected function openWriteStream(array $params, array &$errors)
     {
         $this->body = new EntityBody(fopen('php://temp', 'r+'));
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Currently the S3 StreamWrapper will trigger an error and return true when opening an invalid `s3://` path for reading. This PR ensures that calling `fopen` will return false on failure, which will prevent `file_get_contents` from returning an empty string (as mentioned on #609).

e4f078a is unrelated but it's the only way to get Travis to actually finish a build.