### PR TITLE
Ensure that custom endpoints have a defined scheme and host

### DIFF
--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -57,6 +57,7 @@ class ClientResolver
             'type'  => 'value',
             'valid' => ['string'],
             'doc'   => 'The full URI of the webservice. This is only required when connecting to a custom endpoint (e.g., a local version of S3).',
+            'fn'    => [__CLASS__, '_apply_endpoint'],
         ],
         'region' => [
             'type'     => 'value',
@@ -301,7 +302,7 @@ class ClientResolver
             . "provided for \"{$name}\". Expected {$expected}, but got "
             . describe_type($provided) . "\n\n"
             . $this->getArgMessage($name);
-        throw new \InvalidArgumentException($msg);
+        throw new IAE($msg);
     }
 
     /**
@@ -474,6 +475,18 @@ class ClientResolver
                 ));
             };
         });
+    }
+
+    public static function _apply_endpoint($value, array &$args, HandlerList $list)
+    {
+        $parts = parse_url($value);
+        if (empty($parts['scheme']) || empty($parts['host'])) {
+            throw new IAE(
+                'Endpoints must be full URIs and include a scheme and host'
+            );
+        }
+
+        $args['endpoint'] = $value;
     }
 
     public static function _default_endpoint_provider()

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -426,4 +426,26 @@ EOT;
         ClientResolver::_apply_user_agent([], $args, $list);
         call_user_func($list->resolve(), $command, $request);
     }
+
+    public function malformedEndpointProvider()
+    {
+        return [
+            ['www.amazon.com'], // missing protocol
+            ['https://'], // missing host
+        ];
+    }
+
+    /**
+     * @dataProvider malformedEndpointProvider
+     * @param $endpoint
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Endpoints must be full URIs and include a scheme and host
+     */
+    public function testRejectsMalformedEndpoints($endpoint)
+    {
+        $list = new HandlerList();
+        $args = [];
+        ClientResolver::_apply_endpoint($endpoint, $args, $list);
+    }
 }

--- a/tests/CloudSearchDomain/CloudSearchDomainTest.php
+++ b/tests/CloudSearchDomain/CloudSearchDomainTest.php
@@ -23,7 +23,7 @@ class CloudSearchDomainTest extends \PHPUnit_Framework_TestCase
     {
         $client = new CloudSearchDomainClient([
             'service'   => 'cloudsearchdomain',
-            'endpoint'  => 'search-foo.us-west-2.cloudsearch.amazon.com',
+            'endpoint'  => 'https://search-foo.us-west-2.cloudsearch.amazon.com',
             'signature' => 'v4',
             'version'   => 'latest'
         ]);


### PR DESCRIPTION
Currently, it's very easy to copy a value from the CloudSearchDomain console and be greeted with an opaque error message ('cURL error 3'). As described in #722, this is what happens when you supply a custom `endpoint` to a client that cURL will not be able to use directly. This PR adds a validation function to the ClientResolver that ensures endpoints have a scheme and host.