### PR TITLE
DynamoDB Marshaler mapAsObject argument

### DIFF
--- a/src/DynamoDb/Marshaler.php
+++ b/src/DynamoDb/Marshaler.php
@@ -237,12 +237,13 @@ class Marshaler
      * returned instead.
      *
      * @param array $data Item from a DynamoDB result.
+     * @param bool  $mapAsObject Whether maps should be represented as stdClass.
      *
      * @return array|\stdClass
      */
-    public function unmarshalItem(array $data)
+    public function unmarshalItem(array $data, $mapAsObject = false)
     {
-        return $this->unmarshalValue(['M' => $data]);
+        return $this->unmarshalValue(['M' => $data], $mapAsObject);
     }
 
     /**


### PR DESCRIPTION
Hello,
It seems the argument `mapAsObject` has been forgot to the method `unmarshalItem` as the
method description already reference it and the `unmarshalValue` method implementation.