### PR TITLE
Add missing AccessDeniedException class referenced by the getUser fun…

### DIFF
--- a/src/Aws/Iam/Exception/AccessDeniedException.php
+++ b/src/Aws/Iam/Exception/AccessDeniedException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace Aws\Iam\Exception;
+
+/**
+ * Access Denied
+ */
+class AccessDeniedException extends IamException {}


### PR DESCRIPTION
I ran into an issue when using the IamClient getUser function. It said that the AccessDeniedException class didn't exist. This commit adds the file, following the standards of the other AWS Exception classes.