### PR TITLE
Clean DelegationSetId in Route53Client

### DIFF
--- a/src/Route53/Route53Client.php
+++ b/src/Route53/Route53Client.php
@@ -117,7 +117,7 @@ class Route53Client extends AwsClient
     {
         return function (callable $handler) {
             return function (CommandInterface $c, RequestInterface $r = null) use ($handler) {
-                foreach (['Id', 'HostedZoneId'] as $clean) {
+                foreach (['Id', 'HostedZoneId', 'DelegationSetId'] as $clean) {
                     if ($c->hasParam($clean)) {
                         $c[$clean] = $this->cleanId($c[$clean]);
                     }

--- a/tests/Route53/RouteClient53Test.php
+++ b/tests/Route53/RouteClient53Test.php
@@ -32,10 +32,29 @@ class Route53ClientTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $request = \Aws\serialize($command);
+        $requestUri = (string) $request->getUri();
+        $this->assertContains('/hostedzone/foo/rrset/', $requestUri);
+        $this->assertNotContains('/hostedzone/hostedzone', $requestUri);
 
+        $command = $client->getCommand('GetReusableDelegationSet', [
+            'Id' => '/delegationset/foo',
+        ]);
+
+        $request = \Aws\serialize($command);
+        $requestUri = (string) $request->getUri();
+        $this->assertContains('/delegationset/foo', $requestUri);
+        $this->assertNotContains('/delegationset/delegationset', $requestUri);
+
+        $command = $client->getCommand('CreateHostedZone', [
+            'Name' => 'foo',
+            'CallerReference' => '123',
+            'DelegationSetId' => '/delegationset/bar',
+        ]);
+
+        $request = \Aws\serialize($command);
         $this->assertContains(
-            '/hostedzone/foo/rrset/',
-            (string) $request->getUri()
+            '<DelegationSetId>bar</DelegationSetId>',
+            $request->getBody()->getContents()
         );
     }
 }


### PR DESCRIPTION
The fix 1b4688c4ba19ef8431e8ba96c8ebbe573fe83d43 seems incomplete:
It works for `GetReusableDelegationSet` request, where the parameter's name is `Id`
But does not work for `CreateHostedZone` request, where the parameter is `DelegationSetId`

That is the reason I've workarounded here: https://github.com/plesk/ext-route53/blob/master/plib/library/Client.php#L158
