### PR TITLE
Link docs for S3ClientTrait methods to the S3ClientInterface methods they implement

### DIFF
--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -15,6 +15,9 @@ use GuzzleHttp\Promise\RejectedPromise;
  */
 trait S3ClientTrait
 {
+    /**
+     * @see S3ClientInterface::upload()
+     */
     public function upload(
         $bucket,
         $key,
@@ -27,6 +30,9 @@ trait S3ClientTrait
             ->wait();
     }
 
+    /**
+     * @see S3ClientInterface::uploadAsync()
+     */
     public function uploadAsync(
         $bucket,
         $key,
@@ -38,6 +44,9 @@ trait S3ClientTrait
             ->promise();
     }
 
+    /**
+     * @see S3ClientInterface::copy()
+     */
     public function copy(
         $fromB,
         $fromK,
@@ -50,6 +59,9 @@ trait S3ClientTrait
             ->wait();
     }
 
+    /**
+     * @see S3ClientInterface::copyAsync()
+     */
     public function copyAsync(
         $fromB,
         $fromK,
@@ -74,11 +86,17 @@ trait S3ClientTrait
             ->promise();
     }
 
+    /**
+     * @see S3ClientInterface::registerStreamWrapper()
+     */
     public function registerStreamWrapper()
     {
         StreamWrapper::register($this);
     }
 
+    /**
+     * @see S3ClientInterface::deleteMatchingObjects()
+     */
     public function deleteMatchingObjects(
         $bucket,
         $prefix = '',
@@ -89,6 +107,9 @@ trait S3ClientTrait
             ->wait();
     }
 
+    /**
+     * @see S3ClientInterface::deleteMatchingObjectsAsync()
+     */
     public function deleteMatchingObjectsAsync(
         $bucket,
         $prefix = '',
@@ -114,6 +135,9 @@ trait S3ClientTrait
             ->promise();
     }
 
+    /**
+     * @see S3ClientInterface::uploadDirectory()
+     */
     public function uploadDirectory(
         $directory,
         $bucket,
@@ -124,6 +148,9 @@ trait S3ClientTrait
             ->wait();
     }
 
+    /**
+     * @see S3ClientInterface::uploadDirectoryAsync()
+     */
     public function uploadDirectoryAsync(
         $directory,
         $bucket,
@@ -134,6 +161,9 @@ trait S3ClientTrait
         return (new Transfer($this, $directory, $d, $options))->promise();
     }
 
+    /**
+     * @see S3ClientInterface::downloadBucket()
+     */
     public function downloadBucket(
         $directory,
         $bucket,
@@ -144,6 +174,9 @@ trait S3ClientTrait
             ->wait();
     }
 
+    /**
+     * @see S3ClientInterface::downloadBucketAsync()
+     */
     public function downloadBucketAsync(
         $directory,
         $bucket,
@@ -154,12 +187,17 @@ trait S3ClientTrait
         return (new Transfer($this, $s, $directory, $options))->promise();
     }
 
+    /**
+     * @see S3ClientInterface::determineBucketRegion()
+     */
     public function determineBucketRegion($bucketName)
     {
         return $this->determineBucketRegionAsync($bucketName)->wait();
     }
 
     /**
+     * @see S3ClientInterface::determineBucketRegionAsync()
+     *
      * @param string $bucketName
      *
      * @return PromiseInterface
@@ -184,6 +222,9 @@ trait S3ClientTrait
             });
     }
 
+    /**
+     * @see S3ClientInterface::doesBucketExist()
+     */
     public function doesBucketExist($bucket)
     {
         return $this->checkExistenceWithCommand(
@@ -191,6 +232,9 @@ trait S3ClientTrait
         );
     }
 
+    /**
+     * @see S3ClientInterface::doesObjectExist()
+     */
     public function doesObjectExist($bucket, $key, array $options = [])
     {
         return $this->checkExistenceWithCommand(
@@ -225,16 +269,26 @@ trait S3ClientTrait
         }
     }
 
+    /**
+     * @see S3ClientInterface::execute()
+     */
     abstract public function execute(CommandInterface $command);
 
+    /**
+     * @see S3ClientInterface::getCommand()
+     */
     abstract public function getCommand($name, array $args = []);
 
     /**
+     * @see S3ClientInterface::getHandlerList()
+     *
      * @return HandlerList
      */
     abstract public function getHandlerList();
 
     /**
+     * @see S3ClientInterface::getIterator()
+     *
      * @return \Iterator
      */
     abstract public function getIterator($name, array $args = []);


### PR DESCRIPTION
When these methods were moved to from `Aws\S3\S3Client` to `Aws\S3\S3ClientTrait`, they ceased automatically inheriting their documentation from `Aws\S3\S3ClientInterface`. This PR adds `@see` annotations on all methods in the trait linking them to the methods in the interface. (In the generated API docs, the fully qualified method names are resolved to hyperlinks.)

/cc @imshashank @mtdowling 