### PR TITLE
Fix/eliminate waiter npe

### DIFF
--- a/docs/guide/commands.rst
+++ b/docs/guide/commands.rst
@@ -50,10 +50,47 @@ The following examples are functionally equivalent:
 Command parameters
 ------------------
 
-When you create a command using a client's ``getCommand()`` method, it does not
-immediately execute or transfer an HTTP request. The command is only executed
-when it is passed to the ``execute()`` method of the client. This gives you the
-opportunity to modify the command object before executing the command.
+All commands support a few special parameters that are not part of a service's
+API but instead control the SDK's behavior.
+
+``@http``
+~~~~~~~~~
+
+Using this parameter, it's possible to fine tune how the underlying HTTP handler
+executes the request. The options you can include in the ``@http`` parameter are
+the same as the ones you can set when you instantiate the client with the
+:ref:`"http" client option <config_http>`.
+
+.. code-block:: php
+
+    // Configures the command to be delayed by 500 milliseconds.
+    $command['@http'] = [
+        'delay' => 500,
+    ];
+
+``@retries``
+~~~~~~~~~~~~
+
+Like the :ref:`"retries" client option <config_retries>`, ``@retries`` controls
+how many times a command may be retried before it is considered to have failed.
+Set to ``0`` to disable retries.
+
+.. code-block:: php
+
+    // Disable retries
+    $command['@retries'] = 0;
+
+NB: If you have disabled retries on a client, you cannot selectively enable them
+on individual commands passed to that client.
+
+
+Creating command objects
+------------------------
+
+You can create a command using a client's ``getCommand()`` method. It does not
+immediately execute or transfer an HTTP request, but is only executed when it is
+passed to the ``execute()`` method of the client. This gives you the opportunity
+to modify the command object before executing the command.
 
 .. code-block:: php
 
@@ -69,23 +106,6 @@ opportunity to modify the command object before executing the command.
     ]);
     $command['MaxKeys'] = 100;
     $result = $s3Client->execute($command);
-
-
-HTTP handler options
---------------------
-
-All commands support the special ``@http`` parameter. Using this parameter,
-it's possible to fine tune how the underlying HTTP handler executes the
-request. The options you can include in the ``@http`` parameter are the same as
-the ones you can set when you instantiate the client with the
-:ref:`"http" client option <config_http>`.
-
-.. code-block:: php
-
-    // Configures the command to be delayed by 500 milliseconds.
-    $command['@http'] = [
-        'delay' => 500,
-    ];
 
 
 Command HandlerList

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -621,6 +621,7 @@ for a list of available regions.
         'version' => '2006-03-01'
     ]);
 
+.. _config_retries:
 
 retries
 ~~~~~~~

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -55,8 +55,8 @@ class RetryMiddleware
             $error = null
         ) use ($maxRetries) {
             // Allow command-level options to override this value
-            $maxRetries = null !== $command['retries'] ?
-                $command['retries']
+            $maxRetries = null !== $command['@retries'] ?
+                $command['@retries']
                 : $maxRetries;
 
             if ($retries >= $maxRetries) {

--- a/src/Waiter.php
+++ b/src/Waiter.php
@@ -241,8 +241,8 @@ class Waiter implements PromisorInterface
     {
         if ($result instanceof ResultInterface) {
             return $acceptor['expected'] == $result['@metadata']['statusCode'];
-        } elseif ($result instanceof AwsException) {
-            return $acceptor['expected'] == $result->getResponse()->getStatusCode();
+        } elseif ($result instanceof AwsException && $response = $result->getResponse()) {
+            return $acceptor['expected'] == $response->getStatusCode();
         } else {
             return false;
         }
@@ -256,8 +256,11 @@ class Waiter implements PromisorInterface
      */
     private function matchesError($result, array $acceptor)
     {
-        return !($result instanceof AwsException)
-            ? false
-            : $result->getAwsErrorCode() == $acceptor['expected'];
+        if ($result instanceof AwsException) {
+            return $result->isConnectionError()
+                || $result->getAwsErrorCode() == $acceptor['expected'];
+        }
+
+        return false;
     }
 }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -210,7 +210,7 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
     public function testRetriesCanBeDisabledOnACommand()
     {
         $decider = RetryMiddleware::createDefaultDecider($retries = 3);
-        $command = new Command('foo', ['retries' => 0]);
+        $command = new Command('foo', ['@retries' => 0]);
         $request = new Request('GET', 'http://www.example.com');
         $err = new AwsException('e', $command, ['connection_error' => true]);
         $this->assertFalse($decider(0, $command, $request, null, $err));

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -206,4 +206,13 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($res1, $result);
         $this->assertCount(1, $called);
     }
+
+    public function testRetriesCanBeDisabledOnACommand()
+    {
+        $decider = RetryMiddleware::createDefaultDecider($retries = 3);
+        $command = new Command('foo', ['retries' => 0]);
+        $request = new Request('GET', 'http://www.example.com');
+        $err = new AwsException('e', $command, ['connection_error' => true]);
+        $this->assertFalse($decider(0, $command, $request, null, $err));
+    }
 }

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -359,7 +359,7 @@ class S3ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testRetriesConnectionErrors()
     {
-        $retries = 2;
+        $retries = 11;
         $client = new S3Client([
             'version' => 'latest',
             'region' => 'us-west-2',
@@ -383,9 +383,7 @@ class S3ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->headBucket([
             'Bucket' => 'bucket',
-            '@http' => [
-                'retries' => $retries,
-            ],
+            'retries' => $retries,
         ]);
     }
 }

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -363,6 +363,7 @@ class S3ClientTest extends \PHPUnit_Framework_TestCase
         $client = new S3Client([
             'version' => 'latest',
             'region' => 'us-west-2',
+            'retries' => $retries,
             'http_handler' => function (
                 RequestInterface $request,
                 array $options
@@ -383,7 +384,6 @@ class S3ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->headBucket([
             'Bucket' => 'bucket',
-            'retries' => $retries,
         ]);
     }
 }

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -65,6 +65,7 @@ class WaiterTest extends \PHPUnit_Framework_TestCase
         $client = new DynamoDbClient([
             'version' => 'latest',
             'region' => 'us-west-2',
+            'retries' => 0,
             'http_handler' => function (
                 RequestInterface $request,
                 array $options
@@ -87,7 +88,6 @@ class WaiterTest extends \PHPUnit_Framework_TestCase
 
         $client->waitUntil('TableExists', [
             'TableName' => 'table',
-            'retries' => 0,
         ]);
     }
 

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -6,10 +6,15 @@ use Aws\CommandInterface;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Exception\AwsException;
 use Aws\Result;
+use Aws\S3\S3Client;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @covers Aws\Waiter
@@ -52,6 +57,38 @@ class WaiterTest extends \PHPUnit_Framework_TestCase
                 '@waiter' => ['before' => '%']
             ]
         );
+    }
+
+    public function testContinueWaitingOnHandlerError()
+    {
+        $retries = 10;
+        $client = new DynamoDbClient([
+            'version' => 'latest',
+            'region' => 'us-west-2',
+            'http_handler' => function (
+                RequestInterface $request,
+                array $options
+            ) use (&$retries) {
+                if (0 === --$retries) {
+                    return new FulfilledPromise(new Response(200, [],
+                        Psr7\stream_for('{"Table":{"TableStatus":"ACTIVE"}}')
+                    ));
+                }
+
+                return new RejectedPromise([
+                    'connection_error' => true,
+                    'exception' => $this->getMockBuilder(ConnectException::class)
+                        ->disableOriginalConstructor()
+                        ->getMock(),
+                    'response' => null,
+                ]);
+            },
+        ]);
+
+        $client->waitUntil('TableExists', [
+            'TableName' => 'table',
+            'retries' => 0,
+        ]);
     }
 
     public function testCanCancel()


### PR DESCRIPTION
Addresses #726 and allows retries to be configured on a command instead of just on a client.

/cc @mtdowling 