### PR TITLE
Do not attempt to parse the response body when no output shape is defined in JSON-RPC

### DIFF
--- a/src/Api/Parser/JsonRpcParser.php
+++ b/src/Api/Parser/JsonRpcParser.php
@@ -30,10 +30,12 @@ class JsonRpcParser extends AbstractParser
         ResponseInterface $response
     ) {
         $operation = $this->api->getOperation($command->getName());
-        $result = $this->parser->parse(
-            $operation->getOutput(),
-            $this->parseJson($response->getBody())
-        );
+        $result = null === $operation['output']
+            ? null
+            : $this->parser->parse(
+                $operation->getOutput(),
+                $this->parseJson($response->getBody())
+            );
 
         return new Result($result ?: []);
     }

--- a/tests/Api/Parser/JsonRpcParserTest.php
+++ b/tests/Api/Parser/JsonRpcParserTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Aws\Test\Api\Parser;
 
-
 use Aws\Api\Operation;
 use Aws\Api\Parser\JsonParser;
 use Aws\Api\Parser\JsonRpcParser;
@@ -9,7 +8,6 @@ use Aws\Api\Service;
 use Aws\Api\Shape;
 use Aws\CommandInterface;
 use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\ResponseInterface;
 
 class JsonRpcParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,6 +49,40 @@ class JsonRpcParserTest extends \PHPUnit_Framework_TestCase
         $result = $instance(
             $this->getMock(CommandInterface::class),
             new Response(200, [], json_encode(null))
+        );
+    }
+    
+    public function testCanHandleEmptyResponses()
+    {
+        $operation = $this->getMockBuilder(Operation::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['offsetGet'])
+            ->getMock();
+        $operation->expects($this->atLeastOnce())
+            ->method('offsetGet')
+            ->with('output')
+            ->willReturn(null);
+
+        $service = $this->getMockBuilder(Service::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getOperation'])
+            ->getMock();
+        $service->expects($this->any())
+            ->method('getOperation')
+            ->withAnyParameters()
+            ->willReturn($operation);
+
+        $parser = $this->getMockBuilder(JsonParser::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['parse'])
+            ->getMock();
+        $parser->expects($this->never())
+            ->method('parse');
+
+        $instance = new JsonRpcParser($service, $parser);
+        $result = $instance(
+            $this->getMock(CommandInterface::class),
+            new Response(200, [])
         );
     }
 }


### PR DESCRIPTION
We already do this for REST-JSON and REST-XML.

/cc @mtdowling @cjyclaire 

