### PR TITLE
Update credentials cache to check for updated Doctrine behavior

### DIFF
--- a/tests/Aws/Tests/Common/Credentials/CacheableCredentialsTest.php
+++ b/tests/Aws/Tests/Common/Credentials/CacheableCredentialsTest.php
@@ -72,7 +72,7 @@ class CacheableCredentialsTest extends \Guzzle\Tests\GuzzleTestCase
         $cache = $this->getCache();
 
         $mock = $this->getMockBuilder('Aws\\Common\\Credentials\\Credentials')
-            ->setConstructorArgs(array('foo', 'baz', 'bar', 1))
+            ->setConstructorArgs(array('foo', 'baz', 'bar', 100 + time()))
             ->setMethods(array('isExpired'))
             ->getMock();
 


### PR DESCRIPTION
The test was checking for the existence of something in a cache, but the item must have an expiration in the future for Doctrine 1.6 to report that it contains that key. Our 2.8 build is failing because of this.

/cc @mtdowling @chrisradek @xibz 