### PR TITLE
Fix CI Warning caused by PHPUnit Api deprecation

### DIFF
--- a/tests/Api/Parser/JsonRpcParserTest.php
+++ b/tests/Api/Parser/JsonRpcParserTest.php
@@ -47,7 +47,7 @@ class JsonRpcParserTest extends \PHPUnit_Framework_TestCase
 
         $instance = new JsonRpcParser($service, $parser);
         $result = $instance(
-            $this->getMock(CommandInterface::class),
+            $this->getMockBuilder(CommandInterface::class)->getMock(),
             new Response(200, [], json_encode(null))
         );
     }
@@ -81,7 +81,7 @@ class JsonRpcParserTest extends \PHPUnit_Framework_TestCase
 
         $instance = new JsonRpcParser($service, $parser);
         $result = $instance(
-            $this->getMock(CommandInterface::class),
+            $this->getMockBuilder(CommandInterface::class)->getMock(),
             new Response(200, [])
         );
     }

--- a/tests/Api/Serializer/ComplianceTest.php
+++ b/tests/Api/Serializer/ComplianceTest.php
@@ -72,7 +72,7 @@ class ComplianceTest extends \PHPUnit_Framework_TestCase
                 return $service->toArray();
             },
             'credentials'  => false,
-            'signature'    => $this->getMock('Aws\Signature\SignatureInterface'),
+            'signature'    => $this->getMockBuilder('Aws\Signature\SignatureInterface')->getMock(),
             'region'       => 'us-west-2',
             'endpoint'     => $ep,
             'error_parser' => Service::createErrorParser($service->getProtocol()),

--- a/tests/DoctrineCacheAdapterTest.php
+++ b/tests/DoctrineCacheAdapterTest.php
@@ -9,7 +9,7 @@ class DoctrineCacheAdapterTest extends \PHPUnit_Framework_TestCase
 {
     public function testProxiesCallsToDoctrine()
     {
-        $wrappedCache = $this->getMock(Cache::class);
+        $wrappedCache = $this->getMockBuilder(Cache::class)->getMock();
 
         $wrappedCache->expects($this->once())
             ->method('fetch')
@@ -32,7 +32,7 @@ class DoctrineCacheAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testAdaptsCacheToAwsAndDoctrine()
     {
-        $wrappedCache = $this->getMock(Cache::class);
+        $wrappedCache = $this->getMockBuilder(Cache::class)->getMock();
         $cache = new DoctrineCacheAdapter($wrappedCache);
 
         $this->assertInstanceOf(Cache::class, $cache);

--- a/tests/PsrCacheAdapterTest.php
+++ b/tests/PsrCacheAdapterTest.php
@@ -14,7 +14,7 @@ class PsrCacheAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->wrapped = $this->getMock(CacheItemPoolInterface::class);
+        $this->wrapped = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
         $this->instance = new PsrCacheAdapter($this->wrapped);
     }
 
@@ -26,7 +26,7 @@ class PsrCacheAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testProxiesGetCallsToPsrCache($key, $value)
     {
-        $item = $this->getMock(CacheItemInterface::class);
+        $item = $this->getMockBuilder(CacheItemInterface::class)->getMock();
         $item->expects($this->once())
             ->method('isHit')
             ->willReturn(true);
@@ -51,7 +51,7 @@ class PsrCacheAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testProxiesSetCallsToPsrCache($key, $value, $ttl)
     {
-        $item = $this->getMock(CacheItemInterface::class);
+        $item = $this->getMockBuilder(CacheItemInterface::class)->getMock();
         $item->expects($this->once())
             ->method('set')
             ->with($value)

--- a/tests/S3/AmbiguousSuccessParserTest.php
+++ b/tests/S3/AmbiguousSuccessParserTest.php
@@ -34,11 +34,11 @@ class AmbiguousSuccessParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testConvertsAmbiguousSuccessesToExceptions($operation)
     {
-        $command = $this->getMock(CommandInterface::class);
+        $command = $this->getMockBuilder(CommandInterface::class)->getMock();
         $command->expects($this->any())
             ->method('getName')
             ->willReturn($operation);
-        $response = $this->getMock(ResponseInterface::class);
+        $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $response->expects($this->any())
             ->method('getStatusCode')
             ->willReturn(200);
@@ -53,11 +53,11 @@ class AmbiguousSuccessParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testIgnoresAmbiguousSuccessesOnUnaffectedOperations($operation)
     {
-        $command = $this->getMock(CommandInterface::class);
+        $command = $this->getMockBuilder(CommandInterface::class)->getMock();
         $command->expects($this->any())
             ->method('getName')
             ->willReturn($operation);
-        $response = $this->getMock(ResponseInterface::class);
+        $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
         $response->expects($this->any())
             ->method('getStatusCode')
             ->willReturn(200);

--- a/tests/S3/MultipartCopyTest.php
+++ b/tests/S3/MultipartCopyTest.php
@@ -85,7 +85,7 @@ class MultipartCopyTest extends \PHPUnit_Framework_TestCase
     public function testCanUseCaseInsensitiveConfigKeys()
     {
         $client = $this->getTestClient('s3');
-        $sourceMetadata = $this->getMock(ResultInterface::class);
+        $sourceMetadata = $this->getMockBuilder(ResultInterface::class)->getMock();
         $putObjectMup = new MultipartCopy($client, '/bucket/key', [
             'Bucket' => 'newBucket',
             'Key' => 'newKey',

--- a/tests/S3/RetryableMalformedResponseParserTest.php
+++ b/tests/S3/RetryableMalformedResponseParserTest.php
@@ -24,8 +24,8 @@ class RetryableMalformedResponseParserTest extends \PHPUnit_Framework_TestCase
         );
 
         $instance(
-            $this->getMock(CommandInterface::class),
-            $this->getMock(ResponseInterface::class)
+            $this->getMockBuilder(CommandInterface::class)->getMock(),
+            $this->getMockBuilder(ResponseInterface::class)->getMock()
         );
     }
 }

--- a/tests/S3/S3MultiRegionClientTest.php
+++ b/tests/S3/S3MultiRegionClientTest.php
@@ -102,7 +102,7 @@ class S3MultiRegionClientTest extends \PHPUnit_Framework_TestCase
 
     public function testReadsBucketLocationFromCache()
     {
-        $cache = $this->getMock(CacheInterface::class);
+        $cache = $this->getMockBuilder(CacheInterface::class)->getMock();
         $cache->expects($this->once())
             ->method('get')
             ->with('aws:s3:foo:location')

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -206,7 +206,7 @@ class TransferTest extends \PHPUnit_Framework_TestCase
                         && __DIR__ . '/' . $args['Key'] === $args['SourceFile'];
                 })
             )
-            ->willReturn($this->getMock('Aws\CommandInterface'));
+            ->willReturn($this->getMockBuilder('Aws\CommandInterface')->getMock());
 
         (new Transfer($s3, __DIR__, 's3://bare-bucket'))
             ->transfer();
@@ -230,7 +230,7 @@ class TransferTest extends \PHPUnit_Framework_TestCase
                     && __DIR__ . '/' . $args['Key'] === $args['SourceFile'];
                 })
             )
-            ->willReturn($this->getMock('Aws\CommandInterface'));
+            ->willReturn($this->getMockBuilder('Aws\CommandInterface')->getMock());
 
         $uploader = new Transfer($s3, new \ArrayIterator($justThisFile), 's3://bucket', [
             'base_dir' => __DIR__,
@@ -253,7 +253,7 @@ class TransferTest extends \PHPUnit_Framework_TestCase
                     && $args['Key'] === 'path/to/key';
                 })
             )
-            ->willReturn($this->getMock('Aws\CommandInterface'));
+            ->willReturn($this->getMockBuilder('Aws\CommandInterface')->getMock());
 
         $downloader = new Transfer($s3, $justOneFile, sys_get_temp_dir() . '/downloads', [
             'base_dir' => 's3://bucket/path',

--- a/tests/UsesServiceTrait.php
+++ b/tests/UsesServiceTrait.php
@@ -122,7 +122,7 @@ trait UsesServiceTrait
 
         return new $type(
             $message ?: 'Test error',
-            $this->getMock('Aws\CommandInterface'),
+            $this->getMockBuilder('Aws\CommandInterface')->getMock(),
             [
                 'message' => $message ?: 'Test error',
                 'code'    => $code

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -389,10 +389,13 @@ class WaiterTest extends \PHPUnit_Framework_TestCase
     private function getMockResult($data = [])
     {
         if (is_string($data)) {
-            return new AwsException('ERROR', $this->getMock('Aws\CommandInterface'), [
-                'code'   => $data,
-                'result' => new Result(['@metadata' => ['statusCode' => 200]])
-            ]);
+            return new AwsException('ERROR',
+                $this->getMockBuilder('Aws\CommandInterface')->getMock(),
+                [
+                    'code'   => $data,
+                    'result' => new Result(['@metadata' => ['statusCode' => 200]])
+                ]
+            );
         } else {
             return new Result($data + ['@metadata' => ['statusCode' => 200]]);
         }


### PR DESCRIPTION
[PHPUnit](https://github.com/sebastianbergmann/phpunit) Api `getMock()` Api is tagged as [deprecated](https://github.com/sebastianbergmann/phpunit/blob/5.4/src/Framework/TestCase.php#L1557) since PHPUnit 5.4.0, and there is announcement a month ago about its [`backward-compatibility-break`](https://github.com/sebastianbergmann/phpunit/issues/2194) in PHPUnit 6.

To maintain backward-compatibility in SDK, with composer dependency ` "phpunit/phpunit": "4.0|5.0"`, replacing `getMock()` with `getMockBuilder()`.

Referring original [`getMock()`](https://github.com/sebastianbergmann/phpunit/blob/5.4/src/Framework/TestCase.php#L1536) method, and [`MockBuilder`](https://github.com/sebastianbergmann/phpunit-mock-objects/blob/master/src/Framework/MockObject/MockBuilder.php) in PHPUnit.

cc:\ @mtdowling @xibz 