### PR TITLE
Respect client-supplied location constraints on createBucket commands

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -624,9 +624,13 @@ class S3Client extends AwsClient
         return static function (callable $handler) use ($region) {
             return function (Command $command, $request = null) use ($handler, $region) {
                 if ($command->getName() === 'CreateBucket') {
-                    if ($region === 'us-east-1') {
+                    $locationConstraint = isset($command['CreateBucketConfiguration']['LocationConstraint'])
+                        ? $command['CreateBucketConfiguration']['LocationConstraint']
+                        : null;
+
+                    if ($locationConstraint === 'us-east-1') {
                         unset($command['CreateBucketConfiguration']);
-                    } else {
+                    } elseif ('us-east-1' !== $region && empty($locationConstraint)) {
                         $command['CreateBucketConfiguration'] = ['LocationConstraint' => $region];
                     }
                 }


### PR DESCRIPTION
This PR allows custom location constraints to be supplied.

/cc @mtdowling @chrisradek 