### PR TITLE
Fix wrong tree hash if content is a single zero

### DIFF
--- a/src/Glacier/TreeHash.php
+++ b/src/Glacier/TreeHash.php
@@ -81,7 +81,7 @@ class TreeHash implements HashInterface
     {
         if (!$this->hash) {
             // Clear out the remaining buffer.
-            if ($this->buffer) {
+            if (strlen($this->buffer) > 0) {
                 $this->checksums[] = hash($this->algorithm, $this->buffer, true);
                 $this->buffer = '';
             }

--- a/tests/Glacier/TreeHashTest.php
+++ b/tests/Glacier/TreeHashTest.php
@@ -84,4 +84,17 @@ class TreeHashTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(TreeHash::EMPTY_HASH, bin2hex($hash->complete()));
     }
+
+    /**
+     * @covers Aws\Glacier\TreeHash::complete
+     */
+    public function testCanCalculateHashForSingleZero()
+    {
+        $data = "0";
+
+        $hash = new TreeHash('sha256');
+        $hash->update($data);
+
+        $this->assertEquals(hash('sha256', $data, true), $hash->complete());
+    }
 }


### PR DESCRIPTION
When you tried to calculate the tree hash of the string "0" (without quotes), you got the hash `TreeHash::EMPTY_HASH` instead of the expected `5feceb66ffc86f38d952786c6d696c79c2dbc239dd4e91b46729d73a27fb57e9`.