### PR TITLE
Fix a typo in paginator documentation

### DIFF
--- a/docs/guide/paginators.rst
+++ b/docs/guide/paginators.rst
@@ -88,7 +88,7 @@ of a bucket), you could do the following.
     ]);
 
     $expression = '[CommonPrefixes[].Prefix, Contents[].Key][]';
-    foreach ($paginator->search($expression) as $item) {
+    foreach ($results->search($expression) as $item) {
         echo $item . "\n";
     }
 


### PR DESCRIPTION
Fix a typo in documentation for Paginators.

cc:\ @xibz 