### PR TITLE
Add a mechanism for caching InstanceProfile credentials

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,13 @@
         "ext-simplexml": "*",
         "phpunit/phpunit": "~4.0",
         "behat/behat": "~3.0",
-        "aws/aws-php-sns-message-validator": "^1.0"
+        "doctrine/cache": "~1.4",
+        "aws/aws-php-sns-message-validator": "~1.0"
     },
     "suggest": {
         "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
-        "ext-curl": "To send requests using cURL"
+        "ext-curl": "To send requests using cURL",
+        "doctrine/cache": "To use the DoctrineCacheAdapter"
     },
     "autoload": {
         "psr-4": {

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -46,7 +46,7 @@ that loads API files from the ``src/data`` folder of the SDK.
 credentials
 ~~~~~~~~~~~
 
-:Type: ``array|Aws\Credentials\CredentialsInterface|bool|callable``
+:Type: ``array|Aws\Credentials\CredentialsInterface|bool|callable|Aws\CacheInterface``
 
 If you do not provide a ``credentials`` option, the SDK will attempt to load
 credentials from your environment in the following order:
@@ -107,6 +107,21 @@ create credentials using a function.
         'version'     => 'latest',
         'region'      => 'us-west-2',
         'credentials' => $provider
+    ]);
+
+Pass an instance of ``Aws\CacheInterface`` to cache the values returned by the
+default provider chain across multiple processes.
+
+.. code-block:: php
+
+    use Aws\DoctrineCacheAdapter;
+    use Aws\S3\S3Client;
+    use Doctrine\Common\Cache\ApcCache;
+
+    $s3 = new S3Client([
+        'version'     => 'latest',
+        'region'      => 'us-west-2',
+        'credentials' => new DoctrineCacheAdapter(new ApcCache),
     ]);
 
 You can find more information about providing credentials to a client in the

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -46,7 +46,7 @@ that loads API files from the ``src/data`` folder of the SDK.
 credentials
 ~~~~~~~~~~~
 
-:Type: ``array|Aws\Credentials\CredentialsInterface|bool|callable|Aws\CacheInterface``
+:Type: ``array|Aws\CacheInterface|Aws\Credentials\CredentialsInterface|bool|callable``
 
 If you do not provide a ``credentials`` option, the SDK will attempt to load
 credentials from your environment in the following order:

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -105,7 +105,7 @@ class ClientResolver
         ],
         'credentials' => [
             'type'    => 'value',
-            'valid'   => ['Aws\Credentials\CredentialsInterface', 'array', 'bool', 'callable'],
+            'valid'   => [CredentialsInterface::class, CacheInterface::class, 'array', 'bool', 'callable'],
             'doc'     => 'Specifies the credentials used to sign requests. Provide an Aws\Credentials\CredentialsInterface object, an associative array of "key", "secret", and an optional "token" key, `false` to use null credentials, or a callable credentials provider used to create credentials or return null. See Aws\\Credentials\\CredentialProvider for a list of built-in credentials providers. If no credentials are provided, the SDK will attempt to load them from the environment.',
             'fn'      => [__CLASS__, '_apply_credentials'],
             'default' => [CredentialProvider::class, 'defaultProvider'],
@@ -338,7 +338,7 @@ class ClientResolver
 
     public static function _apply_credentials($value, array &$args)
     {
-        if (is_callable($value) || $value instanceof CacheInterface) {
+        if (is_callable($value)) {
             return;
         } elseif ($value instanceof CredentialsInterface) {
             $args['credentials'] = CredentialProvider::fromCredentials($value);
@@ -359,6 +359,8 @@ class ClientResolver
                 new Credentials('', '')
             );
             $args['config']['signature_version'] = 'anonymous';
+        } elseif ($value instanceof CacheInterface) {
+            $args['credentials'] = CredentialProvider::defaultProvider($args);
         } else {
             throw new IAE('Credentials must be an instance of '
                 . 'Aws\Credentials\CredentialsInterface, an associative '

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -338,7 +338,7 @@ class ClientResolver
 
     public static function _apply_credentials($value, array &$args)
     {
-        if (is_callable($value)) {
+        if (is_callable($value) || $value instanceof CacheInterface) {
             return;
         } elseif ($value instanceof CredentialsInterface) {
             $args['credentials'] = CredentialProvider::fromCredentials($value);

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -2,6 +2,7 @@
 namespace Aws\Credentials;
 
 use Aws;
+use Aws\CacheInterface;
 use Aws\Exception\CredentialsException;
 use GuzzleHttp\Promise;
 
@@ -61,11 +62,16 @@ class CredentialProvider
      */
     public static function defaultProvider(array $config = [])
     {
+        $cache = isset($config['credentials'])
+            && $config['credentials'] instanceof CacheInterface ?
+            $config['credentials']
+            : null;
         return self::memoize(
             self::chain(
                 self::env(),
                 self::ini(),
-                self::instanceProfile($config)
+                $cache ? self::cache(self::instanceProfile($config), $cache)
+                    : self::instanceProfile($config)
             )
         );
     }
@@ -152,6 +158,49 @@ class CredentialProvider
                     }
                     // Refresh the result and forward the promise.
                     return $result = $provider();
+                });
+        };
+    }
+
+    /**
+     * Wraps a credential provider and saves provided credentials in an
+     * instance of Aws\CacheInterface. Forwards calls when no credentials found
+     * in cache and updates cache with the results.
+     *
+     * Defaults to using a simple file-based cache when none provided.
+     *
+     * @param callable $provider Credentials provider function to wrap
+     * @param CacheInterface $cache (optional) Cache to store credentials
+     * @param string|null $cacheKey (optional) Cache key to use
+     *
+     * @return callable
+     */
+    public static function cache(
+        callable $provider,
+        CacheInterface $cache,
+        $cacheKey = null
+    ) {
+        $cacheKey = $cacheKey ?: 'aws_cached_credentials';
+
+        return function () use ($provider, $cache, $cacheKey) {
+            $found = $cache->get($cacheKey);
+            if ($found instanceof CredentialsInterface && !$found->isExpired()) {
+                return Promise\promise_for($found);
+            }
+
+            return $provider()
+                ->then(function (CredentialsInterface $creds) use (
+                    $cache,
+                    $cacheKey
+                ) {
+                    $cache->set(
+                        $cacheKey,
+                        $creds,
+                        null === $creds->getExpiration() ?
+                            0 : $creds->getExpiration() - time()
+                    );
+
+                    return $creds;
                 });
         };
     }

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -62,16 +62,21 @@ class CredentialProvider
      */
     public static function defaultProvider(array $config = [])
     {
-        $cache = isset($config['credentials'])
-            && $config['credentials'] instanceof CacheInterface ?
-            $config['credentials']
-            : null;
+        $instanceProfileProvider = self::instanceProfile($config);
+        if (isset($config['credentials'])
+            && $config['credentials'] instanceof CacheInterface
+        ) {
+            $instanceProfileProvider = self::cache(
+                $instanceProfileProvider,
+                $config['credentials']
+            );
+        }
+
         return self::memoize(
             self::chain(
                 self::env(),
                 self::ini(),
-                $cache ? self::cache(self::instanceProfile($config), $cache)
-                    : self::instanceProfile($config)
+                $instanceProfileProvider
             )
         );
     }

--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -5,7 +5,7 @@ namespace Aws\Credentials;
  * Basic implementation of the AWS Credentials interface that allows callers to
  * pass in the AWS Access Key and AWS Secret Access Key in the constructor.
  */
-class Credentials implements CredentialsInterface
+class Credentials implements CredentialsInterface, \Serializable
 {
     private $key;
     private $secret;
@@ -27,6 +27,16 @@ class Credentials implements CredentialsInterface
         $this->secret = trim($secret);
         $this->token = $token;
         $this->expires = $expires;
+    }
+
+    public static function __set_state(array $state)
+    {
+        return new self(
+            $state['key'],
+            $state['secret'],
+            $state['token'],
+            $state['expires']
+        );
     }
 
     public function getAccessKeyId()
@@ -62,5 +72,20 @@ class Credentials implements CredentialsInterface
             'token'   => $this->token,
             'expires' => $this->expires
         ];
+    }
+
+    public function serialize()
+    {
+        return json_encode($this->toArray());
+    }
+
+    public function unserialize($serialized)
+    {
+        $data = json_decode($serialized, true);
+
+        $this->key = $data['key'];
+        $this->secret = $data['secret'];
+        $this->token = $data['token'];
+        $this->expires = $data['expires'];
     }
 }

--- a/src/DoctrineCacheAdapter.php
+++ b/src/DoctrineCacheAdapter.php
@@ -1,0 +1,55 @@
+<?php
+namespace Aws;
+
+use Doctrine\Common\Cache\Cache;
+
+class DoctrineCacheAdapter implements CacheInterface, Cache
+{
+    /** @var Cache */
+    private $cache;
+
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function get($key)
+    {
+        return $this->cache->fetch($key);
+    }
+
+    public function fetch($key)
+    {
+        return $this->get($key);
+    }
+
+    public function set($key, $value, $ttl = 0)
+    {
+        return $this->cache->save($key, $value, $ttl);
+    }
+
+    public function save($key, $value, $ttl = 0)
+    {
+        return $this->set($key, $value, $ttl);
+    }
+
+    public function remove($key)
+    {
+        return $this->cache->delete($key);
+    }
+
+    public function delete($key)
+    {
+        return $this->remove($key);
+    }
+
+    public function contains($key)
+    {
+        return $this->cache->contains($key);
+    }
+
+    public function getStats()
+    {
+        return $this->cache->getStats();
+    }
+}

--- a/tests/DoctrineCacheAdapterTest.php
+++ b/tests/DoctrineCacheAdapterTest.php
@@ -1,0 +1,41 @@
+<?php
+namespace Aws\Test;
+
+use Aws\CacheInterface;
+use Aws\DoctrineCacheAdapter;
+use Doctrine\Common\Cache\Cache;
+
+class DoctrineCacheAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProxiesCallsToDoctrine()
+    {
+        $wrappedCache = $this->getMock(Cache::class);
+
+        $wrappedCache->expects($this->once())
+            ->method('fetch')
+            ->with('foo')
+            ->willReturn('bar');
+        $wrappedCache->expects($this->once())
+            ->method('save')
+            ->with('foo', 'bar', 0)
+            ->willReturn(true);
+        $wrappedCache->expects($this->once())
+            ->method('delete')
+            ->with('foo')
+            ->willReturn(true);
+
+        $cache = new DoctrineCacheAdapter($wrappedCache);
+        $cache->set('foo', 'bar', 0);
+        $cache->get('foo');
+        $cache->remove('foo');
+    }
+
+    public function testAdaptsCacheToAwsAndDoctrine()
+    {
+        $wrappedCache = $this->getMock(Cache::class);
+        $cache = new DoctrineCacheAdapter($wrappedCache);
+
+        $this->assertInstanceOf(Cache::class, $cache);
+        $this->assertInstanceOf(CacheInterface::class, $cache);
+    }
+}


### PR DESCRIPTION
This PR allows users to pass an instance of `Aws\CacheInterface` as the `credentials` in their client configuration. The default provider chain will still be used, but the cache will hold on to credentials returned by the Ec2 instance metadata service.

Additionally, this PR includes an adapter for instances of `Doctrine\Common\Cache\Cache`, as the only bundled implementation of `Aws\CacheInterface` is an in-memory cache.