### PR TITLE
Properly set security token for S3 direct upload when using temporary credentials

### DIFF
--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -54,6 +54,14 @@ class PostObjectV4
             'enctype' => 'multipart/form-data'
         ];
 
+        $credentials   = $this->client->getCredentials()->wait();
+        $securityToken = $credentials->getSecurityToken();
+
+        if (null !== $securityToken) {
+            array_push($options, ['x-amz-security-token' => $securityToken]);
+            $formInputs['X-Amz-Security-Token'] = $securityToken;
+        }
+
         // setup basic policy
         $policy = [
             'expiration' => TimestampShape::format($expiration, 'iso8601'),
@@ -64,7 +72,7 @@ class PostObjectV4
         $this->formInputs = $formInputs + ['key' => '${filename}'];
 
         // finalize policy and signature
-        $credentials = $this->client->getCredentials()->wait();
+
         $this->formInputs += $this->getPolicyAndSignature(
             $credentials,
             $policy


### PR DESCRIPTION
Hi,

I've been using locally the PostObjectV4 to create form inputs that allowed to directly upload to S3.

This worked perfectly while using access keys. However once deployed and using temporarily credentials, this didn't work.

After a lot of research, it appears that you need to pass an additional "x-amz-security-token" to the policy, and this token must also be set in the HTML form. cf: http://stackoverflow.com/questions/18884683/browser-uploads-to-s3-with-instance-roles/19024044

I've tested this fix and it works :).