### PR TITLE
Update Sdk.php

### DIFF
--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -76,7 +76,7 @@ class Sdk
         }
     }
 
-    public function __call($name, array $args = [])
+    public function __call($name, array $args)
     {
         if (strpos($name, 'create') === 0) {
             return $this->createClient(


### PR DESCRIPTION
It's "pointless. For __call magic methods, PHP always sets $args to an array."

By the way, it becames problematic to mock the SDK.

see : https://github.com/aws/aws-sdk-php/issues/715