### PR TITLE
Fix/s3 connection error handling

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -489,15 +489,11 @@ class S3Client extends AwsClient
                         $error->getResponse()->getBody(),
                         'Your socket connection to the server'
                     ) !== false;
-                } elseif ($error->getPrevious() instanceof RequestException
-                    && defined('CURLE_RECV_ERROR')
-                ) {
-                    $context = $error->getPrevious()->getHandlerContext();
-                    if (isset($context['errno'])
-                        && $context['errno'] === CURLE_RECV_ERROR
-                    ) {
-                        return true;
-                    }
+                } elseif ($error->getPrevious() instanceof RequestException) {
+                    // All commands except CompleteMultipartUpload are
+                    // idempotent and may be retried without worry if a
+                    // networking error has occurred.
+                    return $command->getName() !== 'CompleteMultipartUpload';
                 }
             }
             return false;


### PR DESCRIPTION
To address some reported issues with the retry handling on the S3 client, this PR adds a few more statements to S3's custom retry handler. This should prevent 400 socket timeout errors from being infinitely retried and should ensure connection reset errors are retried within the bounds of the max retry limit.

/cc @mtdowling 