### PR TITLE
Updated version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "~5.3|~6.0.1|~6.1",
-        "guzzlehttp/psr7": "~1.3.1",
-        "guzzlehttp/promises": "~1.0",
-        "mtdowling/jmespath.php": "~2.2"
+        "guzzlehttp/guzzle": "^5.3|^6.0.1",
+        "guzzlehttp/psr7": "^1.3.1",
+        "guzzlehttp/promises": "^1.0",
+        "mtdowling/jmespath.php": "^2.2"
     },
     "require-dev": {
         "ext-openssl": "*",
@@ -29,10 +29,10 @@
         "ext-json": "*",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "phpunit/phpunit": "~4.0|~5.0",
-        "behat/behat": "~3.0",
-        "doctrine/cache": "~1.4",
-        "aws/aws-php-sns-message-validator": "~1.0",
+        "phpunit/phpunit": "^4.0|^5.0",
+        "behat/behat": "^3.0",
+        "doctrine/cache": "^1.4",
+        "aws/aws-php-sns-message-validator": "^1.0",
         "nette/neon": "^2.3",
         "andrewsville/php-token-reflection": "^1.4",
         "psr/cache": "^1.0"


### PR DESCRIPTION
This syntax was originally avoided because it only worked on newer composer versions, but since it's already used in this file anyway, we might as well use it for the rest of them.