### PR TITLE
Make the input for an API example optional

### DIFF
--- a/build/docs/classes/CodeSnippetGenerator.php
+++ b/build/docs/classes/CodeSnippetGenerator.php
@@ -20,16 +20,25 @@ class CodeSnippetGenerator
         $this->service = $service;
     }
 
-    public function __invoke($operation, $params, $comments, $isInput = true)
+    public function generateInput($operation, $params, $comments)
     {
-        $messageShape = $isInput
-            ? $this->service->getOperation($operation)->getInput()
-            : $this->service->getOperation($operation)->getOutput();
+        $messageShape = $this->service->getOperation($operation)->getInput();
         $code = $this->visit($messageShape, $params, '', [], $comments);
 
+        return "\$result = \$client->" . lcfirst($operation) . "($code);";
+    }
+
+    public function generateOutput($operation, $params, $comments)
+    {
+        $messageShape = $this->service->getOperation($operation)->getOutput();
+        return $this->visit($messageShape, $params, '', [], $comments);
+    }
+
+    public function __invoke($operation, $params, $comments, $isInput = true)
+    {
         return $isInput
-            ? "\$result = \$client->" . lcfirst($operation) . "($code);"
-            : $code;
+            ? $this->generateInput($operation, $params, $comments)
+            : $this->generateOutput($operation, $params, $comments);
     }
 
     private function visit(Shape $shape, $value, $indent, $path, $comments)

--- a/build/docs/classes/DocsBuilder.php
+++ b/build/docs/classes/DocsBuilder.php
@@ -686,10 +686,18 @@ EOT;
                 $html->close();
                 $html->elem('p', null, $example['description']);
                 $comments = $example['comments'];
-                $html->elem('pre', null, $generator($name, $example['input'], $comments['input']));
+                $html->elem('pre', null, $generator->generateInput(
+                    $name, 
+                    isset($example['input']) ? $example['input'] : [], 
+                    isset($comments['input']) ? $comments['input'] : []
+                ));
                 if (isset($example['output'])) {
                     $html->elem('p', null, 'Result syntax:');
-                    $html->elem('pre', null, $generator($name, $example['output'], $comments['output'], false));
+                    $html->elem('pre', null, $generator->generateOutput(
+                        $name, 
+                        $example['output'], 
+                        $comments['output']
+                    ));
                 }
             }
         }


### PR DESCRIPTION
The ElasticBeanstalk examples cover operations that do not have an input shape defined. This PR makes the example generator use an empty array when no example input is defined.

/cc @cjyclaire 