### PR TITLE
Ensure errors with unparseable responses are retried when idempotent

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -749,7 +749,10 @@ class S3Client extends AwsClient
             } elseif ($error instanceof AwsException
                 && $retries < $maxRetries
             ) {
-                if ($error->getResponse()) {
+                if (
+                    $error->getResponse()
+                    && $error->getResponse()->getStatusCode() >= 400
+                ) {
                     return strpos(
                         $error->getResponse()->getBody(),
                         'Your socket connection to the server'


### PR DESCRIPTION
This PR makes a code path in the S3 retry handler more specific by only checking error-level responses for the string "Your socket connection to the server..." The branching logic was also catching 200-level responses with reset connections, meaning that they weren't retried.

/cc @mtdowling @chrisradek 