### PR TITLE
When PHP Fatal Error is not surfaced, disable retry on certain errors

### DIFF
--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -130,7 +130,7 @@ class RetryMiddleware
         ) {
             $this->updateHttpStats($value, $requestStats);
 
-            if ($value instanceof \Exception) {
+            if ($value instanceof \Exception || $value instanceof \Error) {
                 if (!$decider($retries, $command, $request, null, $value)) {
                     return \GuzzleHttp\Promise\rejection_for(
                         $this->bindStatsToReturn($value, $requestStats)

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -130,7 +130,7 @@ class RetryMiddleware
         ) {
             $this->updateHttpStats($value, $requestStats);
 
-            if ($value instanceof \Exception || $value instanceof \Error) {
+            if ($value instanceof \Exception || $this->isErrorObject($value)) {
                 if (!$decider($retries, $command, $request, null, $value)) {
                     return \GuzzleHttp\Promise\rejection_for(
                         $this->bindStatsToReturn($value, $requestStats)
@@ -205,5 +205,12 @@ class RetryMiddleware
         }
 
         return $return;
+    }
+
+    private function isErrorObject($value)
+    {
+        return class_exists(\Error::class)
+            ? $value instanceof \Error
+            : false;
     }
 }

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -130,7 +130,7 @@ class RetryMiddleware
         ) {
             $this->updateHttpStats($value, $requestStats);
 
-            if ($value instanceof \Exception || $this->isErrorObject($value)) {
+            if ($this->isThrowable($value)) {
                 if (!$decider($retries, $command, $request, null, $value)) {
                     return \GuzzleHttp\Promise\rejection_for(
                         $this->bindStatsToReturn($value, $requestStats)
@@ -207,10 +207,10 @@ class RetryMiddleware
         return $return;
     }
 
-    private function isErrorObject($value)
+    private function isThrowable($value)
     {
-        return class_exists(\Error::class)
-            ? $value instanceof \Error
-            : false;
+        return class_exists(\Throwable::class)
+            ? $value instanceof \Throwable
+            : $value instanceof \Exception ;
     }
 }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -72,7 +72,7 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
 
     public function testDeciderIgnoresPHPError()
     {
-        if (class_exists(\Error::class)) {
+        if (class_exists(\Throwable::class)) {
             $decider = RetryMiddleware::createDefaultDecider();
             $command = new Command('foo');
             $request = new Request('GET', 'http://www.example.com');

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -70,6 +70,15 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($decider(0, $command, $request, null, $err));
     }
 
+    public function testDeciderIgnoresPHPError()
+    {
+        $decider = RetryMiddleware::createDefaultDecider();
+        $command = new Command('foo');
+        $request = new Request('GET', 'http://www.example.com');
+        $err = new \Error('e');
+        $this->assertFalse($decider(0, $command, $request, null, $err));
+    }
+
     public function awsErrorCodeProvider()
     {
         $command = new Command('foo');

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -72,11 +72,13 @@ class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
 
     public function testDeciderIgnoresPHPError()
     {
-        $decider = RetryMiddleware::createDefaultDecider();
-        $command = new Command('foo');
-        $request = new Request('GET', 'http://www.example.com');
-        $err = new \Error('e');
-        $this->assertFalse($decider(0, $command, $request, null, $err));
+        if (class_exists(\Error::class)) {
+            $decider = RetryMiddleware::createDefaultDecider();
+            $command = new Command('foo');
+            $request = new Request('GET', 'http://www.example.com');
+            $err = new \Error('e');
+            $this->assertFalse($decider(0, $command, $request, null, $err));
+        }
     }
 
     public function awsErrorCodeProvider()


### PR DESCRIPTION
Fix issue #1049 

When using some customized PHP installation approaches in certain OS environments, PHP Fatal Error sometimes couldn't be surfaced at first place. Current retry mechanism checks exceptions and ignores error, this caused trouble for silent failing and retrying succeed requests when dependency is missing in parsing responses.

cc: @mtdowling @xibz 