### PR TITLE
Prune docs and examples from the phar and zip

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,4 @@ UPGRADING.md export-ignore
 src/data/*.json export-ignore
 src/data/*/*/*.json export-ignore
 src/data/*/*/docs*.json.php export-ignore
+src/data/*/*/examples*.json.php export-ignore

--- a/build/Burgomaster.php
+++ b/build/Burgomaster.php
@@ -150,17 +150,21 @@ class Burgomaster
      *
      * Any LICENSE file is automatically copied.
      *
-     * @param string $sourceDir  Source directory to copy from
-     * @param string $destDir    Directory to copy the files to that is relative
-     *                           to the the stage base directory.
-     * @param array  $extensions File extensions to copy from the $sourceDir.
-     *                           Defaults to "php" files only (e.g., ['php']).
+     * @param string    $sourceDir  Source directory to copy from
+     * @param string    $destDir    Directory to copy the files to that is relative
+     *                              to the the stage base directory.
+     * @param array     $extensions File extensions to copy from the $sourceDir.
+     *                              Defaults to "php" files only (e.g., ['php']).
+     * @param Iterator|null  $files Files to copy from the source directory, each
+     *                              yielded out as an SplFileInfo object.
+     *                              Defaults to a recursive iterator of $sourceDir
      * @throws \InvalidArgumentException if the source directory is invalid.
      */
     function recursiveCopy(
         $sourceDir,
         $destDir,
-        $extensions = array('php')
+        $extensions = array('php'),
+        Iterator $files = null
     ) {
         if (!realpath($sourceDir)) {
             throw new \InvalidArgumentException("$sourceDir not found");
@@ -172,14 +176,17 @@ class Burgomaster
 
         $sourceDir = realpath($sourceDir);
         $exts = array_fill_keys($extensions, true);
-        $iter = new \RecursiveDirectoryIterator($sourceDir);
-        $iter = new \RecursiveIteratorIterator($iter);
+        if (empty($files)) {
+            $files = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($sourceDir)
+            );
+        }
         $total = 0;
 
         $this->startSection('copy');
         $this->debug("Starting to copy files from $sourceDir");
 
-        foreach ($iter as $file) {
+        foreach ($files as $file) {
             if (isset($exts[$file->getExtension()])
                 || $file->getBaseName() == 'LICENSE'
             ) {

--- a/build/packager.php
+++ b/build/packager.php
@@ -11,7 +11,17 @@ foreach ($metaFiles as $file) {
     $burgomaster->deepCopy($file, $file);
 }
 
-$burgomaster->recursiveCopy('src', 'Aws');
+$sdkFiles = new \RecursiveIteratorIterator(
+    new \RecursiveDirectoryIterator(realpath('src'))
+);
+$sdkFiles = new CallbackFilterIterator($sdkFiles, function (SplFileInfo $file) {
+    return !in_array($file->getBasename('.php'), [
+        'docs-2.json',
+        'examples-1.json',
+    ]);
+});
+
+$burgomaster->recursiveCopy('src', 'Aws', ['php'], $sdkFiles);
 $burgomaster->recursiveCopy('vendor/aws/aws-php-sns-message-validator/src', 'Aws/Sns');
 $burgomaster->recursiveCopy('vendor/mtdowling/jmespath.php/src', 'JmesPath');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/guzzle/src', 'GuzzleHttp');

--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,5 @@
         "branch-alias": {
             "dev-master": "3.0-dev"
         }
-    },
-    "scripts": {
-        "post-autoload-dump": [
-            "make compile-json"
-        ]
     }
 }


### PR DESCRIPTION
This PR updates Burgomaster's recursiveCopy method to take an optional iterator of files to copy, then uses an iterator to exclude docs-2.json.php and examples-1.json.php files from the phar and zip.

This cuts the phar down to 4.2 MB and brings the zip to under 800 KB.