### PR TITLE
improved acl mapping

### DIFF
--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -861,10 +861,14 @@ class StreamWrapper
      */
     private function determineAcl($mode)
     {
-        switch (substr(decoct($mode), 0, 1)) {
-            case '7': return 'public-read';
-            case '6': return 'authenticated-read';
-            default: return 'private';
+        switch (substr(decoct($mode), 2, 1)) {
+        case '7': 
+        case '6':
+            return 'public-read-write';
+        case '5': 
+        case '4': 
+            return 'public-read';
+        default: return 'private';
         }
     }
 

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -292,7 +292,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->assertTrue(mkdir('s3://bucket', 0777));
-        $this->assertTrue(mkdir('s3://bucket', 0601));
+        $this->assertTrue(mkdir('s3://bucket', 0605));
         $this->assertTrue(mkdir('s3://bucket', 0500));
 
         $this->assertEquals(6, count($history));
@@ -305,8 +305,8 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('PUT', $entries[1]['request']->getMethod());
         $this->assertEquals('/bucket', $entries[1]['request']->getUri()->getPath());
         $this->assertEquals('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertEquals('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertEquals('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertEquals('public-read-write', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertEquals('public-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
         $this->assertEquals('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
     }
 


### PR DESCRIPTION
as suggested and promised in https://github.com/aws/aws-sdk-php/pull/776#issuecomment-143505174 

I don´t expect this to get pulled without some discussion about what would be the best mapping; however imo the current mapping is erroneous and needs improving; 700 should of course be as private as possible.

I chose this simple form:
public-read: the third digit is 4 or 5
public-read-write: the third digit is 6 or 7
private: the rest

rationale:
the x-bit has no meaning in acl, so these options make the most sense. 0 or 1 is no permissions, 2 or 3 are write-but-not-read, which is rarely seen in the wild and of course has no corresponding acl, which leaves read and read+write.
The group (2nd) digit cannot really be described by canned acl policies; it is not authenticated-read, because this does not refer to the private group of the file.
The owner (1st) digit doesn´t get a lot of flexibility in canned acl´s, there is only full access for the owner, no matter which option is chosen. So maybe you might want an error or something if anything else than 6 or 7 is given, in stead of simply give full access to the owner no matter what is requested, which is my solution.

There may be better ways to improve the mapping than using canned acl, I am open to suggestions. Also on expanding the unit tests.