### PR TITLE
Fix PostObjectV4 ignoring customized virtual-style endpoint

### DIFF
--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -151,8 +151,10 @@ class PostObjectV4
             // Use path-style URLs
             $uri = $uri->withPath($this->bucket);
         } else {
-            // Use virtual-style URLs
-            $uri = $uri->withHost($this->bucket . '.' . $uri->getHost());
+            // Use virtual-style URLs if haven't been set up already
+            if (strpos($uri->getHost(), $this->bucket) === false) {
+                $uri = $uri->withHost($this->bucket . '.' . $uri->getHost());
+            }
         }
 
         return (string) $uri;

--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -152,7 +152,7 @@ class PostObjectV4
             $uri = $uri->withPath($this->bucket);
         } else {
             // Use virtual-style URLs if haven't been set up already
-            if (explode('.', $uri->getHost())[0] !== $this->bucket) {
+            if (strpos($uri->getHost(), $this->bucket) !== 0) {
                 $uri = $uri->withHost($this->bucket . '.' . $uri->getHost());
             }
         }

--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -152,7 +152,7 @@ class PostObjectV4
             $uri = $uri->withPath($this->bucket);
         } else {
             // Use virtual-style URLs if haven't been set up already
-            if (strpos($uri->getHost(), $this->bucket) !== 0) {
+            if (strpos($uri->getHost(), $this->bucket . '.') !== 0) {
                 $uri = $uri->withHost($this->bucket . '.' . $uri->getHost());
             }
         }

--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -152,7 +152,7 @@ class PostObjectV4
             $uri = $uri->withPath($this->bucket);
         } else {
             // Use virtual-style URLs if haven't been set up already
-            if (strpos($uri->getHost(), $this->bucket) === false) {
+            if (explode('.', $uri->getHost())[0] !== $this->bucket) {
                 $uri = $uri->withHost($this->bucket . '.' . $uri->getHost());
             }
         }

--- a/tests/S3/PostObjectV4Test.php
+++ b/tests/S3/PostObjectV4Test.php
@@ -209,5 +209,22 @@ class PostObjectV4Test extends \PHPUnit_Framework_TestCase
             'http://foo.s3.amazonaws.com',
             $formAttrs['action']
         );
+
+        $s3 = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-east-1',
+            'credentials' => [
+                'key' => 'akid',
+                'secret' => 'secret',
+            ],
+            'endpoint' => 'http://s3.amazonaws.com',
+            'bucket_endpoint' => true,
+        ]);
+        $postObject = new PostObjectV4($s3, 'amazonaws', []);
+        $formAttrs = $postObject->getFormAttributes();
+        $this->assertEquals(
+            'http://amazonaws.s3.amazonaws.com',
+            $formAttrs['action']
+        );
     }
 }

--- a/tests/S3/PostObjectV4Test.php
+++ b/tests/S3/PostObjectV4Test.php
@@ -190,4 +190,24 @@ class PostObjectV4Test extends \PHPUnit_Framework_TestCase
             $formAttrs['action']
         );
     }
+
+    public function testCanHandleVirtualStyleEndpoint()
+    {
+        $s3 = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-east-1',
+            'credentials' => [
+                'key' => 'akid',
+                'secret' => 'secret',
+            ],
+            'endpoint' => 'http://foo.s3.amazonaws.com',
+            'bucket_endpoint' => true,
+        ]);
+        $postObject = new PostObjectV4($s3, 'foo', []);
+        $formAttrs = $postObject->getFormAttributes();
+        $this->assertEquals(
+            'http://foo.s3.amazonaws.com',
+            $formAttrs['action']
+        );
+    }
 }

--- a/tests/S3/PostObjectV4Test.php
+++ b/tests/S3/PostObjectV4Test.php
@@ -189,26 +189,16 @@ class PostObjectV4Test extends \PHPUnit_Framework_TestCase
             'https://s3.amazonaws.com/foo.bar',
             $formAttrs['action']
         );
-
-        $s3 = new S3Client([
-            'version' => 'latest',
-            'region' => 'us-east-1',
-            'credentials' => [
-                'key' => 'akid',
-                'secret' => 'secret',
-            ],
-            'endpoint' => 'http://foo.bar.s3.amazonaws.com',
-            'bucket_endpoint' => true,
-        ]);
-        $postObject = new PostObjectV4($s3, 'foo.bar', []);
-        $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals(
-            'http://foo.bar.s3.amazonaws.com',
-            $formAttrs['action']
-        );
     }
 
-    public function testCanHandleVirtualStyleEndpoint()
+    /**
+     * @dataProvider virtualStyleProvider
+     *
+     * @param string $endpoint
+     * @param string $bucket
+     * @param string $expected
+     */
+    public function testCanHandleVirtualStyleEndpoint($endpoint, $bucket, $expected)
     {
         $s3 = new S3Client([
             'version' => 'latest',
@@ -217,31 +207,22 @@ class PostObjectV4Test extends \PHPUnit_Framework_TestCase
                 'key' => 'akid',
                 'secret' => 'secret',
             ],
-            'endpoint' => 'http://foo.s3.amazonaws.com',
+            'endpoint' => $endpoint,
             'bucket_endpoint' => true,
         ]);
-        $postObject = new PostObjectV4($s3, 'foo', []);
+        $postObject = new PostObjectV4($s3, $bucket, []);
         $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals(
-            'http://foo.s3.amazonaws.com',
-            $formAttrs['action']
-        );
+        $this->assertEquals($expected, $formAttrs['action']);
+    }
 
-        $s3 = new S3Client([
-            'version' => 'latest',
-            'region' => 'us-east-1',
-            'credentials' => [
-                'key' => 'akid',
-                'secret' => 'secret',
-            ],
-            'endpoint' => 'http://s3.amazonaws.com',
-            'bucket_endpoint' => true,
-        ]);
-        $postObject = new PostObjectV4($s3, 'amazonaws', []);
-        $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals(
-            'http://amazonaws.s3.amazonaws.com',
-            $formAttrs['action']
-        );
+    public function virtualStyleProvider()
+    {
+        return [
+            ['http://foo.s3.amazonaws.com', 'foo', 'http://foo.s3.amazonaws.com'],
+            ['http://foo.s3.amazonaws.com', 'bar', 'http://bar.foo.s3.amazonaws.com'],
+            ['http://s3.amazonaws.com', 'amazonaws', 'http://amazonaws.s3.amazonaws.com'],
+            ['http://foo.bar.s3.amazonaws.com', 'foo.bar', 'http://foo.bar.s3.amazonaws.com'],
+            ['http://foo.com', 'foo.com', 'http://foo.com.foo.com'],
+        ];
     }
 }

--- a/tests/S3/PostObjectV4Test.php
+++ b/tests/S3/PostObjectV4Test.php
@@ -189,6 +189,23 @@ class PostObjectV4Test extends \PHPUnit_Framework_TestCase
             'https://s3.amazonaws.com/foo.bar',
             $formAttrs['action']
         );
+
+        $s3 = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-east-1',
+            'credentials' => [
+                'key' => 'akid',
+                'secret' => 'secret',
+            ],
+            'endpoint' => 'http://foo.bar.s3.amazonaws.com',
+            'bucket_endpoint' => true,
+        ]);
+        $postObject = new PostObjectV4($s3, 'foo.bar', []);
+        $formAttrs = $postObject->getFormAttributes();
+        $this->assertEquals(
+            'http://foo.bar.s3.amazonaws.com',
+            $formAttrs['action']
+        );
     }
 
     public function testCanHandleVirtualStyleEndpoint()


### PR DESCRIPTION
Fixing issue #1129 

The bug: When virtual-style endpoint is hard coded by `endpoint` configuration, `PostObjectV4` doesn't detect it, will still trying to convert it to virtual-style, which causes 2 buckets in the url looks like: `https://bucket.bucket.s3.amazonaws.com`.

@mtdowling @xibz 