### PR TITLE
Return a rejection from Middleware::timer rejection handler.

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -342,7 +342,7 @@ final class Middleware
                                     'total_time' => microtime(true) - $start,
                                 ] + $err->getTransferInfo());
                             }
-                            return $err;
+                            return Promise\rejection_for($err);
                         }
                     );
             };


### PR DESCRIPTION
The timer middleware released recently included a bug where the rejection handler returned an exception rather than throwing it or returning a rejected promise.

/cc @cjyclaire @xibz @chrisradek 