### PR TITLE
Ensure booleans are serialized as strings (not ints) in querystrings

### DIFF
--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -146,6 +146,10 @@ abstract class RestSerializer
                 ? $opts['query'] + $value
                 : $value;
         } elseif ($value !== null) {
+            if ($member->getType() === 'boolean') {
+                $value = $value ? 'true' : 'false';
+            }
+            
             $opts['query'][$member['locationName'] ?: $name] = $value;
         }
     }

--- a/tests/Api/test_cases/protocols/input/rest-json.json
+++ b/tests/Api/test_cases/protocols/input/rest-json.json
@@ -287,6 +287,70 @@
     ]
   },
   {
+    "description": "Boolean in querystring",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "BoolQuery": {
+            "shape": "BoolType",
+            "location": "querystring",
+            "locationName": "bool-query"
+          }
+        }
+      },
+      "BoolType": {
+        "type": "boolean"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": true
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=true",
+          "headers": {}
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": false
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=false",
+          "headers": {}
+        }
+      }
+    ]
+  },
+  {
     "description": "URI parameter and querystring params",
     "metadata": {
       "protocol": "rest-json",

--- a/tests/Api/test_cases/protocols/input/rest-xml.json
+++ b/tests/Api/test_cases/protocols/input/rest-xml.json
@@ -898,7 +898,70 @@
       }
     ]
   },
-
+  {
+    "description": "Boolean in querystring",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "BoolQuery": {
+            "shape": "BoolType",
+            "location": "querystring",
+            "locationName": "bool-query"
+          }
+        }
+      },
+      "BoolType": {
+        "type": "boolean"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": true
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=true",
+          "headers": {}
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "GET",
+            "requestUri": "/path"
+          },
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BoolQuery": false
+        },
+        "serialized": {
+          "body": "",
+          "uri": "/path?bool-query=false",
+          "headers": {}
+        }
+      }
+    ]
+  },
   {
     "description": "String payload",
     "metadata": {


### PR DESCRIPTION
`True` and `false` should serialize to "true" and "false," respectively. They were previously being rendered as "1" and "", which is not how [other SDKs](https://github.com/aws/aws-sdk-go/blob/master/private/protocol/rest/build.go#L244) are handling these values.

/cc @cjyclaire @xibz @mtdowling 