### PR TITLE
Presign without signing

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -21,3 +21,6 @@ default:
         streams:
             paths: [ %paths.base%/features/streams ]
             contexts: [ Aws\Test\Integ\NativeStreamContext ]
+        s3:
+            paths: [ %paths.base%/features/s3 ]
+            contexts: [ Aws\Test\Integ\S3Context ]

--- a/features/bootstrap/Aws/Test/Integ/S3Context.php
+++ b/features/bootstrap/Aws/Test/Integ/S3Context.php
@@ -1,0 +1,1 @@
+../../../../../tests/Integ/S3Context.php

--- a/features/s3/presignedUrls.feature
+++ b/features/s3/presignedUrls.feature
@@ -1,0 +1,33 @@
+@s3 @integ
+Feature: Pre-signed URLs
+
+  Scenario: Get an object with a pre-signed request
+    Given I have uploaded an object to S3 with a key of "file.ext" and a body of "abc123"
+    When I create a pre-signed request for a "GetObject" command with:
+      | key | value    |
+      | Key | file.ext |
+    Then the contents of the response to the presigned request should be "abc123"
+
+  Scenario: Put an object with a pre-signed request
+    Given I create a pre-signed request for a "PutObject" command with:
+      | key           | value            |
+      | Key           | foo.bar          |
+      | Body          | xxx_yyy_zzz      |
+    And I send the pre-signed request
+    When I create a pre-signed request for a "GetObject" command with:
+      | key | value   |
+      | Key | foo.bar |
+    Then the contents of the response to the presigned request should be "xxx_yyy_zzz"
+
+  Scenario: Put an unsigned object with a pre-signed request
+    Given I create a pre-signed request for a "PutObject" command with:
+      | key           | value            |
+      | Key           | foo.bar          |
+      | Body          | xxx_yyy_zzz      |
+      | ContentSha256 | UNSIGNED PAYLOAD |
+    And I change the body of the pre-signed request to be "zzz_yyy_xxx"
+    And I send the pre-signed request
+    When I create a pre-signed request for a "GetObject" command with:
+      | key | value   |
+      | Key | foo.bar |
+    Then the contents of the response to the presigned request should be "zzz_yyy_xxx"

--- a/src/Command.php
+++ b/src/Command.php
@@ -34,6 +34,11 @@ class Command implements CommandInterface
         }
     }
 
+    public function __clone()
+    {
+        $this->handlerList = clone $this->handlerList;
+    }
+
     public function getName()
     {
         return $this->name;

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -219,6 +219,8 @@ class S3Client extends AwsClient implements S3ClientInterface
 
     public function createPresignedRequest(CommandInterface $command, $expires)
     {
+        $command->getHandlerList()->remove('signer');
+
         /** @var \Aws\Signature\SignatureInterface $signer */
         $signer = call_user_func(
             $this->getSignatureProvider(),

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -16,6 +16,7 @@ use Aws\CommandInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Client used to interact with **Amazon Simple Storage Service (Amazon S3)**.
@@ -219,6 +220,7 @@ class S3Client extends AwsClient implements S3ClientInterface
 
     public function createPresignedRequest(CommandInterface $command, $expires)
     {
+        $command = clone $command;
         $command->getHandlerList()->remove('signer');
 
         /** @var \Aws\Signature\SignatureInterface $signer */

--- a/src/Signature/S3SignatureV4.php
+++ b/src/Signature/S3SignatureV4.php
@@ -27,6 +27,24 @@ class S3SignatureV4 extends SignatureV4
     }
 
     /**
+     * Always add a x-amz-content-sha-256 for data integrity.
+     */
+    public function presign(
+        RequestInterface $request,
+        CredentialsInterface $credentials,
+        $expires
+    ) {
+        if (!$request->hasHeader('x-amz-content-sha256')) {
+            $request = $request->withHeader(
+                'X-Amz-Content-Sha256',
+                $this->getPresignedPayload($request)
+            );
+        }
+
+        return parent::presign($request, $credentials, $expires);
+    }
+
+    /**
      * Override used to allow pre-signed URLs to be created for an
      * in-determinate request payload.
      */

--- a/tests/Ec2/CopySnapshotMiddlewareTest.php
+++ b/tests/Ec2/CopySnapshotMiddlewareTest.php
@@ -1,8 +1,11 @@
 <?php
 namespace Aws\Test\Ec2;
 
+use Aws\CommandInterface;
 use Aws\Ec2\Ec2Client;
+use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @covers Aws\Ec2\CopySnapshotMiddleware
@@ -27,20 +30,22 @@ class CopySnapshotMiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $ec2 = new Ec2Client([
             'region'  => 'us-east-2',
-            'version' => 'latest'
+            'version' => 'latest',
+            'handler' => function (CommandInterface $cmd, RequestInterface $r) {
+                $url = $cmd['PresignedUrl'];
+                $this->assertNotNull($url);
+                $this->assertContains('https://ec2.eu-west-1.amazonaws.com', $url);
+                $this->assertContains('SourceSnapshotId=foo', $url);
+                $this->assertContains('SourceRegion=eu-west-1', $url);
+                $this->assertContains('X-Amz-Signature=', $url);
+                $this->assertSame('us-east-2', $cmd['DestinationRegion']);
+
+                return new Result;
+            },
         ]);
-        $this->addMockResults($ec2, [[], []]);
-        $cmd = $ec2->getCommand('CopySnapshot', [
+        $ec2->copySnapshot([
             'SourceRegion'     => 'eu-west-1',
-            'SourceSnapshotId' => 'foo'
+            'SourceSnapshotId' => 'foo',
         ]);
-        $ec2->execute($cmd);
-        $url = $cmd['PresignedUrl'];
-        $this->assertNotNull($url);
-        $this->assertContains('https://ec2.eu-west-1.amazonaws.com', $url);
-        $this->assertContains('SourceSnapshotId=foo', $url);
-        $this->assertContains('SourceRegion=eu-west-1', $url);
-        $this->assertContains('X-Amz-Signature=', $url);
-        $this->assertSame('us-east-2', $cmd['DestinationRegion']);
     }
 }

--- a/tests/Integ/S3Context.php
+++ b/tests/Integ/S3Context.php
@@ -1,0 +1,119 @@
+<?php
+namespace Aws\Test\Integ;
+
+use Behat\Behat\Tester\Exception\PendingException;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7;
+use PHPUnit_Framework_Assert as Assert;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class S3Context implements Context, SnippetAcceptingContext
+{
+    use IntegUtils;
+
+    /** @var RequestInterface */
+    private $presignedRequest;
+
+    /**
+     * @BeforeSuite
+     */
+    public static function createTestBucket()
+    {
+        $client = self::getSdk()->createS3();
+        if (!$client->doesBucketExist(self::getResourceName())) {
+            $client->createBucket(['Bucket' => self::getResourceName()]);
+            $client->waitUntil('BucketExists', [
+                'Bucket' => self::getResourceName(),
+            ]);
+        }
+    }
+
+    /**
+     * @AfterSuite
+     */
+    public static function deleteTestBucket()
+    {
+        $client = self::getSdk()->createS3();
+        $client->deleteMatchingObjects(self::getResourceName(), '', '//');
+        $client->deleteBucket(['Bucket' => self::getResourceName()]);
+        $client->waitUntil('BucketNotExists', [
+            'Bucket' => self::getResourceName(),
+        ]);
+    }
+
+    private static function getResourceName()
+    {
+        static $bucketName;
+
+        if (empty($bucketName)) {
+            $bucketName = self::getResourcePrefix() . '-'
+                . preg_replace('/\W/', '-', self::class);
+        }
+
+        return $bucketName;
+    }
+
+    /**
+     * @Given I have uploaded an object to S3 with a key of :key and a body of :body
+     */
+    public function iHaveUploadedThatStringToSWithAKeyOfAndABodyOf($key, $body)
+    {
+        self::getSdk()
+            ->createS3()
+            ->putObject([
+                'Bucket' => self::getResourceName(),
+                'Key' => $key,
+                'Body' => $body,
+            ]);
+    }
+
+    /**
+     * @When I create a pre-signed request for a :command command with:
+     */
+    public function iCreateAPreSignedUrlForACommandWith(
+        $commandName,
+        TableNode $table
+    ) {
+        $args = ['Bucket' => self::getResourceName()];
+        foreach ($table as $row) {
+            $args[$row['key']] = $row['value'];
+        }
+        $client = self::getSdk()->createS3();
+        $command = $client->getCommand($commandName, $args);
+        $this->presignedRequest = $client
+            ->createPresignedRequest($command, '+1 hour');
+    }
+
+    /**
+     * @Then the contents of the response to the presigned request should be :body
+     */
+    public function theContentsAtThePresignedUrlShouldBe($body)
+    {
+        Assert::assertSame(
+            $body,
+            file_get_contents((string) $this->presignedRequest->getUri())
+        );
+    }
+
+    /**
+     * @Given I send the pre-signed request
+     */
+    public function iSendThePreSignedRequest()
+    {
+        (new Client)->send($this->presignedRequest);
+    }
+
+    /**
+     * @Given I change the body of the pre-signed request to be :body
+     */
+    public function iChangeTheBodyOfThePreSignedRequestToBe($body)
+    {
+        $this->presignedRequest = $this->presignedRequest
+            ->withBody(Psr7\stream_for($body));
+    }
+}


### PR DESCRIPTION
When creating presigned URLs, requests are first signed with `Middleware::signer` and then presigned. This PR updates the `createPresignedRequest` method to remove the signing middleware before serializing the command into a request. It also adds some presigned URL integ tests to make sure everything's hunky-dory.

Resolves #954.

/cc @mtdowling @xibz @cjyclaire 