### PR TITLE
Remove query string in URI when converting GET to POST

### DIFF
--- a/src/CloudSearchDomain/CloudSearchDomainClient.php
+++ b/src/CloudSearchDomain/CloudSearchDomainClient.php
@@ -72,11 +72,13 @@ class CloudSearchDomainClient extends AwsClient
         if ($r->getMethod() === 'POST') {
             return $r;
         }
+
         $query = $r->getUri()->getQuery();
         $req = $r->withMethod('POST')
             ->withBody(Psr7\stream_for($query))
             ->withHeader('Content-Length', strlen($query))
-            ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withUri($r->getUri()->withQuery(''));
         return $req;
     }
 }

--- a/tests/CloudSearchDomain/CloudSearchDomainTest.php
+++ b/tests/CloudSearchDomain/CloudSearchDomainTest.php
@@ -45,6 +45,6 @@ class CloudSearchDomainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
         $this->assertEquals(7, $request->getHeaderLine('Content-Length'));
         $this->assertEquals('foo=bar', $request->getBody());
-        $this->assertEquals('', $request->getUri()->getQuery());
+        $this->assertSame('', $request->getUri()->getQuery());
     }
 }

--- a/tests/CloudSearchDomain/CloudSearchDomainTest.php
+++ b/tests/CloudSearchDomain/CloudSearchDomainTest.php
@@ -45,5 +45,6 @@ class CloudSearchDomainTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
         $this->assertEquals(7, $request->getHeaderLine('Content-Length'));
         $this->assertEquals('foo=bar', $request->getBody());
+        $this->assertEquals('', $request->getUri()->getQuery());
     }
 }


### PR DESCRIPTION
This fix remove query string in URI when converting GET to POST.
Fix issue #1047 

cc: @chrisradek @LiuJoyceC 