### PR TITLE
FIX Changed session IDs now have data written

### DIFF
--- a/src/Aws/DynamoDb/Session/SessionHandler.php
+++ b/src/Aws/DynamoDb/Session/SessionHandler.php
@@ -332,7 +332,7 @@ class SessionHandler implements SessionHandlerInterface
         $this->sessionWritten = $this->lockingStrategy->doWrite(
             $this->formatId($id),
             $data,
-            ($data !== $this->dataRead)
+            ($id !== $this->openSessionId) || ($data !== $this->dataRead)
         );
 
         return $this->isSessionWritten();


### PR DESCRIPTION
This is a fix for #821; where sessions where IDs are regenerated but session data remains the same fail to have the data propagated to the new session record in DynamoDB.