### PR TITLE
Test with HHVM nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.0
   - hhvm
+  - hhvm-nightly
 
 sudo: false
 
@@ -14,7 +15,9 @@ env:
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php:
+        - hhvm
+        - hhvm-nightly
   fast_finish: true
 
 install:


### PR DESCRIPTION
A recent comment on our favorite HHVM issue indicates that [the incompatible yield syntax might have been solved in HHVM's nightly build](https://github.com/facebook/hhvm/issues/1627#issuecomment-157794564).

This PR adds that check to our test matrix.