### PR TITLE
Updated Api/Validator Class to adhere to PHP array-keys casting

### DIFF
--- a/src/Api/Validator.php
+++ b/src/Api/Validator.php
@@ -241,7 +241,11 @@ class Validator
 
     private function checkAssociativeArray($value)
     {
-        if (!is_array($value) || isset($value[0])) {
+        // String array-keys containing valid integers will be cast to the integer type. E.g. the key "8" will actually
+        // be stored under 8. On the other hand "08" will not be cast, as it isn't a valid decimal integer.
+        // @see http://php.net/manual/en/language.types.array.php#example-97
+        // Here we can not simply check `isset($value[0])` to distinguish between associative or sequential arrays.
+        if (!is_array($value) || isset($value[NULL])) {
             $this->addError('must be an associative array. Found '
                 . Aws\describe_type($value));
             return false;

--- a/tests/Api/ValidatorTest.php
+++ b/tests/Api/ValidatorTest.php
@@ -143,7 +143,63 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                     'members' => ['foo' => ['type' => 'structure']]
                 ],
                 ['foo' => [1, 3]],
-                "Found 1 error while validating the input provided for the Foo operation:\n[foo] must be an associative array. Found array(2)"
+                true
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => ['0' => 1, '1'=> 3]],
+                true
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => ['0' => 1, 'bar'=> 3]],
+                true
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => [0 => 1, 'bar'=> 3]],
+                true
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => [0, 1]],
+                true
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => NULL],
+                "Found 1 error while validating the input provided for the Foo operation:\n[foo] must be an associative array. Found NULL"
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => [null => 'a']],
+                "Found 1 error while validating the input provided for the Foo operation:\n[foo] must be an associative array. Found array(1)"
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => ['' => 'a']],
+                "Found 1 error while validating the input provided for the Foo operation:\n[foo] must be an associative array. Found array(1)"
             ],
             [
                 [
@@ -210,7 +266,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
                     ]
                 ],
                 ['foo' => ['abc']],
-                "Found 1 error while validating the input provided for the Foo operation:\n[foo] must be an associative array. Found array(1)"
+                true,
             ],
             [
                 [


### PR DESCRIPTION
The current code of `Validator::checkAssociativeArray($value)` is not correctly identifying associative arrays where keys are strings containing valid integer numbers.
See http://php.net/manual/en/language.types.array.php#example-97 for an example of array-keys casting.

As an example, take the following associative array:
```
$a = [
  '0' => 'a',
  'two' => 'b',
];
```

The current function is wrongly report that it is not an associative array, given that $a[0] is set.