### PR TITLE
Skip invalid example snippets instead of breaking the doc

### DIFF
--- a/build/docs/classes/CodeSnippetGenerator.php
+++ b/build/docs/classes/CodeSnippetGenerator.php
@@ -64,16 +64,25 @@ class CodeSnippetGenerator
     private function structure(StructureShape $shape, $value, $indent, $path, $comments)
     {
         $lines = ['['];
+        $discrepancy = false;
         foreach ($value as $key => $val) {
             $path[] = ".{$key}";
             $comment = $this->getCommentFor($path, $comments);
-            $shapeVal = $this->visit($shape->getMember($key), $val, "{$indent}    ", $path, $comments);
-            $lines[] = rtrim("{$indent}    '{$key}' => {$shapeVal}, {$comment}");
+            try {
+                $shapeVal = $this->visit($shape->getMember($key), $val, "{$indent}    ", $path, $comments);
+                $lines[] = rtrim("{$indent}    '{$key}' => {$shapeVal}, {$comment}");
+            } catch (\InvalidArgumentException $e) {
+                $discrepancy = true;
+                break;
+            }
             array_pop($path);
         }
         $lines[] = "{$indent}]";
-
-        return implode("\n", $lines);
+        if ($discrepancy) {
+            echo "Skipping examples due to discrepancy in shape: {$shape->getName()}. \n";
+        } else {
+            return implode("\n", $lines);
+        }
     }
 
     private function arr(ListShape $shape, $value, $indent, $path, $comments)

--- a/build/docs/classes/CodeSnippetGenerator.php
+++ b/build/docs/classes/CodeSnippetGenerator.php
@@ -70,11 +70,11 @@ class CodeSnippetGenerator
             $comment = $this->getCommentFor($path, $comments);
             try {
                 $shapeVal = $this->visit($shape->getMember($key), $val, "{$indent}    ", $path, $comments);
-                $lines[] = rtrim("{$indent}    '{$key}' => {$shapeVal}, {$comment}");
             } catch (\InvalidArgumentException $e) {
                 $discrepancy = true;
                 break;
             }
+            $lines[] = rtrim("{$indent}    '{$key}' => {$shapeVal}, {$comment}");
             array_pop($path);
         }
         $lines[] = "{$indent}]";


### PR DESCRIPTION
Considering that manually maintain and fix example file might not be a best practice, which would introduce burden into CI process as well, since having out-dated documentation is bad, this PR skips invalid example code snippets with helpful message instead of letting it stops doc generation.

@imshashank @mtdowling
#1152 

Added notes:
I do have concerns that this solution will make it easy to ignore existing example discrepancy.

Edited:
Personally, I think this PR should only be merged when there is no better option when integrate with full CI