### PR TITLE
Map phar in stub file and set a versioned alias

### DIFF
--- a/build/packager.php
+++ b/build/packager.php
@@ -28,7 +28,12 @@ $burgomaster->createAutoloader([
 ], $autoloaderFilename);
 
 $burgomaster->createZip(__DIR__ . "/artifacts/aws.zip");
-$burgomaster->createPhar(__DIR__ . "/artifacts/aws.phar", null, $autoloaderFilename);
+$burgomaster->createPhar(
+    __DIR__ . "/artifacts/aws.phar",
+    null,
+    $autoloaderFilename,
+    'aws-' . \Aws\Sdk::VERSION . '.phar'
+);
 
 $burgomaster->startSection('test-phar');
 $burgomaster->exec('php ' . __DIR__ . '/test-phar.php');


### PR DESCRIPTION
Another attempt to resolve #563. Other projects that distribute a phar (including Composer, PHPUnit, and Behat) include a call to Phar::mapPhar($filename)) in their phar stubs, and its absence could explain why aws-autoloader.php cannot be found when aws.phar is loaded from opcache instead of from the filesystem.

/cc @mtdowling