### PR TITLE
Fix non-sequential keys when SetValue with duplicates is de-duped

### DIFF
--- a/src/DynamoDb/Marshaler.php
+++ b/src/DynamoDb/Marshaler.php
@@ -179,7 +179,7 @@ class Marshaler
                 $data[] = current($marshaled);
             }
 
-            return [$previousType . 'S' => array_unique($data)];
+            return [$previousType . 'S' => array_values(array_unique($data))];
         }
 
         // Handle list and map values.

--- a/tests/DynamoDb/MarshalerTest.php
+++ b/tests/DynamoDb/MarshalerTest.php
@@ -174,6 +174,7 @@ class MarshalerTest extends \PHPUnit_Framework_TestCase
                 $m->set([$m->binary('a'), $m->binary('b'), $m->binary('c')]),
                 ['BS' => ['a', 'b', 'c']]
             ],
+            [$m->set(['a', 'b', 'b', 'c']), ['SS' => ['a', 'b', 'c']]],
             [$m->set([]), self::ERROR],
 
                 // Errors


### PR DESCRIPTION
When marshaling a SetValue, the set is de-duped, but the process of de-duping leaves the keys in a state where json_encode will treat the set as an associative array making DynamoDB queries fail. Wrapping around array_values fixes this.