### PR TITLE
Clear stat cache on stream_flush

### DIFF
--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -174,6 +174,7 @@ class StreamWrapper
             $params['ContentType'] = $type;
         }
 
+        $this->clearCacheKey("s3://{$params['Bucket']}/{$params['Key']}");
         return $this->boolCall(function () use ($params) {
             return (bool) $this->getClient()->putObject($params);
         });

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -510,6 +510,18 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0040777, $stat['mode']);
     }
 
+    public function testStatDataIsClearedOnWrite()
+    {
+        $this->cache->set('s3://foo/bar', ['size' => 123, 7 => 123]);
+        $this->assertEquals(123, filesize('s3://foo/bar'));
+        $this->addMockResults($this->client, [
+            new Result,
+            new Result(['ContentLength' => 124])
+        ]);
+        file_put_contents('s3://foo/bar', 'baz!');
+        $this->assertEquals(124, filesize('s3://foo/bar'));
+    }
+
     public function testCanPullStatDataFromCache()
     {
         $this->cache->set('s3://foo/bar', ['size' => 123, 7 => 123]);


### PR DESCRIPTION
This PR updates the StreamWrapper wipe the cached stats on a path when writing new data to S3 in `stream_flush`. Previously, the stat would be cached in PHP stat cache and in the internal cache.

/cc @xibz @cjyclaire @mtdowling 