### PR TITLE
Lowercase signed header names in presigned request

### DIFF
--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -83,7 +83,7 @@ class SignatureV4 implements SignatureInterface
         $parsed['query']['X-Amz-Algorithm'] = 'AWS4-HMAC-SHA256';
         $parsed['query']['X-Amz-Credential'] = $credential;
         $parsed['query']['X-Amz-Date'] = gmdate('Ymd\THis\Z', time());
-        $parsed['query']['X-Amz-SignedHeaders'] = 'Host';
+        $parsed['query']['X-Amz-SignedHeaders'] = 'host';
         $parsed['query']['X-Amz-Expires'] = $this->convertExpires($expires);
         $context = $this->createContext($parsed, $payload);
         $stringToSign = $this->createStringToSign($httpDate, $scope, $context['creq']);

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -142,6 +142,23 @@ class SignatureV4Test extends \PHPUnit_Framework_TestCase
         $signature->presign($request, $credentials, 'December 31, 2013 00:00:00 UTC');
     }
 
+    public function testPresignerDowncasesSignedHeaderNames()
+    {
+        $_SERVER['override_v4_time'] = true;
+        list($request, $credentials, $signature) = $this->getFixtures();
+        $credentials = new Credentials('foo', 'bar', '123');
+        $query = Psr7\parse_query(
+            $signature->presign($request, $credentials, 1386720000)
+                ->getUri()
+                ->getQuery()
+        );
+        $this->assertArrayHasKey('X-Amz-SignedHeaders', $query);
+        $this->assertSame(
+            strtolower($query['X-Amz-SignedHeaders']),
+            $query['X-Amz-SignedHeaders']
+        );
+    }
+
     public function testConvertsPostToGet()
     {
         $request = new Request(


### PR DESCRIPTION
This PR changes the `X-Amz-SignedHeaders` value from 'Host' to 'host' to match [the spec](http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html) and [the Ruby SDK's implementation](https://github.com/aws/aws-sdk-ruby/blob/ef9f2d3655c4bacb3adff580a6b295df510f78fe/aws-sdk-core/lib/aws-sdk-core/signers/v4.rb#L183). This resolves #951.

/cc @mtdowling @cjyclaire 