### PR TITLE
Add Metadata from config to params

### DIFF
--- a/src/S3/MultipartUploader.php
+++ b/src/S3/MultipartUploader.php
@@ -187,6 +187,11 @@ class MultipartUploader extends AbstractUploader
             $params['ACL'] = $this->config['acl'];
         }
 
+	// Set our Metadata
+	if(isset($this->config['Metadata'])) {
+            $params['Metadata'] = $this->config['Metadata'];
+        }
+
         // Set the content type
         if ($uri = $this->source->getMetadata('uri')) {
             $params['ContentType'] = Psr7\mimetype_from_filename($uri)


### PR DESCRIPTION
Lots of missing arguments from `MultiPartUploader` that are present in `S3::putObject()`, but this one is mission critical for us.  

See:  https://github.com/aws/aws-sdk-php/issues/712