### PR TITLE
Throw an exception when attempting to serialize an AwsClient

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -273,6 +273,12 @@ class AwsClient implements AwsClientInterface
         return new Waiter($this, $name, $args, $config);
     }
 
+    public function __sleep()
+    {
+        throw new \RuntimeException('Instances of ' . static::class
+            . ' cannot be serialized');
+    }
+
     /**
      * Get the signature_provider function of the client.
      *

--- a/tests/AwsClientTest.php
+++ b/tests/AwsClientTest.php
@@ -322,4 +322,14 @@ class AwsClientTest extends \PHPUnit_Framework_TestCase
             'version'      => 'latest'
         ]);
     }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Instances of Aws\AwsClient cannot be serialized
+     */
+    public function testDoesNotPermitSerialization()
+    {
+        $client = $this->createClient();
+        \serialize($client);
+    }
 }


### PR DESCRIPTION
Clients are not serializable, but the error message produced when attempting to serialize isn't particularly helpful. It's usually `Serialization of 'Closure' is not allowed` or something similar. This PR would short-circuit that attempt and immediately throw a RuntimeException. SDK consumers who need to serialize a client should implement and use a serialization proxy. This resolves #891.

/cc @mtdowling @chrisradek @xibz 