### PR TITLE
Add async counterparts to S3Client::upload and S3Client::copy

### DIFF
--- a/docs/service/s3-multipart-upload.rst
+++ b/docs/service/s3-multipart-upload.rst
@@ -217,3 +217,27 @@ The following configuration options are valid:
     multipart upload and that is used to resume a previous upload. When this
     option is provided, the ``bucket``, ``key``, and ``part_size`` options
     are ignored.
+
+Multipart Copies
+----------------
+
+The SDK also includes a ``MultipartCopy`` object that is used in a similar manner
+to the ``MultipartUploader`` but is designed for copying objects between 5GB and
+5TB in size within S3.
+
+.. code-block:: php
+
+    use Aws\S3\MultipartCopy;
+    use Aws\Exception\MultipartUploadException;
+
+    $copier = new MultipartCopy($s3Client, '/bucket/key?versionId=foo', [
+        'bucket' => 'your-bucket',
+        'key'    => 'my-file.zip',
+    ]);
+
+    try {
+        $result = $copier->copy();
+        echo "Copy complete: {$result['ObjectURL'}\n";
+    } catch (MultipartUploadException $e) {
+        echo $e->getMessage() . "\n";
+    }

--- a/src/S3/MultipartCopy.php
+++ b/src/S3/MultipartCopy.php
@@ -57,6 +57,11 @@ class MultipartCopy extends AbstractUploadManager
         ]);
     }
 
+    public function copy()
+    {
+        return $this->upload();
+    }
+
     protected function loadUploadWorkflowInfo()
     {
         return [
@@ -140,9 +145,18 @@ class MultipartCopy extends AbstractUploadManager
         }
 
         list($bucket, $key) = explode('/', ltrim($this->source, '/'), 2);
-        return $this->client->headObject([
+        $headParams = [
             'Bucket' => $bucket,
             'Key' => $key,
-        ]);
+        ];
+        if (strpos($key, '?')) {
+            list($key, $query) = explode('?', $key, 2);
+            $headParams['Key'] = $key;
+            $query = Psr7\parse_query($query, false);
+            if (isset($query['versionId'])) {
+                $headParams['VersionId'] = $query['versionId'];
+            }
+        }
+        return $this->client->headObject($headParams);
     }
 }

--- a/src/S3/MultipartCopy.php
+++ b/src/S3/MultipartCopy.php
@@ -57,6 +57,11 @@ class MultipartCopy extends AbstractUploadManager
         ]);
     }
 
+    /**
+     * An alias of the self::upload method.
+     *
+     * @see self::upload
+     */
     public function copy()
     {
         return $this->upload();

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -485,8 +485,8 @@ class S3Client extends AwsClient
      *
      * @param string $fromBucket    Bucket where the copy source resides.
      * @param string $fromKey       Key of the copy source.
-     * @param string $bucket        Bucket to which to copy the object.
-     * @param string $key           Key to which to copy the object.
+     * @param string $destBucket    Bucket to which to copy the object.
+     * @param string $destKey       Key to which to copy the object.
      * @param string $acl           ACL to apply to the copy (default: private).
      * @param array  $options       Options used to configure the upload process.
      *
@@ -496,13 +496,13 @@ class S3Client extends AwsClient
     public function copy(
         $fromBucket,
         $fromKey,
-        $bucket,
-        $key,
+        $destBucket,
+        $destKey,
         $acl = 'private',
         array $options = []
     ) {
         return $this
-            ->copyAsync($fromBucket, $fromKey, $bucket, $key, $acl, $options)
+            ->copyAsync($fromBucket, $fromKey, $destBucket, $destKey, $acl, $options)
             ->wait();
     }
 
@@ -511,8 +511,8 @@ class S3Client extends AwsClient
      *
      * @param string $fromBucket    Bucket where the copy source resides.
      * @param string $fromKey       Key of the copy source.
-     * @param string $bucket        Bucket to which to copy the object.
-     * @param string $key           Key to which to copy the object.
+     * @param string $destBucket    Bucket to which to copy the object.
+     * @param string $destKey       Key to which to copy the object.
      * @param string $acl           ACL to apply to the copy (default: private).
      * @param array  $options       Options used to configure the upload process.
      *
@@ -523,8 +523,8 @@ class S3Client extends AwsClient
     public function copyAsync(
         $fromBucket,
         $fromKey,
-        $bucket,
-        $key,
+        $destBucket,
+        $destKey,
         $acl = 'private',
         array $options = []
     ) {
@@ -540,7 +540,7 @@ class S3Client extends AwsClient
 
         return Promise\coroutine($this->doCopyAsync(
             ['Bucket' => $fromBucket, 'Key' => $fromKey],
-            ['Bucket' => $bucket, 'Key' => $key],
+            ['Bucket' => $destBucket, 'Key' => $destKey],
             $acl,
             $options + $defaults
         ));

--- a/tests/UsesServiceTrait.php
+++ b/tests/UsesServiceTrait.php
@@ -13,6 +13,8 @@ use Aws\Api\Service;
  */
 trait UsesServiceTrait
 {
+    private $_mock_handler;
+
     /**
      * Creates an instance of the AWS SDK for a test
      *
@@ -45,7 +47,7 @@ trait UsesServiceTrait
             && !isset($args['handler'])
             && !isset($args['http_handler'])
         ) {
-            $args['handler'] = new MockHandler([]);
+            $this->_mock_handler = $args['handler'] = new MockHandler([]);
         }
 
         return $this->getTestSdk($args)->createClient($service);
@@ -73,10 +75,15 @@ trait UsesServiceTrait
             }
         }
 
-        $mock = new MockHandler($results, $onFulfilled, $onRejected);
-        $client->getHandlerList()->setHandler($mock);
+        $this->_mock_handler = new MockHandler($results, $onFulfilled, $onRejected);
+        $client->getHandlerList()->setHandler($this->_mock_handler);
 
         return $client;
+    }
+
+    private function mockQueueEmpty()
+    {
+        return 0 === count($this->_mock_handler);
     }
 
     /**


### PR DESCRIPTION
This PR adds `uploadAsync` and `copyAsync` methods to `Aws\S3\S3Client`, both of which return promises that will be fulfilled with the result of the underlying operation. `upload` and `copy` now simply call `uploadAsync` and `copyAsync` respectively and wait on the returned promise.

/cc @mtdowling 