### PR TITLE
Add S3 TransferException to track failed file source

### DIFF
--- a/src/Exception/TransferException.php
+++ b/src/Exception/TransferException.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Aws\Exception;
+
+class TransferException extends \RuntimeException
+{
+    /** @var string file source path */
+    private $source;
+    /** @var array files haven't been transferred yet */
+    private $uncompleted = [];
+
+    /**
+     * TransferException constructor.
+     *
+     * @param array $inProgress
+     * @param \Exception|array $prev Exception being thrown
+     */
+    public function __construct(array $inProgress, $prev = null)
+    {
+        $msg = "An error occurs in a S3 Transfer when transferring file: ";
+
+        $this->source = $inProgress['Failed'];
+        $this->uncompleted = $inProgress['Uncompleted'];
+
+        $msg .= $this->source;
+
+        parent::__construct($msg, 0, $prev);
+    }
+
+    /**
+     * Get the source file path that cause error
+     *
+     * @return string
+     */
+    public function getFileSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * Get remaining file names that haven't been transferred
+     *
+     * @return array
+     */
+    public function getUncompletedFiles()
+    {
+        return $this->uncompleted;
+    }
+}

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -252,8 +252,10 @@ class Transfer implements PromisorInterface
             'concurrency' => $this->concurrency,
             'before'      => $this->before,
             'fulfilled'   => function ($value, $idx, Promise\PromiseInterface $p) {
-                $uri = $value->get('@metadata')['effectiveUri'];
-                $this->clearTaskDone((new Uri($uri))->getPath());
+                if ($value !== null && $value instanceof Aws\ResultInterface) {
+                    $uri = $value->get('@metadata')['effectiveUri'];
+                    $this->clearTaskDone((new Uri($uri))->getPath());
+                }
             },
             'rejected'    => function ($reason, $idx, Promise\PromiseInterface $p) {
                 $cmd = $reason->getCommand();

--- a/tests/Exception/TransferExceptionTest.php
+++ b/tests/Exception/TransferExceptionTest.php
@@ -35,8 +35,8 @@ class TransferExceptionTest extends \PHPUnit_Framework_TestCase
     public function getTestCases()
     {
         return [
-            [ 'foo/bar/a.txt', [] ],
-            [ 'foo/bar/a.txt', ['foo/bar/b.txt', 'foo/bar/c.txt'] ]
+            [ '/foo/bar/a.txt', [] ],
+            [ '/foo/bar/a.txt', ['/foo/bar/b.txt', '/foo/bar/c.txt'] ]
         ];
     }
 }

--- a/tests/Exception/TransferExceptionTest.php
+++ b/tests/Exception/TransferExceptionTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace Aws\Test\Exception;
+
+use Aws\Command;
+use Aws\Exception\AwsException;
+use Aws\Exception\TransferException;
+
+/**
+ * @covers Aws\Exception\TransferException
+ */
+class TransferExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getTestCases
+     */
+
+    public function testCanCreateMultipartException($source, $uncompleted)
+    {
+        $msg = "some error message";
+        $inProgress = [
+            'Failed' => $source,
+            'Uncompleted' => $uncompleted,
+        ];
+        $prev = new AwsException($msg, new Command("cmd"));
+
+        $exception = new TransferException($inProgress, $prev);
+        $expectedMsg = "An error occurs in a S3 Transfer when transferring file: ";
+
+        $this->assertEquals($expectedMsg . $inProgress['Failed'], $exception->getMessage());
+        $this->assertSame($prev, $exception->getPrevious());
+        $this->assertSame($inProgress['Failed'], $exception->getFileSource());
+        $this->assertSame($inProgress['Uncompleted'], $exception->getUncompletedFiles());
+    }
+
+    public function getTestCases()
+    {
+        return [
+            [ 'foo/bar/a.txt', [] ],
+            [ 'foo/bar/a.txt', ['foo/bar/b.txt', 'foo/bar/c.txt'] ]
+        ];
+    }
+}

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -1,9 +1,14 @@
 <?php
 namespace Aws\Test\S3;
 
+use Aws\Command;
 use Aws\CommandInterface;
+use Aws\Exception\AwsException;
+use Aws\Exception\TransferException;
+use Aws\MockHandler;
 use Aws\Result;
 use Aws\S3\S3Client;
+use Aws\S3\S3ClientInterface;
 use Aws\S3\Transfer;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Promise;
@@ -206,7 +211,7 @@ class TransferTest extends \PHPUnit_Framework_TestCase
                         && __DIR__ . '/' . $args['Key'] === $args['SourceFile'];
                 })
             )
-            ->willReturn($this->getMock('Aws\CommandInterface'));
+            ->willReturn($this->getMockBuilder('Aws\CommandInterface')->getMock());
 
         (new Transfer($s3, __DIR__, 's3://bare-bucket'))
             ->transfer();
@@ -230,7 +235,7 @@ class TransferTest extends \PHPUnit_Framework_TestCase
                     && __DIR__ . '/' . $args['Key'] === $args['SourceFile'];
                 })
             )
-            ->willReturn($this->getMock('Aws\CommandInterface'));
+            ->willReturn($this->getMockBuilder('Aws\CommandInterface')->getMock());
 
         $uploader = new Transfer($s3, new \ArrayIterator($justThisFile), 's3://bucket', [
             'base_dir' => __DIR__,
@@ -253,13 +258,99 @@ class TransferTest extends \PHPUnit_Framework_TestCase
                     && $args['Key'] === 'path/to/key';
                 })
             )
-            ->willReturn($this->getMock('Aws\CommandInterface'));
+            ->willReturn($this->getMockBuilder('Aws\CommandInterface')->getMock());
 
         $downloader = new Transfer($s3, $justOneFile, sys_get_temp_dir() . '/downloads', [
             'base_dir' => 's3://bucket/path',
         ]);
 
         $downloader->transfer();
+    }
+
+    /**
+     * @expectedException \Aws\Exception\TransferException
+     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: foo/bar/small.txt
+     */
+    public function testEnsureTrackingFailedFileWhenUpload()
+    {
+        $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [
+            new AwsException('Failed', new Command('PutObject')),
+        ]);
+
+        $dir = sys_get_temp_dir() . '/unittest';
+        `rm -rf $dir`;
+        mkdir($dir);
+        $filename = $dir . '/small.txt';
+        $f = fopen($filename, 'w+');
+        $line = str_repeat('.', 1024);
+        for ($i = 0; $i < 6; $i++) {
+            fwrite($f, $line);
+        }
+        fclose($f);
+
+        $t = new Transfer($s3, $dir, 's3://foo/bar');
+        $t->transfer();
+        `rm -rf $dir`;
+    }
+
+    /**
+     * @expectedException \Aws\Exception\TransferException
+     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: foo/bar/large.txt
+     */
+    public function testEnsureTrackingFailedFileWhenMultipartUpload()
+    {
+        $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [
+            new Result(['UploadId' => '123']),
+            new Result(['ETag' => 'a']),
+            new Result(['ETag' => 'b']),
+            new AwsException('Failed', new Command('CreateMultipartUpload')),
+        ]);
+
+        $dir = sys_get_temp_dir() . '/unittest';
+        `rm -rf $dir`;
+        mkdir($dir);
+        $filename = $dir . '/large.txt';
+        $f = fopen($filename, 'w+');
+        $line = str_repeat('.', 1024);
+        for ($i = 0; $i < 6000; $i++) {
+            fwrite($f, $line);
+        }
+        fclose($f);
+
+        $t = new Transfer($s3, $dir, 's3://foo/bar', [
+            'mup_threshold' => 5248000
+        ]);
+        $t->transfer();
+        `rm -rf $dir`;
+    }
+
+    /**
+     * @expectedException \Aws\Exception\TransferException
+     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: foo/bar
+     */
+    public function testEnsureTrackingFailedFileWhenDownload()
+    {
+        $s3 = $this->getTestClient('s3');
+        $lso = [
+            'IsTruncated' => false,
+            'Contents' => [
+                ['Key' => 'bar/a/b'],
+            ]
+        ];
+        $this->addMockResults($s3, [
+            new Result($lso),
+            new AwsException('Failed', new Command('GetObject')),
+        ]);
+
+        $dir = sys_get_temp_dir() . '/unittest';
+        `rm -rf $dir`;
+        mkdir($dir);
+
+        $t = new Transfer($s3, 's3://foo/bar', $dir);
+        $t->transfer();
+        `rm -rf $dir`;
     }
 
     private function mockResult(callable $fn)

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -264,12 +264,12 @@ class TransferTest extends \PHPUnit_Framework_TestCase
             'base_dir' => 's3://bucket/path',
         ]);
 
-        $downloader->transfer();
+        $downloader->promise();
     }
 
     /**
      * @expectedException \Aws\Exception\TransferException
-     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: foo/bar/small.txt
+     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: /foo/bar/small.txt
      */
     public function testEnsureTrackingFailedFileWhenUpload()
     {
@@ -296,7 +296,7 @@ class TransferTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Aws\Exception\TransferException
-     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: foo/bar/large.txt
+     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: /foo/bar/large.txt
      */
     public function testEnsureTrackingFailedFileWhenMultipartUpload()
     {
@@ -328,7 +328,7 @@ class TransferTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Aws\Exception\TransferException
-     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: foo/bar
+     * @expectedExceptionMessage An error occurs in a S3 Transfer when transferring file: /foo/bar/a
      */
     public function testEnsureTrackingFailedFileWhenDownload()
     {
@@ -341,7 +341,10 @@ class TransferTest extends \PHPUnit_Framework_TestCase
         ];
         $this->addMockResults($s3, [
             new Result($lso),
-            new AwsException('Failed', new Command('GetObject')),
+            new AwsException('Failed', new Command('GetObject', [
+                'Bucket' => 'foo/bar',
+                'Key' => 'a'
+            ])),
         ]);
 
         $dir = sys_get_temp_dir() . '/unittest';


### PR DESCRIPTION
Feature request from #1015.
By providing file information, customer would have better troubleshooting experience.

Besides having `getFileSouce()` to get the source file path that cause error, also add `getUncompletedFiles()` to retrieve remaining files that haven't been transferred.

cc:\ @mtdowling @xibz  
