### PR TITLE
Take account of the fact that session IDs can and should change.

### DIFF
--- a/tests/Aws/Tests/DynamoDb/Session/SessionHandlerTest.php
+++ b/tests/Aws/Tests/DynamoDb/Session/SessionHandlerTest.php
@@ -112,6 +112,70 @@ class SessionHandlerTest extends AbstractSessionTestCase
         $this->assertTrue($this->handler->write('test', 'ANYTHING'));
     }
 
+    public function testSessionWritesDataOnChangedSessionID()
+    {
+        //set up our test session store and data
+        $store = array();
+        $mockSessionData = serialize(array(
+            'fizz' => 'buzz',
+        ));
+
+        //construct our mock client/strategy/handler
+        $client = $this->getMockedClient();
+        $strategy = $this->getMock('Aws\DynamoDb\Session\LockingStrategy\LockingStrategyInterface');
+        $handler = SessionHandler::factory(array(
+            'dynamodb_client' => $client,
+            'locking_strategy' => $strategy,
+        ));
+
+        $command = $this->getMockedCommand($client);
+        $command->expects($this->any())
+            ->method('execute')
+            ->will($this->returnValue(array('foo' => 'bar')));
+
+        $client->expects($this->any())
+            ->method('getIterator')
+            ->will($this->returnValue(array()));
+
+        //doRead function to fetch session data by ID
+        $strategy->expects($this->any())
+            ->method('doRead')
+            ->will($this->returnCallback(function ($id) use (&$store) {
+                if (isset($store[$id])) {
+                    return array(
+                        'expires' => time() + 10000,
+                        'data' => $store[$id],
+                    );
+                }
+
+                return array();
+            }));
+
+        //doWrite to mock our ID - Only change data if $isChanged is true
+        $strategy->expects($this->any())
+            ->method('doWrite')
+            ->will($this->returnCallback(function ($id, $data, $isChanged) use (&$store) {
+                if ($isChanged) {
+                    $store[$id] = $data;
+                }
+
+                return true;
+            }));
+
+        //doDestroy - remove data by id
+        $strategy->expects($this->any())
+            ->method('doDestroy')
+            ->will($this->returnCallback(function ($id) use (&$store) {
+            unset($store[$id]);
+            return true;
+        }));
+
+        $this->assertTrue($handler->write('test', $mockSessionData));
+        $this->assertEquals($mockSessionData, $handler->read('test'));
+        $this->assertTrue($handler->write('newsessionid', $mockSessionData));
+        $this->assertEquals($mockSessionData, $handler->read('newsessionid'));
+    }
+
     public function testSessionGarbageCollection()
     {
         $this->assertTrue($this->handler->gc('ANYTHING'));

--- a/tests/Aws/Tests/DynamoDb/Session/SessionHandlerTest.php
+++ b/tests/Aws/Tests/DynamoDb/Session/SessionHandlerTest.php
@@ -100,16 +100,6 @@ class SessionHandlerTest extends AbstractSessionTestCase
         $this->assertEquals(array('foo' => 'bar'), $result);
     }
 
-    public function testSessionOpenAndCloseAreSuccessful()
-    {
-        session_id('test');
-        $this->assertFalse($this->handler->isSessionOpen());
-        $this->assertTrue($this->handler->open('test', 'example'));
-        $this->assertTrue($this->handler->isSessionOpen());
-        $this->assertTrue($this->handler->close());
-        $this->assertFalse($this->handler->isSessionOpen());
-    }
-
     public function testSessionReadAndDeleteExpiredItem()
     {
         $this->assertTrue($this->handler->open('test', 'example'));
@@ -138,5 +128,33 @@ class SessionHandlerTest extends AbstractSessionTestCase
             ->will($this->throwException(new \Exception));
 
         $this->assertFalse($handler->gc('ANYTHING'));
+    }
+
+    public function testSessionDataCanBeWrittenToNewIdWithNoChanges()
+    {
+
+        $client   = $this->getMockedClient();
+        $strategy = $this->getMock('Aws\DynamoDb\Session\LockingStrategy\LockingStrategyInterface');
+        $handler = SessionHandler::factory(array(
+            'dynamodb_client'  => $client,
+            'locking_strategy' => $strategy,
+        ));
+        $data = 'serializedData';
+
+        $strategy->expects($this->once())
+            ->method('doRead')
+            ->with('oldId')
+            ->will($this->returnValue(array(
+                'expires' => time() + 50000,
+                'data' => $data
+            )));
+
+        $strategy->expects($this->once())
+            ->method('doWrite')
+            ->with('newId', $data, true)
+            ->will($this->returnValue(true));
+
+        $this->assertSame($data, $handler->read('oldId'));
+        $this->assertTrue($handler->write('newId', $data));
     }
 }


### PR DESCRIPTION
This PR removes three protected members from the DynamoDb `SessionHandler`: `$dataRead`, `$openSessionId`, and `$sessionWritten`. In their place, the session handler uses `session_id` to get the open session ID and will look up session data and whether a session was written dynamically based on the current session ID in arrays at `$sessionDataRead` and `$sessionsWritten`. 

Since PHP does not allow `__get` methods to be declared `protected`, this PR has a side effect of making the `->dataRead` and `->sessionWritten` members publicly readable, but this information could always have been accessed from anywhere in the process using PHP's `session_*` functions.

The motivation for this PR is that the session handler as it is written is unable to detect when `session_regenerate_id` is called, as `session_set_save_handler` provides no session ID generation hook prior to PHP 5.5. Since changing the session ID after changing privilege levels is [an official OWASP recommendation](https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Renew_the_Session_ID_After_Any_Privilege_Level_Change), the Dynamo session handler should support doing so seamlessly.

/cc @dhensby @mtdowling @chrisradek