### PR TITLE
Add support for supplying source iterators to the transfer manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-json": "*",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.0|~5.0",
         "behat/behat": "~3.0",
         "doctrine/cache": "~1.4",
         "aws/aws-php-sns-message-validator": "~1.0",

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -3,10 +3,10 @@ namespace Aws\S3;
 
 use Aws;
 use Aws\CommandInterface;
-use Aws\ResultInterface;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Promise\PromisorInterface;
+use Iterator;
 
 /**
  * Transfers files from the local filesystem to S3 or from S3 to the local
@@ -20,6 +20,7 @@ class Transfer implements PromisorInterface
     private $client;
     private $promise;
     private $source;
+    private $sourceMetadata;
     private $destination;
     private $concurrency;
     private $mupThreshold;
@@ -61,7 +62,7 @@ class Transfer implements PromisorInterface
      *   rather than writing to STDOUT.
      *
      * @param S3Client         $client  Client used for transfers.
-     * @param string|\Iterator $source  Where the files are transferred from.
+     * @param string|Iterator  $source  Where the files are transferred from.
      * @param string           $dest    Where the files are transferred to.
      * @param array            $options Hash of options.
      */
@@ -81,23 +82,26 @@ class Transfer implements PromisorInterface
 
         // Prepare the source.
         if (is_string($source)) {
-            $this->source = $this->prepareTarget($source);
-        } elseif ($source instanceof \Iterator) {
-            if (isset($options['base_dir'])) {
-                $this->source = $this->prepareTarget($options['base_dir']);
-            } else {
+            $this->sourceMetadata = $this->prepareTarget($source);
+            $this->source = $source;
+        } elseif ($source instanceof Iterator) {
+            if (empty($options['base_dir'])) {
                 throw new \InvalidArgumentException('You must provide the source'
                     . ' argument as a string or provide the "base_dir" option.');
             }
+
+            $this->sourceMetadata = $this->prepareTarget($options['base_dir']);
+            $this->source = $source;
         } else {
             throw new \InvalidArgumentException('source must be the path to a '
                 . 'directory or an iterator that yields file names.');
         }
 
         // Validate schemes.
-        if ($this->source['scheme'] === $this->destination['scheme']) {
-            throw new \InvalidArgumentException("You cannot copy from "
-                . "{$this->source['scheme']} to {$this->destination['scheme']}."
+        if ($this->sourceMetadata['scheme'] === $this->destination['scheme']) {
+            throw new \InvalidArgumentException("You cannot copy from"
+                . " {$this->sourceMetadata['scheme']} to"
+                . " {$this->destination['scheme']}."
             );
         }
 
@@ -137,7 +141,7 @@ class Transfer implements PromisorInterface
         // If the promise has been created, just return it.
         if (!$this->promise) {
             // Create an upload/download promise for the transfer.
-            $this->promise = $this->source['scheme'] === 'file'
+            $this->promise = $this->sourceMetadata['scheme'] === 'file'
                 ? $this->createUploadPromise()
                 : $this->createDownloadPromise();
         }
@@ -211,74 +215,48 @@ class Transfer implements PromisorInterface
 
     private function createDownloadPromise()
     {
-        // Prepare args for ListObjects.
-        $listArgs = $this->getS3Args($this->source['path']);
-        if (isset($listArgs['Key'])) {
-            $listArgs['Prefix'] = $listArgs['Key'] . '/';
-            unset($listArgs['Key']);
-        }
+        $parts = $this->getS3Args($this->sourceMetadata['path']);
+        $prefix = "s3://{$parts['Bucket']}/"
+            . (isset($parts['Key']) ? $parts['Key'] . '/' : '');
 
-        // Get the Paginator for ListObjects
-        $objects = $this->client->getPaginator('ListObjects', $listArgs);
+        $commands = [];
+        foreach ($this->getDownloadsIterator() as $object) {
+            // Prepare the sink.
+            $localKey = $object;
+            if ($prefix && strpos($localKey, $prefix) === 0) {
+                $localKey = substr($localKey, strlen($prefix));
+            }
+            $sink = $this->destination['path'] . '/' . $localKey;
 
-        // Asynchronously execute the paginator, building command pools to
-        // download the objects.
-        return $objects->each(function (
-            ResultInterface $result
-        ) use ($listArgs) {
-            $commands = [];
-            $prefix = isset($listArgs['Prefix']) ? $listArgs['Prefix'] : null;
-            foreach ($result->search('Contents[].Key') as $key) {
-                // Skip files on S3 that just mark the existence of a folder.
-                if (substr($key, -1, 1) === '/') {
-                    continue;
-                }
-
-                // Prepare the sink.
-                $localKey = $key;
-                if ($prefix && strpos($localKey, $prefix) === 0) {
-                    $localKey = substr($key, strlen($prefix));
-                }
-                $sink = $this->destination['path'] . '/' . $localKey;
-
-                // Create the directory if needed.
-                $dir = dirname($sink);
-                if (!is_dir($dir) && !mkdir($dir, 0777, true)) {
-                    return Promise\rejection_for(
-                        new \RuntimeException("Could not create dir: {$dir}")
-                    );
-                }
-
-                // Create the command.
-                $commands[] = $this->client->getCommand('GetObject', [
-                    'Bucket' => $listArgs['Bucket'],
-                    'Key'    => $key,
-                    '@http'  => ['sink'  => $sink],
-                ]);
+            // Create the directory if needed.
+            $dir = dirname($sink);
+            if (!is_dir($dir) && !mkdir($dir, 0777, true)) {
+                return Promise\rejection_for(
+                    new \RuntimeException("Could not create dir: {$dir}")
+                );
             }
 
-            // Create a GetObject command pool and return the promise.
-            return (new Aws\CommandPool($this->client, $commands, [
-                'concurrency' => $this->concurrency,
-                'before'      => $this->before,
-                'rejected'    => function ($reason, $idx, Promise\PromiseInterface $p) {
-                    $p->reject($reason);
-                }
-            ]))->promise();
-        });
+            // Create the command.
+            $commands[] = $this->client->getCommand(
+                'GetObject',
+                $this->getS3Args($object) + ['@http'  => ['sink'  => $sink]]
+            );
+        }
+
+        // Create a GetObject command pool and return the promise.
+        return (new Aws\CommandPool($this->client, $commands, [
+            'concurrency' => $this->concurrency,
+            'before'      => $this->before,
+            'rejected'    => function ($reason, $idx, Promise\PromiseInterface $p) {
+                $p->reject($reason);
+            }
+        ]))->promise();
     }
 
     private function createUploadPromise()
     {
-        // Creates an iterator that yields promises for either upload or
-        // multipart upload operations for each file in the source directory.
-        $files = Aws\recursive_dir_iterator($this->source['path']);
-        // Filter out directories.
-        $files = \Aws\filter($files, function ($file) {
-            return !is_dir($file);
-        });
         // Map each file into a promise that performs the actual transfer.
-        $files = \Aws\map($files, function ($file) {
+        $files = \Aws\map($this->getUploadsIterator(), function ($file) {
             return (filesize($file) >= $this->mupThreshold)
                 ? $this->uploadMultipart($file)
                 : $this->upload($file);
@@ -287,6 +265,43 @@ class Transfer implements PromisorInterface
         // Create an EachPromise, that will concurrently handle the upload
         // operations' yielded promises from the iterator.
         return Promise\each_limit_all($files, $this->concurrency);
+    }
+
+    /** @return Iterator */
+    private function getUploadsIterator()
+    {
+        if (is_string($this->source)) {
+            return Aws\filter(
+                Aws\recursive_dir_iterator($this->sourceMetadata['path']),
+                function ($file) { return !is_dir($file); }
+            );
+        }
+
+        return $this->source;
+    }
+
+    /** @return Iterator */
+    private function getDownloadsIterator()
+    {
+        if (is_string($this->source)) {
+            $listArgs = $this->getS3Args($this->sourceMetadata['path']);
+            if (isset($listArgs['Key'])) {
+                $listArgs['Prefix'] = $listArgs['Key'] . '/';
+                unset($listArgs['Key']);
+            }
+
+            $files = $this->client
+                ->getPaginator('ListObjects', $listArgs)
+                ->search('Contents[].Key');
+            $files = Aws\map($files, function ($key) use ($listArgs) {
+                return "s3://{$listArgs['Bucket']}/$key";
+            });
+            return Aws\filter($files, function ($key) {
+                return substr($key, -1, 1) !== '/';
+            });
+        }
+
+        return $this->source;
     }
 
     private function upload($filename)
@@ -318,7 +333,7 @@ class Transfer implements PromisorInterface
     private function createS3Key($filename)
     {
         $relative_file_path = ltrim(
-            preg_replace('#^' . preg_quote($this->source['path']) . '#', '', $filename),
+            preg_replace('#^' . preg_quote($this->sourceMetadata['path']) . '#', '', $filename),
             '/\\'
         );
         
@@ -332,7 +347,7 @@ class Transfer implements PromisorInterface
     private function addDebugToBefore($debug)
     {
         $before = $this->before;
-        $sourcePath = $this->source['path'];
+        $sourcePath = $this->sourceMetadata['path'];
         $s3Args = $this->s3Args;
 
         $this->before = static function (


### PR DESCRIPTION
Iterators must yield absolute paths and must be paired with a `base_dir` option. We document that using iterators with the transfer manager is possible, but they are currently not supported.

/cc @mtdowling @chrisradek 