### PR TITLE
Document how to disable content decoding

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -199,3 +199,16 @@ was written for a different version of PHP.
 
 If you encounter a parsing error, please check your system and make sure it
 fulfills the SDK's :doc:`/getting-started/requirements`.
+
+
+Why is the S3 client decompressing gzipped files?
+-------------------------------------------------
+
+Some HTTP handlers -- including the default Guzzle 6 HTTP handler -- will
+inflate compressed response bodies by default. This behavior can be overridden
+by setting the :ref:`http_decode_content` HTTP option to ``false``. For
+backwards compatibility reasons, this default cannot be changed, but it is
+recommended that you disable content decoding at the S3 client level.
+
+See :ref:`http_decode_content` for an example of how to disable automatic
+content decoding.

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -426,6 +426,44 @@ information provided by different HTTP handlers will vary.
   specific PHP stream resource.
 
 
+.. _http_decode_content:
+
+decode_content
+^^^^^^^^^^^^^^
+
+:Type: ``bool``
+
+Instructs the underlying HTTP handler to inflate the body of compressed
+responses. When not enabled, compressed response bodies may be inflated with a
+``GuzzleHttp\Psr7\InflateStream``.
+
+.. note::
+
+    Content decoding is enabled by default in the SDK's default HTTP handler,
+    and for backwards compatibility reasons this default cannot be changed. If
+    you store compressed files in S3, it is recommended that you disable content
+    decoding at the S3 client level.
+
+    .. code-block:: php
+
+        use Aws\S3\S3Client;
+        use GuzzleHttp\Psr7\InflateStream;
+
+        $client = new S3Client([
+            'region'  => 'us-west-2',
+            'version' => 'latest',
+            'http'    => ['decode_content' => false],
+        ]);
+
+        $result = $client->getObject([
+            'Bucket' => 'my-bucket',
+            'Key'    => 'massize_gzipped_file.tgz'
+        ]);
+
+        $compressedBody = $result['Body']; // This content is still gzipped.
+        $inflatedBody = new InflateStream($result['Body']); // This is now readable.
+
+
 .. _http_delay:
 
 delay

--- a/docs/guide/handlers-and-middleware.rst
+++ b/docs/guide/handlers-and-middleware.rst
@@ -468,6 +468,7 @@ to use the following options:
 
 - :ref:`http_connect_timeout`
 - :ref:`http_debug`
+- :ref:`http_decode_content` (optional)
 - :ref:`http_delay`
 - :ref:`http_progress` (optional)
 - :ref:`http_proxy`

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -737,6 +737,43 @@ EOXML;
         $client->headObject(['Bucket' => 'bucket', 'Key' => 'key']);
     }
 
+    public function testContentDecodingCanBeDisabled()
+    {
+        $client = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-west-2',
+            'http' => ['decode_content' => false],
+            'http_handler' => function (RequestInterface $r, array $opts = []) {
+                $this->assertArrayHasKey('decode_content', $opts);
+                $this->assertSame(false, $opts['decode_content']);
+
+                return Promise\promise_for(new Response);
+            }
+        ]);
+
+        $client->getObject(['Bucket' => 'bucket', 'Key' => 'key']);
+    }
+
+    public function testContentDecodingCanBeDisabledOnCommands()
+    {
+        $client = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-west-2',
+            'http_handler' => function (RequestInterface $r, array $opts = []) {
+                $this->assertArrayHasKey('decode_content', $opts);
+                $this->assertSame(false, $opts['decode_content']);
+
+                return Promise\promise_for(new Response);
+            }
+        ]);
+
+        $client->getObject([
+            'Bucket' => 'bucket',
+            'Key' => 'key',
+            '@http' => ['decode_content' => false],
+        ]);
+    }
+
     public function testCanDetermineRegionOfBucket()
     {
         $client = new S3Client([


### PR DESCRIPTION
~~This PR documents Guzzle's `decode_content` option as part of the HTTP handler configuration and defaults it to `false` in the S3 client. This should take care of #986 and any similar issues related to content encoding in S3.~~

This PR documents Guzzle's `decode_content` option as part of the HTTP handler configuration and documents the need to set it to `false` when dealing with compressed objects in S3. I do not believe the
default can be changed due to backwards compatibility concerns.

/cc @xibz @mtdowling @cjyclaire 