### PR TITLE
Ensure that an unserialized RefreshableInstanceProfileCredentials object is still useful

### DIFF
--- a/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
+++ b/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
@@ -42,6 +42,21 @@ class RefreshableInstanceProfileCredentials extends AbstractRefreshableCredentia
         $this->client = $client ?: InstanceMetadataClient::factory();
     }
 
+    public function serialize()
+    {
+        return json_encode(array(
+            'credentials' => parent::serialize(),
+            'client' => serialize($this->client),
+        ));
+    }
+
+    public function unserialize($value)
+    {
+        $serialized = json_decode($value, true);
+        parent::unserialize($serialized['credentials']);
+        $this->client = unserialize($serialized['client']);
+    }
+
     /**
      * Attempt to get new credentials from the instance profile
      *

--- a/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
+++ b/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
@@ -41,6 +41,11 @@ class RefreshableInstanceProfileCredentials extends AbstractRefreshableCredentia
     public function __construct(CredentialsInterface $credentials, InstanceMetadataClient $client = null)
     {
         $this->credentials = $credentials;
+        $this->setClient($client);
+    }
+
+    public function setClient(InstanceMetadataClient $client = null)
+    {
         $this->customClient = null !== $client;
         $this->client = $client ?: InstanceMetadataClient::factory();
     }

--- a/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
+++ b/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
@@ -29,6 +29,8 @@ class RefreshableInstanceProfileCredentials extends AbstractRefreshableCredentia
      * @var InstanceMetadataClient
      */
     protected $client;
+    /** @var bool */
+    private $customClient;
 
     /**
      * Constructs a new instance profile credentials decorator
@@ -39,22 +41,32 @@ class RefreshableInstanceProfileCredentials extends AbstractRefreshableCredentia
     public function __construct(CredentialsInterface $credentials, InstanceMetadataClient $client = null)
     {
         $this->credentials = $credentials;
+        $this->customClient = null !== $client;
         $this->client = $client ?: InstanceMetadataClient::factory();
     }
 
     public function serialize()
     {
-        return json_encode(array(
+        $serializable = array(
             'credentials' => parent::serialize(),
-            'client' => serialize($this->client),
-        ));
+            'customClient' => $this->customClient,
+        );
+
+        if ($this->customClient) {
+            $serializable['client'] = serialize($this->client);
+        }
+
+        return json_encode($serializable);
     }
 
     public function unserialize($value)
     {
         $serialized = json_decode($value, true);
         parent::unserialize($serialized['credentials']);
-        $this->client = unserialize($serialized['client']);
+        $this->customClient = $serialized['customClient'];
+        $this->client = $this->customClient ?
+            unserialize($serialized['client'])
+            : InstanceMetadataClient::factory();
     }
 
     /**

--- a/src/Aws/Common/InstanceMetadata/InstanceMetadataClient.php
+++ b/src/Aws/Common/InstanceMetadata/InstanceMetadataClient.php
@@ -26,7 +26,7 @@ use Guzzle\Http\Message\RequestFactory;
 /**
  * Client used for interacting with the Amazon EC2 instance metadata server
  */
-class InstanceMetadataClient extends AbstractClient
+class InstanceMetadataClient extends AbstractClient implements \Serializable
 {
     /**
      * Factory method to create a new InstanceMetadataClient using an array
@@ -63,6 +63,16 @@ class InstanceMetadataClient extends AbstractClient
         $this->setBaseUrl($config->get(Options::BASE_URL));
         $this->defaultHeaders = new Collection();
         $this->setRequestFactory(RequestFactory::getInstance());
+    }
+
+    public function serialize()
+    {
+        return json_encode($this->getConfig()->toArray());
+    }
+
+    public function unserialize($value)
+    {
+        $this->__construct(Collection::fromConfig(json_decode($value, true)));
     }
 
     /**

--- a/src/Aws/Common/InstanceMetadata/InstanceMetadataClient.php
+++ b/src/Aws/Common/InstanceMetadata/InstanceMetadataClient.php
@@ -26,7 +26,7 @@ use Guzzle\Http\Message\RequestFactory;
 /**
  * Client used for interacting with the Amazon EC2 instance metadata server
  */
-class InstanceMetadataClient extends AbstractClient implements \Serializable
+class InstanceMetadataClient extends AbstractClient
 {
     /**
      * Factory method to create a new InstanceMetadataClient using an array
@@ -63,16 +63,6 @@ class InstanceMetadataClient extends AbstractClient implements \Serializable
         $this->setBaseUrl($config->get(Options::BASE_URL));
         $this->defaultHeaders = new Collection();
         $this->setRequestFactory(RequestFactory::getInstance());
-    }
-
-    public function serialize()
-    {
-        return json_encode($this->getConfig()->toArray());
-    }
-
-    public function unserialize($value)
-    {
-        $this->__construct(Collection::fromConfig(json_decode($value, true)));
     }
 
     /**


### PR DESCRIPTION
This class was serializing with just the credentials it had at the time `serialize` was called, so any attempt to subsequently refresh the credentials would have `null` where it was expecting an instance of `Aws\Common\InstanceMetadata\InstanceMetadataClient`. Would address #710.