### PR TITLE
Fix warning when doing batch delete and there are no object in S3 bucket

### DIFF
--- a/src/S3/BatchDelete.php
+++ b/src/S3/BatchDelete.php
@@ -69,7 +69,7 @@ class BatchDelete implements PromisorInterface
         $fn = function (BatchDelete $that) use ($iter) {
             return $iter->each(function ($result) use ($that) {
                 $promises = [];
-                if (is_array($results['Contents'])) {
+                if (is_array($result['Contents'])) {
                     foreach ($result['Contents'] as $object) {
                         if ($promise = $that->enqueue($object)) {
                             $promises[] = $promise;

--- a/src/S3/BatchDelete.php
+++ b/src/S3/BatchDelete.php
@@ -69,9 +69,11 @@ class BatchDelete implements PromisorInterface
         $fn = function (BatchDelete $that) use ($iter) {
             return $iter->each(function ($result) use ($that) {
                 $promises = [];
-                foreach ($result['Contents'] as $object) {
-                    if ($promise = $that->enqueue($object)) {
-                        $promises[] = $promise;
+                if (is_array($results['Contents'])) {
+                    foreach ($result['Contents'] as $object) {
+                        if ($promise = $that->enqueue($object)) {
+                            $promises[] = $promise;
+                        }
                     }
                 }
                 return $promises ? Promise\all($promises) : null;


### PR DESCRIPTION
When trying to run batch delete and there are no object with given prefix PHP Warning is thrown.

When running following code and there are no object with `path/to` key prefix.
```
$d = Aws\S3\BatchDelete::fromListObjects($this->s3, ['Bucket' => 'bucket', 'Prefix' => "path/to/"]);
$d->delete();
```

```
Warning: Invalid argument supplied for foreach() in /path/to/app/vendor/aws/aws-sdk-php/src/S3/BatchDelete.php on line 73
```
