### PR TITLE
Trigger errors when the session handler fails to write or delete data

### DIFF
--- a/src/DynamoDb/StandardSessionConnection.php
+++ b/src/DynamoDb/StandardSessionConnection.php
@@ -77,7 +77,7 @@ class StandardSessionConnection implements SessionConnectionInterface
                 'AttributeUpdates' => $attributes,
             ]);
         } catch (DynamoDbException $e) {
-            return false;
+            return $this->triggerError("Error writing session $id: {$e->getMessage()}");
         }
     }
 
@@ -89,7 +89,7 @@ class StandardSessionConnection implements SessionConnectionInterface
                 'Key'       => $this->formatKey($id),
             ]);
         } catch (DynamoDbException $e) {
-            return false;
+            return $this->triggerError("Error deleting session $id: {$e->getMessage()}");
         }
     }
 
@@ -133,5 +133,17 @@ class StandardSessionConnection implements SessionConnectionInterface
     protected function formatKey($key)
     {
         return [$this->config['hash_key'] => ['S' => $key]];
+    }
+
+    /**
+     * @param string $error
+     *
+     * @return bool
+     */
+    protected function triggerError($error)
+    {
+        trigger_error($error, E_USER_WARNING);
+
+        return false;
     }
 }


### PR DESCRIPTION
This PR converts exceptions thrown within the DynamoDB session handler into warning-level errors. The current behavior of the handler (returning false on failure) is not changed, but errors will become more visible (as requested in #585).

/cc @mtdowling @chrisradek 