### PR TITLE
Should respect documented fields in credentials file

### DIFF
--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -280,14 +280,21 @@ class CredentialProvider
                 return self::reject("No credentials present in INI profile "
                     . "'$profile' ($filename)");
             }
+            if (!isset($data[$profile]['aws_session_token'])
+            ) {
+                $data[$profile]['aws_session_token'] = null;
+                if (isset($data[$profile]['aws_security_token'])
+                ) {
+                    $data[$profile]['aws_session_token'] = $data[$profile]['aws_security_token'];
+                    unset($data[$profile]['aws_security_token']);
+                }
+            }
 
             return Promise\promise_for(
                 new Credentials(
                     $data[$profile]['aws_access_key_id'],
                     $data[$profile]['aws_secret_access_key'],
-                    isset($data[$profile]['aws_security_token'])
-                        ? $data[$profile]['aws_security_token']
-                        : null
+                    $data[$profile]['aws_session_token']
                 )
             );
         };

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -228,7 +228,7 @@ class ClientResolverTest extends \PHPUnit_Framework_TestCase
 [foo]
 aws_access_key_id = foo
 aws_secret_access_key = baz
-aws_security_token = tok
+aws_session_token = tok
 EOT;
         file_put_contents($dir . '/credentials', $ini);
         $home = getenv('HOME');

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -140,7 +140,7 @@ class CredentialProviderTest extends \PHPUnit_Framework_TestCase
 [default]
 aws_access_key_id = foo
 aws_secret_access_key = baz
-aws_security_token = tok
+aws_session_token = tok
 EOT;
         file_put_contents($dir . '/credentials', $ini);
         putenv('HOME=' . dirname($dir));
@@ -150,6 +150,24 @@ EOT;
         $this->assertEquals('tok', $creds->getSecurityToken());
         unlink($dir . '/credentials');
     }
+
+	public function testCreatesFromOldIniFile()
+	{
+		$dir = $this->clearEnv();
+		$ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = baz
+aws_security_token = tok
+EOT;
+		file_put_contents($dir . '/credentials', $ini);
+		putenv('HOME=' . dirname($dir));
+		$creds = call_user_func(CredentialProvider::ini())->wait();
+		$this->assertEquals('foo', $creds->getAccessKeyId());
+		$this->assertEquals('baz', $creds->getSecretKey());
+		$this->assertEquals('tok', $creds->getSecurityToken());
+		unlink($dir . '/credentials');
+	}
 
     /**
      * @expectedException \Aws\Exception\CredentialsException


### PR DESCRIPTION
This change allows the documented field to be used for session token as stated in my [issue](https://github.com/aws/aws-sdk-php/issues/773) here.