### PR TITLE
Fix sed to work on GNU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ check-tag:
 tag: check-tag
 	@echo Tagging $(TAG)
 	chag update $(TAG)
-	sed -i '' -e "s/VERSION = '.*'/VERSION = '$(TAG)'/" src/Sdk.php
+	sed -i'' -e "s/VERSION = '.*'/VERSION = '$(TAG)'/" src/Sdk.php
 	php -l src/Sdk.php
 	git commit -a -m '$(TAG) release'
 	chag tag


### PR DESCRIPTION
```
sed -i  '' -e "s/VERSION = '.*'/VERSION = '3.20.15'/" src/Sdk.php
```
The above command would fail on GNU. 

The update works fine on both GNU and OSX 10.9+

Reference:
- http://www.grymoire.com/Unix/Sed.html#uh-62h
- http://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux