### PR TITLE
Ensure that connect errors on S3 are retried as configured

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -473,8 +473,8 @@ class S3Client extends AwsClient
         }
 
         $decider = RetryMiddleware::createDefaultDecider($value);
-        $decider = function ($retries, $request, $result, $error) use ($decider) {
-            if ($decider($retries, $request, $result, $error)) {
+        $decider = function ($retries, $command, $request, $result, $error) use ($decider) {
+            if ($decider($retries, $command, $request, $result, $error)) {
                 return true;
             } elseif ($error instanceof AwsException) {
                 return $error->getResponse()


### PR DESCRIPTION
It seems that S3 connection errors were not being retried due to a function signature mismatch.