### PR TITLE
Disable content decoding on HeadObject

### DIFF
--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -825,7 +825,7 @@ EOXML;
         $this->assertSame('test/yearmonth=201601/', $response['CommonPrefixes'][0]['Prefix']);
     }
 
-    public function testListObjectsDoesUrlDecodeEncodedKeysWhenEncodingSupplied()
+    public function testListObjectsDoesNotUrlDecodeEncodedKeysWhenEncodingSupplied()
     {
         $client = new S3Client([
             'version' => 'latest',
@@ -866,5 +866,21 @@ EOXML;
     </CommonPrefixes>
 </ListBucketResult>
 EOXML;
+    }
+
+    public function testHeadObjectDisablesContentDecodingByDefault()
+    {
+        $client = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-west-2',
+            'http_handler' => function (RequestInterface $r, array $opts = []) {
+                $this->assertArrayHasKey('decode_content', $opts);
+                $this->assertSame(false, $opts['decode_content']);
+
+                return Promise\promise_for(new Response);
+            }
+        ]);
+
+        $client->headObject(['Bucket' => 'bucket', 'Key' => 'key']);
     }
 }


### PR DESCRIPTION
This PR sets 'decode_content' to `false` on HeadObject requests. If an object has a content-encoding of 'gzip' or 'deflate,' leaving 'decode_content' unset will cause the 'ContentLength' and 'ContentEncoding' headers to be swallowed.

/cc @mtdowling @chrisradek @xibz 