### PR TITLE
S3: Transfer - normalize path

### DIFF
--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -328,6 +328,7 @@ class Transfer implements PromisorInterface
 
     private function createS3Key($filename)
     {
+        $filename = $this->normalizePath($filename);
         $relative_file_path = ltrim(
             preg_replace('#^' . preg_quote($this->sourceMetadata['path']) . '#', '', $filename),
             '/\\'


### PR DESCRIPTION
Normalizing filename before comparing with already normalized "base_dir".

(Windows problem)

```
'base_dir' => 'C:\data\example\files'
```

Before:
```
Transferring C:\data\example\files\test\file.txt -> s3://bucket/C:\data\example\files\test\file.txt (PutObject)
```

After:
```
Transferring C:/data/example/files/test/file.txt -> s3://bucket/test/file.txt (PutObject)
```