### PR TITLE
Fix DynamoDB session handler sleep time

### DIFF
--- a/src/DynamoDb/LockingSessionConnection.php
+++ b/src/DynamoDb/LockingSessionConnection.php
@@ -49,7 +49,7 @@ class LockingSessionConnection extends StandardSessionConnection
                 if ($e->getAwsErrorCode() === 'ConditionalCheckFailedException'
                     && time() < $timeout
                 ) {
-                    usleep(pow(10, -6) * rand(
+                    usleep(rand(
                         $this->config['min_lock_retry_microtime'],
                         $this->config['max_lock_retry_microtime']
                     ));


### PR DESCRIPTION
Between attempts to access a locked session, the handler is meant to
wait for a configurable number of microseconds. The handler code was
previously multiplying the wait time by 10^-6 before passing it to
usleep, even though the values were already in microseconds. For the
default min and max wait time values of 10000 and 50000, the usleep
argument would always be less than one and so the handler wouldn't
wait at all between attempts.

This commit removes the multiplication by 10^-6, so the handler sleeps
for the intended amount of time between requests.