### PR TITLE
Allow cucumber tests to run with Ec2 instance profile credentials

### DIFF
--- a/features/smoke/cloudfront/cloudfront.feature
+++ b/features/smoke/cloudfront/cloudfront.feature
@@ -3,9 +3,9 @@
 Feature: Amazon CloudFront
 
   Scenario: Making a basic request
-    When I call the "ListDistributions" API with:
+    When I call the "ListCloudFrontOriginAccessIdentities" API with:
     | MaxItems | 1 |
-    Then the value at "DistributionList.Items" should be a list
+    Then the value at "CloudFrontOriginAccessIdentityList.Items" should be a list
 
   Scenario: Error handling
     When I attempt to call the "GetDistribution" API with:

--- a/tests/Integ/IntegUtils.php
+++ b/tests/Integ/IntegUtils.php
@@ -7,7 +7,6 @@ trait IntegUtils
     {
         return new \Aws\Sdk($args + [
             'region'  => 'us-east-1',
-            'profile' => 'integ',
             'version' => 'latest',
             'ua_append' => 'PHPUnit/Integration'
         ]);


### PR DESCRIPTION
Rather than specifying the credentials profile in `Aws\Test\Integ\IntegUtils`, the integration test runner should just use the default credential provider. Profiles can be specified by setting the `AWS_PROFILE` environment variable.

Additionally, the CloudFront integration test no longer relies on accounts being in a particular state, as that will allow more flexibility with which accounts may execute tests.

/cc @mtdowling 