### PR TITLE
Wrong signature generation on S3 presign request.

### DIFF
--- a/src/Signature/S3SignatureV4.php
+++ b/src/Signature/S3SignatureV4.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\RequestInterface;
  */
 class S3SignatureV4 extends SignatureV4
 {
-    const UNSIGNED_PAYLOAD = 'UNSIGNED PAYLOAD';
+    const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
     
     /**
      * Always add a x-amz-content-sha-256 for data integrity.


### PR DESCRIPTION
In aws documentation unsigned payload string is "UNSIGNED-PAYLOAD", "UNSIGNED PAYLOAD" used before. Resolve #997 #996 
http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
http://docs.aws.amazon.com/AmazonS3/latest/API/bucket-policy-s3-sigv4-conditions.html

