### PR TITLE
Adding a rejected promise handler to determineBucketRegionAsync

### DIFF
--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -2,6 +2,7 @@
 namespace Aws\S3;
 
 use Aws\CommandInterface;
+use Aws\Exception\AwsException;
 use Aws\HandlerList;
 use Aws\ResultInterface;
 use Aws\S3\Exception\S3Exception;
@@ -174,6 +175,12 @@ trait S3ClientTrait
         return $handler($command)
             ->then(static function (ResultInterface $result) {
                 return $result['@metadata']['headers']['x-amz-bucket-region'];
+            }, static function (AwsException $exception) {
+                $response = $exception->getResponse();
+                if ($response === null) {
+                    throw $exception;
+                }
+                return $response->getHeaderLine('x-amz-bucket-region');
             });
     }
 

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -786,8 +786,24 @@ EOXML;
                 ]));
             },
         ]);
-
         $this->assertSame('alderaan-north-1', $client->determineBucketRegion('bucket'));
+
+        $client = new S3Client([
+            'region' => 'us-west-2',
+            'version' => 'latest',
+            'http_handler' => function() {
+                return new RejectedPromise([
+                    'connection_error' => false,
+                    'exception' => $this->getMockBuilder(AwsException::class)
+                        ->disableOriginalConstructor()
+                        ->getMock(),
+                    'response' => new Response(400, [
+                        'X-Amz-Bucket-Region' => 'us-west-2',
+                    ]),
+                ]);
+            },
+        ]);
+        $this->assertSame('us-west-2', $client->determineBucketRegion('bucket'));
     }
 
     /**

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -2,6 +2,7 @@
 namespace Aws\Test\S3;
 
 use Aws\Command;
+use Aws\Exception\AwsException;
 use Aws\Result;
 use Aws\S3\MultipartUploader;
 use Aws\S3\S3Client;
@@ -787,6 +788,27 @@ EOXML;
         ]);
 
         $this->assertSame('alderaan-north-1', $client->determineBucketRegion('bucket'));
+    }
+
+    /**
+     * @expectedException \Aws\Exception\AwsException
+     */
+    public function testDetermineBucketRegionExposeException()
+    {
+        $client = new S3Client([
+            'region' => 'us-west-2',
+            'version' => 'latest',
+            'http_handler' => function() {
+                return new RejectedPromise([
+                    'connection_error' => false,
+                    'exception' => $this->getMockBuilder(AwsException::class)
+                        ->disableOriginalConstructor()
+                        ->getMock(),
+                    'response' => null,
+                ]);
+            },
+        ]);
+        $client->determineBucketRegion('bucket');
     }
     
     public function testAppliesAccelerateMiddleware()


### PR DESCRIPTION
Addressing issue #1065 

Adding a rejected promise handler to `determineBucketRegionAsync` to surface exception immediately when making a `HEAD` bucket request.

cc:\ @mtdowling @xibz @jeskew 