### PR TITLE
Add a helper function to generate SMTP password from credentials

### DIFF
--- a/src/Ses/SesClient.php
+++ b/src/Ses/SesClient.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\Ses;
 
+use Aws\Credentials\CredentialsInterface;
+
 /**
  * This client is used to interact with the **Amazon Simple Email Service (Amazon SES)**.
  *
@@ -83,4 +85,15 @@ namespace Aws\Ses;
  * @method \Aws\Result verifyEmailIdentity(array $args = [])
  * @method \GuzzleHttp\Promise\Promise verifyEmailIdentityAsync(array $args = [])
  */
-class SesClient extends \Aws\AwsClient {}
+class SesClient extends \Aws\AwsClient
+{
+    public static function generateSmtpPassword(CredentialsInterface $creds)
+    {
+        static $version = "\x02";
+        static $algo = 'sha256';
+        static $message = 'SendRawEmail';
+        $signature = hash_hmac($algo, $message, $creds->getSecretKey(), true);
+
+        return base64_encode($version . $signature);
+    }
+}

--- a/tests/Ses/SesClientTest.php
+++ b/tests/Ses/SesClientTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Aws\Test\Ses;
+
+use Aws\Credentials\Credentials;
+use Aws\Ses\SesClient;
+
+class SesClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanGenerateSmtpPasswordFromCredentials()
+    {
+        $testCreds = new Credentials(
+            'AKIAIOSFODNN7EXAMPLE',
+            'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+        );
+        // Created using sample code on: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert
+        $expectedPassword = 'An60U4ZD3sd4fg+FvXUjayOipTt8LO4rUUmhpdX6ctDy';
+
+        $this->assertSame(
+            $expectedPassword,
+            SesClient::generateSmtpPassword($testCreds)
+        );
+    }
+}


### PR DESCRIPTION
Based on [this section of the SES docs](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html#smtp-credentials-convert).

/cc @mtdowling @chrisradek 