### PR TITLE
Fixed guzzle version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": ">=5.3|~6.0.1|~6.1",
+        "guzzlehttp/guzzle": ~5.3|~6.0.1|~6.1",
         "guzzlehttp/psr7": "~1.0",
         "guzzlehttp/promises": "~1.0",
         "mtdowling/jmespath.php": "~2.2"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": ~5.3|~6.0.1|~6.1",
+        "guzzlehttp/guzzle": "~5.3|~6.0.1|~6.1",
         "guzzlehttp/psr7": "~1.0",
         "guzzlehttp/promises": "~1.0",
         "mtdowling/jmespath.php": "~2.2"


### PR DESCRIPTION
Without this fix, you're allowing ALL versions of guzzle 5.3 or greater, for example, guzzle 10.5.2 would be allowed by this version constraint.