### PR TITLE
Change formatId() to protected in the DynamoDB SessionHandler

### DIFF
--- a/src/DynamoDb/SessionHandler.php
+++ b/src/DynamoDb/SessionHandler.php
@@ -220,7 +220,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return string Prepared session ID.
      */
-    private function formatId($id)
+    protected function formatId($id)
     {
         return trim($this->sessionName . '_' . $id, '_');
     }


### PR DESCRIPTION
Allowing it to be overridden in classes that extend Aws\DynamoDb\SessionHandler.

We have a use case for this where we need to use a different table key value to PHP's session name. Whist this can be achieved with most methods by extending SessionHandler, then amending $id before passing it to parent::, this does not work with close() as it directly access session_id().