### PR TITLE
Add SNS message validator to the distributables 

### DIFF
--- a/build/packager.php
+++ b/build/packager.php
@@ -13,6 +13,7 @@ foreach ($metaFiles as $file) {
 }
 
 $burgomaster->recursiveCopy('src', 'Aws');
+$burgomaster->recursiveCopy('vendor/aws/aws-php-sns-message-validator/src', 'Aws/Sns');
 $burgomaster->recursiveCopy('vendor/mtdowling/jmespath.php/src', 'JmesPath');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/guzzle/src', 'GuzzleHttp');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/psr7/src', 'GuzzleHttp/Psr7');

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "ext-dom": "*",
         "ext-simplexml": "*",
         "phpunit/phpunit": "~4.0",
-        "behat/behat": "~3.0"
+        "behat/behat": "~3.0",
+        "aws/aws-php-sns-message-validator": "^1.0"
     },
     "suggest": {
         "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",


### PR DESCRIPTION
Breaking out the SNS validator was great for users who are comfortable with composer and don't need the rest of the SDK. This makes sure the functionality is still present for phar users who are upgrading from v2 to v3.