### PR TITLE
[Doc Fix] Duplicate "EC2" in Doc quicklink

### DIFF
--- a/build/docs/classes/DocsBuilder.php
+++ b/build/docs/classes/DocsBuilder.php
@@ -148,6 +148,17 @@ class DocsBuilder
             return array_shift($versions);
         }, $services);
 
+        $serviceMap = [];
+        foreach ($services as $service) {
+            $isOlderVersion = isset($serviceMap[$service->name]) &&
+                $service->version < $serviceMap[$service->name]->version;
+            if ($isOlderVersion) {
+                continue;
+            }
+            $serviceMap[$service->name] = $service;
+        }
+        $services = array_values($serviceMap);
+
         // Sort the services in the order provided in the config
         usort($services, function (Service $a, Service $b) {
             return array_search($a->name, $this->quickLinks)


### PR DESCRIPTION
In current [API doc](http://docs.aws.amazon.com/aws-sdk-php/v3/api/index.html), there exists 2 EC2 QuickLinks leads to 2 versions of `Ec2Client`.

This bug is introduced in PR #1072 that intends to fix the problem of ELB and ELBV2 sharing same service title by indexing them with `title` and `shortTitle` separately. In `quickLink` part, since now each service version has different key in `services` array, the latest version of the service needs to be kept.

@mtdowling 