### PR TITLE
Add a CognitoIdentity credential provider

### DIFF
--- a/src/CognitoIdentity/CognitoIdentityProvider.php
+++ b/src/CognitoIdentity/CognitoIdentityProvider.php
@@ -1,0 +1,61 @@
+<?php
+namespace Aws\CognitoIdentity;
+
+use Aws\Credentials\Credentials;
+use GuzzleHttp\Promise;
+
+class CognitoIdentityProvider
+{
+    /** @var CognitoIdentityClient */
+    private $client;
+    /** @var string */
+    private $identityPoolId;
+    /** @var string|null */
+    private $accountId;
+    /** @var array */
+    private $logins;
+
+    public function __construct(
+        $poolId,
+        array $clientOptions,
+        array $logins = [],
+        $accountId = null
+    ) {
+        $this->identityPoolId = $poolId;
+        $this->logins = $logins;
+        $this->accountId = $accountId;
+        $this->client = new CognitoIdentityClient($clientOptions + [
+            'credentials' => false,
+        ]);
+    }
+
+    public function __invoke()
+    {
+        return Promise\coroutine(function () {
+            $params = $this->logins ? ['Logins' => $this->logins] : [];
+            $getIdParams = $params + ['IdentityPoolId' => $this->identityPoolId];
+            if ($this->accountId) {
+                $getIdParams['AccountId'] = $this->accountId;
+            }
+
+            $id = (yield $this->client->getId($getIdParams));
+            $result = (yield $this->client->getCredentialsForIdentity([
+                'IdentityId' => $id['IdentityId'],
+            ] + $params));
+
+            yield new Credentials(
+                $result['Credentials']['AccessKeyId'],
+                $result['Credentials']['SecretKey'],
+                $result['Credentials']['SessionToken'],
+                (int) $result['Credentials']['Expiration']->format('U')
+            );
+        });
+    }
+
+    public function updateLogin($key, $value)
+    {
+        $this->logins[$key] = $value;
+
+        return $this;
+    }
+}

--- a/src/Sts/StsClient.php
+++ b/src/Sts/StsClient.php
@@ -43,7 +43,9 @@ class StsClient extends AwsClient
             $c['AccessKeyId'],
             $c['SecretAccessKey'],
             isset($c['SessionToken']) ? $c['SessionToken'] : null,
-            isset($c['Expiration']) ? $c['Expiration'] : null
+            isset($c['Expiration']) && $c['Expiration'] instanceof \DateTimeInterface
+                ? (int) $c['Expiration']->format('U')
+                : null
         );
     }
 }

--- a/tests/CognitoIdentity/CognitoIdentityProviderTest.php
+++ b/tests/CognitoIdentity/CognitoIdentityProviderTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Aws\Test\CognitoIdentity;
+
+use Aws\Api\DateTimeResult;
+use Aws\CognitoIdentity\CognitoIdentityProvider;
+use Aws\MockHandler;
+use Aws\Result;
+use Aws\Test\UsesServiceTrait;
+
+class CognitoIdentityProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCreatesFromCognitoIdentity()
+    {
+        $options = [
+            'region' => 'not-a-region',
+            'version' => 'latest',
+            'handler' => new MockHandler([
+                new Result(['IdentityId' => 'foo:bar:baz']),
+                new Result([
+                    'Credentials' => [
+                        'AccessKeyId' => 'foo',
+                        'SecretKey' => 'bar',
+                        'SessionToken' => 'baz',
+                        'Expiration' => DateTimeResult::fromEpoch(time() + 10),
+                    ]
+                ]),
+            ]),
+        ];
+
+        $provider = new CognitoIdentityProvider('poolId', $options);
+        $credentials = call_user_func($provider)->wait();
+
+        $this->assertSame('foo', $credentials->getAccessKeyId());
+        $this->assertSame('bar', $credentials->getSecretKey());
+        $this->assertSame('baz', $credentials->getSecurityToken());
+        $this->assertFalse($credentials->isExpired());
+    }
+
+    public function testAccessTokensCanBeRefreshed()
+    {
+        $provider = new CognitoIdentityProvider(
+            'poolId',
+            ['region' => 'us-east-1',  'version' => 'latest'],
+            [
+                'www.amazon.com' => 'access-token-old',
+                'graph.facebook.com' => 'access-token-fb',
+            ]
+        );
+
+        $provider->updateLogin('www.amazon.com', 'access-token-new');
+        $this->assertSame(
+            'access-token-new',
+            $this->readAttribute($provider, 'logins')['www.amazon.com']
+        );
+    }
+}

--- a/tests/Sts/StsClientTest.php
+++ b/tests/Sts/StsClientTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Test\Sts;
 
+use Aws\Api\DateTimeResult;
 use Aws\Result;
 use Aws\Sts\StsClient;
 
@@ -16,7 +17,7 @@ class StsClientTest extends \PHPUnit_Framework_TestCase
                 'AccessKeyId' => 'foo',
                 'SecretAccessKey' => 'bar',
                 'SessionToken' => 'baz',
-                'Expiration' => 30,
+                'Expiration' => DateTimeResult::fromEpoch(time() + 10),
             ]
         ]);
 
@@ -29,7 +30,8 @@ class StsClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $credentials->getAccessKeyId());
         $this->assertEquals('bar', $credentials->getSecretKey());
         $this->assertEquals('baz', $credentials->getSecurityToken());
-        $this->assertEquals(30, $credentials->getExpiration());
+        $this->assertInternalType('int', $credentials->getExpiration());
+        $this->assertFalse($credentials->isExpired());
     }
 
     /**


### PR DESCRIPTION
The added provider uses a Cognito Identity's anonymous APIs to create credentials. It also moves the `createCredentials` method from `Aws\Sts\StsClient` into a trait.

/cc @mtdowling @chrisradek 