### PR TITLE
Let the RT keep track of session IDs

### DIFF
--- a/src/DynamoDb/SessionHandler.php
+++ b/src/DynamoDb/SessionHandler.php
@@ -32,9 +32,6 @@ class SessionHandler implements \SessionHandlerInterface
     /** @var string Stores serialized data for tracking changes. */
     private $dataRead;
 
-    /** @var string Keeps track of the open session's ID. */
-    private $openSessionId;
-
     /** @var bool Keeps track of whether the session has been written. */
     private $sessionWritten;
 
@@ -100,9 +97,8 @@ class SessionHandler implements \SessionHandlerInterface
     {
         $this->savePath = $savePath;
         $this->sessionName = $sessionName;
-        $this->openSessionId = session_id();
 
-        return (bool) $this->openSessionId;
+        return true;
     }
 
     /**
@@ -115,12 +111,10 @@ class SessionHandler implements \SessionHandlerInterface
         // Make sure the session is unlocked and the expiration time is updated,
         // even if the write did not occur
         if (!$this->sessionWritten) {
-            $id = $this->formatId($this->openSessionId);
+            $id = $this->formatId(session_id());
             $result = $this->connection->write($id, '', false);
             $this->sessionWritten = (bool) $result;
         }
-
-        $this->openSessionId = null;
 
         return $this->sessionWritten;
     }

--- a/tests/DynamoDb/SessionHandlerTest.php
+++ b/tests/DynamoDb/SessionHandlerTest.php
@@ -53,4 +53,20 @@ class SessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($sh->write('test', serialize($data)));
         $this->assertTrue($sh->close());
     }
+
+    public function testHandlerWhenNothingWritten()
+    {
+        $connection = $this->getMockForAbstractClass(
+            'Aws\DynamoDb\SessionConnectionInterface'
+        );
+        $connection->expects($this->once())
+            ->method('write')
+            ->with('name_test', '', false)
+            ->willReturn(true);
+
+        $sh = new SessionHandler($connection);
+        session_id('test');
+        $sh->open('', 'name');
+        $this->assertTrue($sh->close());
+    }
 }


### PR DESCRIPTION
Rather than have the session handler keep track of the current session id, this PR punts that responsibility to the runtime. `session_id` is therefore called in the `close` handler instead of the `open` handler, as some users had reported that certain runtimes would not return a valid session ID when `session_id` was called before `session_start` had completed.

/cc @chrisradek @mtdowling 