### PR TITLE
Add a cache adapter for the psr-6 interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "doctrine/cache": "~1.4",
         "aws/aws-php-sns-message-validator": "~1.0",
         "nette/neon": "^2.3",
-        "andrewsville/php-token-reflection": "^1.4"
+        "andrewsville/php-token-reflection": "^1.4",
+        "psr/cache": "^1.0"
     },
     "suggest": {
         "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",

--- a/src/PsrCacheAdapter.php
+++ b/src/PsrCacheAdapter.php
@@ -1,0 +1,38 @@
+<?php
+namespace Aws;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+class PsrCacheAdapter implements CacheInterface
+{
+    /** @var CacheItemPoolInterface */
+    private $pool;
+
+    public function __construct(CacheItemPoolInterface $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    public function get($key)
+    {
+        $item = $this->pool->getItem($key);
+
+        return $item->isHit() ? $item->get() : null;
+    }
+
+    public function set($key, $value, $ttl = 0)
+    {
+        $item = $this->pool->getItem($key);
+        $item->set($value);
+        if ($ttl > 0) {
+            $item->expiresAfter($ttl);
+        }
+
+        $this->pool->save($item);
+    }
+
+    public function remove($key)
+    {
+        $this->pool->deleteItem($key);
+    }
+}

--- a/tests/PsrCacheAdapterTest.php
+++ b/tests/PsrCacheAdapterTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace Aws\Test;
+
+use Aws\PsrCacheAdapter;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+class PsrCacheAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var CacheItemPoolInterface|\PHPUnit_Framework_MockObject_MockObject $wrappedCache */
+    private $wrapped;
+    /** @var PsrCacheAdapter */
+    private $instance;
+
+    public function setUp()
+    {
+        $this->wrapped = $this->getMock(CacheItemPoolInterface::class);
+        $this->instance = new PsrCacheAdapter($this->wrapped);
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    public function testProxiesGetCallsToPsrCache($key, $value)
+    {
+        $item = $this->getMock(CacheItemInterface::class);
+        $item->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item->expects($this->once())
+            ->method('get')
+            ->willReturn($value);
+
+        $this->wrapped->expects($this->once())
+            ->method('getItem')
+            ->with($key)
+            ->willReturn($item);
+
+        $this->assertSame($value, $this->instance->get($key));
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param int|\DateInterval $ttl
+     */
+    public function testProxiesSetCallsToPsrCache($key, $value, $ttl)
+    {
+        $item = $this->getMock(CacheItemInterface::class);
+        $item->expects($this->once())
+            ->method('set')
+            ->with($value)
+            ->willReturnSelf();
+        $item->expects($this->once())
+            ->method('expiresAfter')
+            ->with($ttl)
+            ->willReturnSelf();
+
+        $this->wrapped->expects($this->once())
+            ->method('getItem')
+            ->with($key)
+            ->willReturn($item);
+        $this->wrapped->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $this->instance->set($key, $value, $ttl);
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     *
+     * @param string $key
+     */
+    public function testProxiesRemoveCallsToPsrCache($key)
+    {
+        $this->wrapped->expects($this->once())
+            ->method('deleteItem')
+            ->with($key)
+            ->willReturn(true);
+
+        $this->instance->remove($key);
+    }
+
+    public function cacheDataProvider()
+    {
+        return [
+            ['foo', 'bar', 300],
+        ];
+    }
+}


### PR DESCRIPTION
The added class allows users to create an instance of `Aws\CacheInterface` from an instance of `Psr\Cache\CacheItemPoolInterface`.

/cc @mtdowling @chrisradek 
