### PR TITLE
Document limitations of copy method wrt stream wrapper

### DIFF
--- a/docs/service/s3-stream-wrapper.rst
+++ b/docs/service/s3-stream-wrapper.rst
@@ -194,16 +194,17 @@ rename()        Rename an object by copying the object then deleting the
                 ``CopyObject`` and ``DeleteObject`` operations to the stream
                 context parameters to modify how the object is copied and
                 deleted.
-copy()          Copy an object from one location to another. You can pass
-                options available to the ``CopyObject`` operation into the
-                stream context options to modify how the object is copied.
-
-                .. code-block:: php
-
-                    // Copy a file on Amazon S3 to another bucket
-                    copy('s3://bucket/key', 's3://other_bucket/key');
 
 =============== ================================================================
+
+
+.. note::
+
+    While ``copy`` will generally work with the S3 stream wrapper, some errors
+    may not be properly reported due to the internals of the ``copy`` function
+    in PHP. It is recommended that you use an instance of `Aws\S3\ObjectCopier
+    <http://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.S3.ObjectCopier.html>`_
+    instead.
 
 
 Working with buckets
@@ -219,8 +220,8 @@ Here's an example of creating a bucket:
     mkdir('s3://bucket');
 
 You can pass in stream context options to the ``mkdir()`` method to modify how
-the bucket is created using the parameters available to the
-`CreateBucket <http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_createBucket>`_
+the bucket is created using the parameters available to the `CreateBucket
+<http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_createBucket>`_
 operation.
 
 .. code-block:: php

--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -1,7 +1,11 @@
 <?php
 namespace Aws\S3;
 
+use Aws\Exception\MultipartUploadException;
+use Aws\Result;
+use Aws\S3\Exception\S3Exception;
 use GuzzleHttp\Promise\PromisorInterface;
+use InvalidArgumentException;
 
 /**
  * Copies objects from one S3 location to another, utilizing a multipart copy
@@ -42,6 +46,8 @@ class ObjectCopier implements PromisorInterface
      *                                          (default: private).
      * @param array             $options        Options used to configure the
      *                                          copy process.
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct(
         S3ClientInterface $client,
@@ -60,6 +66,13 @@ class ObjectCopier implements PromisorInterface
         $this->options = $options + self::$defaults;
     }
 
+    /**
+     * Perform the configured copy asynchronously. Returns a promise that is
+     * fulfilled with the result of the CompleteMultipartUpload or CopyObject
+     * operation or rejected with an exception.
+     *
+     * @return \GuzzleHttp\Promise\Promise
+     */
     public function promise()
     {
         return \GuzzleHttp\Promise\coroutine(function () {
@@ -94,6 +107,15 @@ class ObjectCopier implements PromisorInterface
         });
     }
 
+    /**
+     * Perform the configured copy synchronously. Returns the result of the
+     * CompleteMultipartUpload or CopyObject operation.
+     *
+     * @return Result
+     *
+     * @throws S3Exception
+     * @throws MultipartUploadException
+     */
     public function copy()
     {
         return $this->promise()->wait();


### PR DESCRIPTION
`copy` cannot accurately report failure when the target is an S3 path. This PR adds a note to the stream wrapper guide to that effect.

/cc @cjyclaire @xibz 