### PR TITLE
Add doc for retry behavior and cached credentials, fix typo.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -215,7 +215,7 @@ content decoding.
 
 
 How do I disable body signing in S3?
--------------------------------------------------
+------------------------------------
 
 You can disable body signing by setting the ``ContentSHA256`` parameter in
 command object to ``Aws\Signature\S3SignatureV4::UNSIGNED_PAYLOAD``. Then PHP SDK will use it as
@@ -240,3 +240,16 @@ the 'x-amz-content-sha-256' header and the body checksum in the canonical reques
     // Using commands explicitly.
     $command = $s3Client->getCommand('PutObject', $params);
     $result = $s3Client->execute($command);
+
+How is retry scheme handled in PHP SDK?
+---------------------------------------
+
+PHP SDK has a ``RetryMiddleware`` that handles retry behavior. In terms of 5xx HTTP
+status codes for server errors, SDK retries on 500, 502, 503 and 504.
+
+Throttling exceptions including ``RequestLimitExceeded``, ``Throttling``,
+``ProvisionedThroughputExceededException``, ``ThrottlingException``, ``RequestThrottled``
+and ``BandwidthLimitExceeded`` are handled with retries as well.
+
+SDK also integrates exponential delay with backoff and jitter algorithm in retry scheme. Furthermore,
+default retry behavior is configured as ``3`` for all services except dynamoDB, which is ``10``.

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -395,7 +395,7 @@ connect_timeout
 ^^^^^^^^^^^^^^^
 
 A float describing the number of seconds to wait while trying to connect to a
-server. Use ``0`` to wait indefinitely (the default behavior).
+server. Use ``60`` to wait indefinitely (the default behavior).
 
 .. code-block:: php
 
@@ -621,7 +621,7 @@ timeout
 
 :Type: ``float``
 
-A float describing the timeout of the request in seconds. Use ``0`` to wait
+A float describing the timeout of the request in seconds. Use ``60`` to wait
 indefinitely (the default behavior).
 
 .. code-block:: php

--- a/docs/guide/credentials.rst
+++ b/docs/guide/credentials.rst
@@ -70,6 +70,10 @@ been configured with an IAM role.
     service. Please check if the service you are using supports temporary
     credentials by reading `AWS Services that Support AWS STS <http://docs.aws.amazon.com/STS/latest/UsingSTS/UsingTokens.html>`_.
 
+    To Avoid hitting metadata service every time, an instance of ``Aws\CacheInterface``
+    can be passed in as the ``'credentials'`` option to a client constructor. This lets SDK
+    use cached instance profile credentials instead. For more information, see ``'credentials'`` `option <http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/configuration.html#credentials>`_.
+
 For more information, see `IAM Roles for Amazon EC2 <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
 
 

--- a/docs/service/s3-transfer.rst
+++ b/docs/service/s3-transfer.rst
@@ -204,7 +204,7 @@ a callback passed to its constructor.
         'before' => function (\Aws\Command $command) {
             // Commands can vary for multipart uploads, so check which command
             // is being processed
-            if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload']) {
+            if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload'])) {
                 // Set custom cache-control metadata
                 $command['CacheControl'] = 'max-age=3600';
                 // Apply a canned ACL


### PR DESCRIPTION
Doc: There are several issues asking for more documentation on SDK retry behavior and caching instance profile credentials.

Typo: Fix for `timeout` behavior, default timeout is 60s, which is configured via `default_socket_timeout` php.ini setting.

cc:\ @mtdowling @xibz @petermoon 