### PR TITLE
Allow the error handler to recover from error parser errors

### DIFF
--- a/src/Api/ErrorParser/JsonParserTrait.php
+++ b/src/Api/ErrorParser/JsonParserTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Api\ErrorParser;
 
+use Aws\Api\Parser\PayloadParserTrait;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -8,6 +9,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 trait JsonParserTrait
 {
+    use PayloadParserTrait;
+
     private function genericHandler(ResponseInterface $response)
     {
         $code = (string) $response->getStatusCode();
@@ -17,7 +20,7 @@ trait JsonParserTrait
             'code'        => null,
             'message'     => null,
             'type'        => $code[0] == '4' ? 'client' : 'server',
-            'parsed'      => json_decode($response->getBody(), true)
+            'parsed'      => $this->parseJson($response->getBody())
         ];
     }
 }

--- a/src/Api/ErrorParser/XmlErrorParser.php
+++ b/src/Api/ErrorParser/XmlErrorParser.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Api\ErrorParser;
 
+use Aws\Api\Parser\PayloadParserTrait;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -8,6 +9,8 @@ use Psr\Http\Message\ResponseInterface;
  */
 class XmlErrorParser
 {
+    use PayloadParserTrait;
+
     public function __invoke(ResponseInterface $response)
     {
         $code = (string) $response->getStatusCode();
@@ -22,7 +25,7 @@ class XmlErrorParser
 
         $body = $response->getBody();
         if ($body->getSize() > 0) {
-            $this->parseBody(new \SimpleXMLElement($body), $data);
+            $this->parseBody($this->parseXml($body), $data);
         } else {
             $this->parseHeaders($response, $data);
         }

--- a/src/WrappedHttpHandler.php
+++ b/src/WrappedHttpHandler.php
@@ -145,6 +145,8 @@ class WrappedHttpHandler
                     . "{$parts['message']} - " . $err['response']->getBody();
             } catch (ParserException $e) {
                 $parts = [];
+                $serviceError .= ' Unable to parse error information from '
+                    . "response - {$e->getMessage()}";
             }
 
             $parts['response'] = $err['response'];

--- a/src/WrappedHttpHandler.php
+++ b/src/WrappedHttpHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws;
 
+use Aws\Api\Parser\Exception\ParserException;
 use GuzzleHttp\Promise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -138,11 +139,15 @@ class WrappedHttpHandler
         if (!isset($err['response'])) {
             $parts = ['response' => null];
         } else {
-            $errorParser = $this->errorParser;
-            $parts = $errorParser($err['response']);
+            try {
+                $parts = call_user_func($this->errorParser, $err['response']);
+                $serviceError .= " {$parts['code']} ({$parts['type']}): "
+                    . "{$parts['message']} - " . $err['response']->getBody();
+            } catch (ParserException $e) {
+                $parts = [];
+            }
+
             $parts['response'] = $err['response'];
-            $serviceError .= " {$parts['code']} ({$parts['type']}): "
-                . "{$parts['message']} - " . $err['response']->getBody();
         }
 
         $parts['exception'] = $err['exception'];


### PR DESCRIPTION
Should help with the visibility of errors when responses do not necessarily follow the expected error format (e.g., #823).

/cc @mtdowling @chrisradek 