### PR TITLE
Refresh credentials as a set when signing requests

### DIFF
--- a/src/Aws/Common/Credentials/AbstractRefreshableCredentials.php
+++ b/src/Aws/Common/Credentials/AbstractRefreshableCredentials.php
@@ -22,6 +22,25 @@ namespace Aws\Common\Credentials;
 abstract class AbstractRefreshableCredentials extends AbstractCredentialsDecorator
 {
     /**
+     * Get the underlying credentials, refreshing if necessary.
+     *
+     * @return Credentials
+     */
+    public function getCredentials()
+    {
+        if ($this->credentials->isExpired()) {
+            $this->refresh();
+        }
+
+        return new Credentials(
+            $this->credentials->getAccessKeyId(),
+            $this->credentials->getSecretKey(),
+            $this->credentials->getSecurityToken(),
+            $this->credentials->getExpiration()
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getAccessKeyId()

--- a/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
+++ b/src/Aws/Common/Credentials/RefreshableInstanceProfileCredentials.php
@@ -40,7 +40,7 @@ class RefreshableInstanceProfileCredentials extends AbstractRefreshableCredentia
      */
     public function __construct(CredentialsInterface $credentials, InstanceMetadataClient $client = null)
     {
-        $this->credentials = $credentials;
+        parent::__construct($credentials);
         $this->setClient($client);
     }
 
@@ -82,10 +82,10 @@ class RefreshableInstanceProfileCredentials extends AbstractRefreshableCredentia
     protected function refresh()
     {
         $credentials = $this->client->getInstanceProfileCredentials();
-        // Expire the token 30 minutes early to pre-fetch before expiring.
+        // Expire the token 5 minutes early to pre-fetch before expiring.
         $this->credentials->setAccessKeyId($credentials->getAccessKeyId())
             ->setSecretKey($credentials->getSecretKey())
             ->setSecurityToken($credentials->getSecurityToken())
-            ->setExpiration($credentials->getExpiration() - 1800);
+            ->setExpiration($credentials->getExpiration() - 300);
     }
 }

--- a/src/Aws/Common/Signature/SignatureListener.php
+++ b/src/Aws/Common/Signature/SignatureListener.php
@@ -16,6 +16,7 @@
 
 namespace Aws\Common\Signature;
 
+use Aws\Common\Credentials\AbstractRefreshableCredentials;
 use Aws\Common\Credentials\CredentialsInterface;
 use Aws\Common\Credentials\NullCredentials;
 use Guzzle\Common\Event;
@@ -76,8 +77,12 @@ class SignatureListener implements EventSubscriberInterface
      */
     public function onRequestBeforeSend(Event $event)
     {
-        if(!$this->credentials instanceof NullCredentials) {
-            $this->signature->signRequest($event['request'], $this->credentials);
+        $creds = $this->credentials instanceof AbstractRefreshableCredentials
+            ? $this->credentials->getCredentials()
+            : $this->credentials;
+
+        if(!$creds instanceof NullCredentials) {
+            $this->signature->signRequest($event['request'], $creds);
         }
     }
 }

--- a/tests/Aws/Tests/Common/Credentials/AbstractRefreshableCredentialsTest.php
+++ b/tests/Aws/Tests/Common/Credentials/AbstractRefreshableCredentialsTest.php
@@ -41,4 +41,24 @@ class AbstractRefreshableCredentialsTest extends \Guzzle\Tests\GuzzleTestCase
         $mock->getSecurityToken();
         $mock->serialize();
     }
+
+    public function testCanReturnRefreshedCredentialsInSingleTransaction()
+    {
+        $c = new Credentials('a', 'b', 'c', 10);
+
+        $mock = $this->getMockBuilder('Aws\\Common\\Credentials\\AbstractRefreshableCredentials')
+            ->setConstructorArgs(array($c))
+            ->setMethods(array('refresh'))
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('refresh');
+
+        /** @var $mock \Aws\Common\Credentials\AbstractRefreshableCredentials */
+        $newCreds = $mock->getCredentials();
+        $this->assertInstanceOf('\Aws\Common\Credentials\CredentialsInterface', $newCreds);
+        $this->assertSame($c->getAccessKeyId(), $newCreds->getAccessKeyId());
+        $this->assertSame($c->getSecretKey(), $newCreds->getSecretKey());
+        $this->assertSame($c->getSecurityToken(), $newCreds->getSecurityToken());
+    }
 }

--- a/tests/Aws/Tests/Common/Credentials/RefreshableInstanceProfileCredentialsTest.php
+++ b/tests/Aws/Tests/Common/Credentials/RefreshableInstanceProfileCredentialsTest.php
@@ -48,8 +48,8 @@ class RefreshableInstanceProfileCredentialsTest extends \Guzzle\Tests\GuzzleTest
 
         $credentials->getSecurityToken();
 
-        // Should expire 30 minutes before the returned expiration date.
-        $this->assertEquals(1904598340, $credentials->getExpiration());
+        // Should expire 5 minutes before the returned expiration date.
+        $this->assertEquals(1904599840, $credentials->getExpiration());
 
         $mockedRequests = $mock->getReceivedRequests();
         $this->assertEquals(2, count($mockedRequests));


### PR DESCRIPTION
This PR addresses the same issue as https://github.com/boto/botocore/pull/764. In v2 of the SDK, if refreshable credentials expire during the signing process, the key, secret, and token may be pulled from different credential sets, as a call to `->refresh()` can be triggered by credentials being expired during calls to `->getAccessKeyId()`, `->getSecretKey()`, `->getSecurityToken()`. This PR updates the signature listener to instead get credentials using an atomic `->getCredentials()` method, which provides only a single opportunity for a refresh.

/cc @mtdowling @cjyclaire 