### PR TITLE
[Doc only] typo fix & add documentation for retry scheme in FAQ & caching credentials

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -215,7 +215,7 @@ content decoding.
 
 
 How do I disable body signing in S3?
--------------------------------------------------
+------------------------------------
 
 You can disable body signing by setting the ``ContentSHA256`` parameter in
 command object to ``Aws\Signature\S3SignatureV4::UNSIGNED_PAYLOAD``. Then PHP SDK will use it as
@@ -240,3 +240,17 @@ the 'x-amz-content-sha-256' header and the body checksum in the canonical reques
     // Using commands explicitly.
     $command = $s3Client->getCommand('PutObject', $params);
     $result = $s3Client->execute($command);
+
+How is retry scheme handled in PHP SDK?
+---------------------------------------
+
+PHP SDK has a ``RetryMiddleware`` that handles retry behavior. In terms of 5xx HTTP
+status codes for server errors, SDK retries on 500, 502, 503 and 504.
+
+Throttling exceptions including ``RequestLimitExceeded``, ``Throttling``,
+``ProvisionedThroughputExceededException``, ``ThrottlingException``, ``RequestThrottled``
+and ``BandwidthLimitExceeded`` are handled with retries as well.
+
+SDK also integrates exponential delay with backoff and jitter algorithm in retry scheme. Furthermore,
+default retry behavior is configured as ``3`` for all services except dynamoDB, which is ``10``.
+

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -395,7 +395,7 @@ connect_timeout
 ^^^^^^^^^^^^^^^
 
 A float describing the number of seconds to wait while trying to connect to a
-server. Use ``0`` to wait indefinitely (the default behavior).
+server. Use ``60`` to wait indefinitely (the default behavior).
 
 .. code-block:: php
 
@@ -621,7 +621,7 @@ timeout
 
 :Type: ``float``
 
-A float describing the timeout of the request in seconds. Use ``0`` to wait
+A float describing the timeout of the request in seconds. Use ``60`` to wait
 indefinitely (the default behavior).
 
 .. code-block:: php

--- a/docs/service/s3-transfer.rst
+++ b/docs/service/s3-transfer.rst
@@ -204,7 +204,7 @@ a callback passed to its constructor.
         'before' => function (\Aws\Command $command) {
             // Commands can vary for multipart uploads, so check which command
             // is being processed
-            if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload']) {
+            if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload'])){
                 // Set custom cache-control metadata
                 $command['CacheControl'] = 'max-age=3600';
                 // Apply a canned ACL


### PR DESCRIPTION
There are several issues asking for more documentation for SDK retry behavior.
Typo fix for `timeout` behavior, default timeout is 60s, which is configured via `default_socket_timeout` php.ini setting.

cc:\ @mtdowling @xibz @petermoon 