### PR TITLE
Merge args only once when creating client with SDK

### DIFF
--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -194,7 +194,6 @@ class Sdk
         // Get information about the service from the manifest file.
         $service = manifest($name);
         $namespace = $service['namespace'];
-        $args = $this->mergeArgs($namespace, $service, $args);
 
         // Instantiate the client class.
         $client = "Aws\\{$namespace}\\{$namespace}Client";


### PR DESCRIPTION
Currently [Sdk](https://github.com/aws/aws-sdk-php/blob/master/src/Sdk.php#L194) merges args[] twice in creating clients. This PR removes the extra merge. 
issue: #1031 

cc:\ @xibz @mtdowling 