### PR TITLE
Correctly requeue throttled WriteRequestBatch items

### DIFF
--- a/src/DynamoDb/WriteRequestBatch.php
+++ b/src/DynamoDb/WriteRequestBatch.php
@@ -227,9 +227,7 @@ class WriteRequestBatch
             foreach ($requests as $request) {
                 $this->queue[] = [
                     'table' => $table,
-                    'data'  => isset($request['PutRequest'])
-                        ? $request['PutRequest']
-                        : $request['DeleteRequest']
+                    'data'  => $request,
                 ];
             }
         }


### PR DESCRIPTION
This PR ensures that when unprocessed items are requeued from the response to a BatchWriteItem operation in a WriteRequestBatch flush, they keep their PutRequest/DeleteRequest identifier.

/cc @mtdowling @xibz 