### PR TITLE
Backoff in MS (not seconds) and throw in some jitter

### DIFF
--- a/src/DynamoDb/DynamoDbClient.php
+++ b/src/DynamoDb/DynamoDbClient.php
@@ -78,7 +78,7 @@ class DynamoDbClient extends AwsClient
                 RetryMiddleware::createDefaultDecider($value),
                 function ($retries) {
                     return $retries
-                        ? (50 * (int) pow(2, $retries - 1)) / 1000
+                        ? RetryMiddleware::exponentialDelay($retries) / 2
                         : 0;
                 }
             ),

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -86,7 +86,7 @@ class RetryMiddleware
      */
     public static function exponentialDelay($retries)
     {
-        return (int) pow(2, $retries - 1);
+        return mt_rand(0, (int) pow(2, $retries - 1) * 100);
     }
 
     /**

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -82,10 +82,24 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
     public function testDelaysExponentially()
     {
         $this->assertEquals(0, RetryMiddleware::exponentialDelay(0));
-        $this->assertEquals(1, RetryMiddleware::exponentialDelay(1));
-        $this->assertEquals(2, RetryMiddleware::exponentialDelay(2));
-        $this->assertEquals(4, RetryMiddleware::exponentialDelay(3));
-        $this->assertEquals(8, RetryMiddleware::exponentialDelay(4));
+        $this->assertLessThanOrEqual(100, RetryMiddleware::exponentialDelay(1));
+        $this->assertLessThanOrEqual(200, RetryMiddleware::exponentialDelay(2));
+        $this->assertLessThanOrEqual(400, RetryMiddleware::exponentialDelay(3));
+        $this->assertLessThanOrEqual(800, RetryMiddleware::exponentialDelay(4));
+    }
+
+    public function testDelaysWithSomeRandomness()
+    {
+        $maxDelay = 100 * pow(2, 4);
+        $values = array_map(function () {
+            return RetryMiddleware::exponentialDelay(5);
+        }, range(1, 200));
+
+        $this->assertGreaterThan(1, count(array_unique($values)));
+        foreach ($values as $value) {
+            $this->assertGreaterThanOrEqual(0, $value);
+            $this->assertLessThanOrEqual($maxDelay, $value);
+        }
     }
 
     public function testRetriesWhenResultMatches()


### PR DESCRIPTION
This PR converts the delay value provided from the SDK to Guzzle from seconds to milliseconds. Guzzle is expecting MS, so the previous behavior was to delay for trivial amounts of time (as reported in #815). Since I was already mucking about in the backoff code, I threw in some randomness.

One thing I'm not clear on is if the delay times are correct. [The DynamoDB docs advise delaying  (50 * (int) pow(2, $retries - 1)) between retries](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html), whereas the standard AWS guideline is to [wait pow(2, $retries - 1) * 100 milliseconds](http://docs.aws.amazon.com/general/latest/gr/api-retries.html). When adding jitter, should I aim to make those values match the maximum possible retry delay (which is what I've done below), or should I try to make those the average retry delay?

/cc @mtdowling @chrisradek 