### PR TITLE
Updating validation to be more flexible

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -767,7 +767,7 @@ to the HTTP handler.
 validate
 ~~~~~~~~
 
-:Type: ``bool``
+:Type: ``bool|array``
 :Default: ``bool(true)``
 
 Set to false to disable client-side parameter validation. You may find that
@@ -781,6 +781,23 @@ difference is negligible.
         'version'  => '2006-03-01',
         'region'   => 'eu-west-1',
         'validate' => false
+    ]);
+
+Set to an associative array of validation options to enable specific validation
+constraints:
+
+- ``required`` - Validate that required parameters are present (on by default).
+- ``min`` - Validate the minimum length of a value (on by default).
+- ``max`` - Validate the maximum length of a value.
+- ``pattern`` - Validate that the value matches a regular expression.
+
+.. code-block:: php
+
+    // Validate only that required values are present.
+    $s3 = new Aws\S3\S3Client([
+        'version'  => '2006-03-01',
+        'region'   => 'eu-west-1',
+        'validate' => ['required' => true]
     ]);
 
 

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -119,9 +119,9 @@ class ClientResolver
         ],
         'validate' => [
             'type'    => 'value',
-            'valid'   => ['bool'],
+            'valid'   => ['bool', 'array'],
             'default' => true,
-            'doc'     => 'Set to false to disable client-side parameter validation.',
+            'doc'     => 'Set to false to disable client-side parameter validation. Set to true to utilize default validation constraints. Set to an associative array of validation options to enable specific validation constraints.',
             'fn'      => [__CLASS__, '_apply_validate'],
         ],
         'debug' => [
@@ -419,12 +419,17 @@ class ClientResolver
 
     public static function _apply_validate($value, array &$args, HandlerList $list)
     {
-        if ($value === true) {
-            $list->appendValidate(
-                Middleware::validation($args['api'], new Validator()),
-                'validation'
-            );
+        if ($value === false) {
+            return;
         }
+
+        $validator = $value === true
+            ? new Validator()
+            : new Validator($value);
+        $list->appendValidate(
+            Middleware::validation($args['api'], $validator),
+            'validation'
+        );
     }
 
     public static function _apply_handler($value, array &$args, HandlerList $list)

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -62,9 +62,9 @@ final class Middleware
      *
      * @return callable
      */
-    public static function validation(Service $api)
+    public static function validation(Service $api, Validator $validator = null)
     {
-        $validator = new Validator();
+        $validator = $validator ?: new Validator();
         return function (callable $handler) use ($api, $validator) {
             return function (
                 CommandInterface $command,


### PR DESCRIPTION
This commit updates the SDK to allow customers to configure exactly what
they want to validate client side. I've added the ability to provide
validation constraints as feature flags to a Validator and to the
validate client option. This commit also updates the SDK to no longer
validate "max" by default.

@jeskew 