### PR TITLE
Add ECS credential into credential chain

### DIFF
--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -67,7 +67,7 @@ class EcsCredentialProvider
     private function request($url)
     {
         $client = $this->client;
-        $request = new Request('GET', new Uri(self::ENV_URI . $url));
+        $request = new Request('GET', new Uri(self::SERVER_URI . $url));
         return $client($request)->then(function (ResponseInterface $response) {
             $result = $this->decodeResult((string) $response->getBody());
             return new Credentials(
@@ -87,9 +87,9 @@ class EcsCredentialProvider
     private function decodeResult($response)
     {
         $result = json_decode($response, true);
-        if ($result['Code'] !== 'Success') {
-            throw new CredentialsException('Unexpected ECS credential value '
-                .  'response code: ' . $result['Code']);
+
+        if (!isset($result['AccessKeyId'])) {
+            throw new CredentialsException('Unexpected ECS credential value');
         }
         return $result;
     }

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -1,0 +1,96 @@
+<?php
+namespace Aws\Credentials;
+
+use Aws\Exception\CredentialsException;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Credential provider that fetches credentials with GET request.
+ * ECS environment variable is used in constructing request URI.
+ */
+class EcsCredentialProvider
+{
+    const SERVER_URI = 'http://169.254.170.2/';
+    const ENV_URI = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+
+    /** @var callable */
+    private $client;
+
+    /**
+     * @param array $config Configuration options
+     */
+    public function __construct(array $config = [])
+    {
+        $this->client = isset($config['client'])
+            ? $config['client'] // internal use only
+            : \Aws\default_http_handler();
+    }
+
+    /**
+     * Load ECS credentials
+     *
+     * @return PromiseInterface
+     */
+    public function __invoke()
+    {
+        return $this->request($this->getEcsUri());
+    }
+
+    /**
+     * Fetch credential URI from ECS environment variable
+     *
+     * @return string Returns ECS URI
+     * @throws CredentialsException If the credential URI path cannot be found
+     */
+    private function getEcsUri()
+    {
+        $creds_uri = getenv(self::ENV_URI);
+
+        if (!$creds_uri) {
+            throw new CredentialsException(
+                "Unable to find an ECS environment variable value for "
+                . self::ENV_URI
+            );
+        }
+        return $creds_uri;
+    }
+
+    /**
+     * @param string $url
+     * @return PromiseInterface Returns a promise that is fulfilled with the
+     *                          body of the response as a string.
+     */
+    private function request($url)
+    {
+        $client = $this->client;
+        $request = new Request('GET', new Uri(self::ENV_URI . $url));
+        return $client($request)->then(function (ResponseInterface $response) {
+            $result = $this->decodeResult((string) $response->getBody());
+            return new Credentials(
+                $result['AccessKeyId'],
+                $result['SecretAccessKey'],
+                $result['Token'],
+                strtotime($result['Expiration'])
+            );
+        })->otherwise(function ($reason) {
+            $msg = $reason->getMessage();
+            throw new CredentialsException(
+                "Error retrieving credential from ECS ($msg)"
+            );
+        });
+    }
+
+    private function decodeResult($response)
+    {
+        $result = json_decode($response, true);
+        if ($result['Code'] !== 'Success') {
+            throw new CredentialsException('Unexpected ECS credential value '
+                .  'response code: ' . $result['Code']);
+        }
+        return $result;
+    }
+}

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -5,6 +5,7 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\LruArrayCache;
 use GuzzleHttp\Promise;
+use Aws\Credentials\EcsCredentialProvider;
 
 /**
  * @covers \Aws\Credentials\CredentialProvider
@@ -249,6 +250,12 @@ EOT;
     {
         $p = CredentialProvider::instanceProfile();
         $this->assertInstanceOf('Aws\Credentials\InstanceProfileProvider', $p);
+    }
+
+    public function testCreatesFromEcsCredentialProvider()
+    {
+        $p = CredentialProvider::ecsCredentials();
+        $this->assertInstanceOf('Aws\Credentials\EcsCredentialProvider', $p);
     }
 
     public function testGetsHomeDirectoryForWindowsUsers()

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -1,0 +1,109 @@
+<?php
+namespace Aws\Test\Credentials;
+
+use Aws\Credentials\EcsCredentialProvider;
+use Aws\Ecs\EcsClient;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @covers Aws\Credentials\EcsCredentialProvider
+ */
+class EcsCredentialProviderTest extends \PHPUnit_Framework_TestCase
+{
+    private $uripath;
+
+    private function clearEnv()
+    {
+        putenv(EcsCredentialProvider::ENV_URI . '=');
+    }
+
+    public function setUp()
+    {
+        $this->uripath = getenv(EcsCredentialProvider::ENV_URI);
+    }
+
+    public function tearDown()
+    {
+        $this->uripath = getenv(EcsCredentialProvider::ENV_URI);
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Unable to find an ECS environment variable value
+     */
+    public function testRejectsIfUriPathIsNotAvailable()
+    {
+        $client = function () use (&$responses) {
+            return Promise\rejection_for([
+                'exception' => new \Exception('error')
+            ]);
+        };
+        $p = new EcsCredentialProvider(['client' => $client]);
+        $p()->wait();
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Unexpected ECS credential value
+     */
+    public function testThrowsExceptionOnInvalidEcsCredential()
+    {
+        $this->getTestCreds(
+            $this->getCredentialArray(null, null, null, null, false)
+        )->wait();
+    }
+
+    public function testLoadsCredentialsAndProfile()
+    {
+        $t = time() + 1000;
+        $c = $this->getTestCreds(
+            $this->getCredentialArray('foo', 'baz', null, "@{$t}")
+        )->wait();
+        $this->assertEquals('foo', $c->getAccessKeyId());
+        $this->assertEquals('baz', $c->getSecretKey());
+        $this->assertEquals(null, $c->getSecurityToken());
+        $this->assertEquals($t, $c->getExpiration());
+    }
+
+    public function testDoesNotRequireConfig()
+    {
+        new EcsCredentialProvider();
+    }
+
+    private function getCredentialArray(
+        $key, $secret, $token = null, $time = null, $success = true
+    ){
+        return [
+            'Code'            => $success ? 'Success' : 'Failed',
+            'AccessKeyId'     => $key,
+            'SecretAccessKey' => $secret,
+            'Token'           => $token,
+            'Expiration'      => $time
+        ];
+    }
+
+    private function getTestCreds($result, Response $more = null)
+    {
+        $responses = [];
+        $responses[] = new Response(200, [], Psr7\stream_for(json_encode($result)));
+        if ($more) {
+            $responses[] = $more;
+        }
+        $this->clearEnv();
+        putenv(EcsCredentialProvider::ENV_URI
+            . '=/latest/credentials?id=7e9114eb-6b2f-426e-908a-7f0a318e1786');
+        $client = function () use (&$responses) {
+            if (empty($responses)) {
+                throw new \Exception('No responses');
+            }
+            return Promise\promise_for(array_shift($responses));
+        };
+        $args['client'] = $client;
+
+        $provider = new EcsCredentialProvider($args);
+        return $provider();
+    }
+}


### PR DESCRIPTION
Add ECS Credential Provider which provides refreshable credentials within Amazon EC2 Container Service containers when enabled. Using ECS credential before fetching credentials from EC2 instance metadata in default credential chain.

cc:\ @mtdowling 