### PR TITLE
Allow getIterator() to continue to work without a *_token

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -245,7 +245,7 @@ class AwsClient implements AwsClientInterface
             return $this->getPaginator($name, $args)->search($key);
         }
 
-        $result = $this->getCommand($name, $args)->search($key);
+        $result = $this->execute($this->getCommand($name, $args))[$key];
 
         return new \ArrayIterator((array) $result);
     }


### PR DESCRIPTION
Allow `getIterator()` calls to non-paginated APIs, such as

```php
$ec2->getIterator('DescribeSubnets');
```
to continue to work as they did in v2 instead of failing with
```
Call to undefined method Aws\Command::search()
```