### PR TITLE
Skip undefined output shapes

### DIFF
--- a/src/Api/Parser/AbstractRestParser.php
+++ b/src/Api/Parser/AbstractRestParser.php
@@ -53,7 +53,10 @@ abstract class AbstractRestParser extends AbstractParser
             }
         }
 
-        if (!$payload && $response->getBody()->getSize() > 0) {
+        if (!$payload
+            && $response->getBody()->getSize() > 0
+            && count($output->getMembers()) > 0
+        ) {
             // if no payload was found, then parse the contents of the body
             $this->payload($response, $output, $result);
         }

--- a/tests/Api/test_cases/protocols/input/rest-json.json
+++ b/tests/Api/test_cases/protocols/input/rest-json.json
@@ -111,6 +111,56 @@
     ]
   },
   {
+    "description": "Querystring list of strings",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "StringList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "StringList": {
+        "type": "list",
+        "member": {
+          "shape": "String"
+        }
+      },
+      "String": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": ["value1", "value2"]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=value1&item=value2",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "String to string maps in querystring",
     "metadata": {
       "protocol": "rest-json",

--- a/tests/Api/test_cases/protocols/input/rest-xml.json
+++ b/tests/Api/test_cases/protocols/input/rest-xml.json
@@ -723,6 +723,56 @@
     ]
   },
   {
+    "description": "Querystring list of strings",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Items": {
+            "shape": "StringList",
+            "location": "querystring",
+            "locationName": "item"
+          }
+        }
+      },
+      "StringList": {
+        "type": "list",
+        "member": {
+          "shape": "String"
+        }
+      },
+      "String": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Items": ["value1", "value2"]
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?item=value1&item=value2",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "String to string maps in querystring",
     "metadata": {
       "protocol": "rest-xml",
@@ -862,7 +912,8 @@
           "foo": {
             "shape": "FooShape"
           }
-        }
+        },
+        "payload": "foo"
       },
       "FooShape": {
         "type": "string"
@@ -876,8 +927,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "foo"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },
@@ -905,7 +955,8 @@
           "foo": {
             "shape": "FooShape"
           }
-        }
+        },
+        "payload": "foo"
       },
       "FooShape": {
         "type": "blob"
@@ -919,8 +970,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "foo"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },
@@ -940,8 +990,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "foo"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },
@@ -968,7 +1017,8 @@
           "foo": {
             "shape": "FooShape"
           }
-        }
+        },
+        "payload": "foo"
       },
       "FooShape": {
         "locationName": "foo",
@@ -991,8 +1041,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "foo"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },
@@ -1014,8 +1063,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "foo"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },
@@ -1033,8 +1081,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "foo"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },
@@ -1054,8 +1101,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "foo"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },
@@ -1083,7 +1129,8 @@
           "Grant": {
             "shape": "Grant"
           }
-        }
+        },
+        "payload": "Grant"
       },
       "Grant": {
         "type": "structure",
@@ -1126,8 +1173,7 @@
             "requestUri": "/"
           },
           "input": {
-            "shape": "InputShape",
-            "payload": "Grant"
+            "shape": "InputShape"
           },
           "name": "OperationName"
         },

--- a/tests/Api/test_cases/protocols/output/query.json
+++ b/tests/Api/test_cases/protocols/output/query.json
@@ -757,6 +757,7 @@
       {
         "given": {
           "output": {
+            "resultWrapper": "OperationNameResult",
             "shape": "OutputShape"
           },
           "name": "OperationName"
@@ -767,7 +768,7 @@
         "response": {
           "status_code": 200,
           "headers": {},
-          "body": "<OperationNameResponse><Foo/><RequestId>requestid</RequestId></OperationNameResponse>"
+          "body": "<OperationNameResponse><OperationNameResult><Foo/></OperationNameResult><ResponseMetadata><RequestId>requestid</RequestId></ResponseMetadata></OperationNameResponse>"
         }
       }
     ]

--- a/tests/Api/test_cases/protocols/output/rest-json.json
+++ b/tests/Api/test_cases/protocols/output/rest-json.json
@@ -448,6 +448,26 @@
     ]
   },
   {
+    "description": "Ignores undefined output",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {},
+    "cases": [
+      {
+        "given": {
+          "name": "OperationName"
+        },
+        "result": {},
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "OK"
+        }
+      }
+    ]
+  },
+  {
     "description": "Supports header maps",
     "metadata": {
       "protocol": "rest-json"


### PR DESCRIPTION
This PR prevents the SDK from attempting to parse the payload of responses for which no output shape has been defined. This will address an error described in [the AWS forums](https://forums.aws.amazon.com/thread.jspa?threadID=223125), which was caused by an endpoint w/o any defined response shape returning the string `OK`.

/cc @mtdowling @xibz 