### PR TITLE
Fix Marshaler leaving dangling references

### DIFF
--- a/src/DynamoDb/Marshaler.php
+++ b/src/DynamoDb/Marshaler.php
@@ -283,8 +283,8 @@ class Marshaler
                 }
                 // NOBREAK: Unmarshal M the same way as L, for arrays.
             case 'L':
-                foreach ($value as &$v) {
-                    $v = $this->unmarshalValue($v, $mapAsObject);
+                foreach ($value as $k => $v) {
+                    $value[$k] = $this->unmarshalValue($v, $mapAsObject);
                 }
                 return $value;
             case 'B':
@@ -292,8 +292,8 @@ class Marshaler
             case 'SS':
             case 'NS':
             case 'BS':
-                foreach ($value as &$v) {
-                    $v = $this->unmarshalValue([$type[0] => $v]);
+                foreach ($value as $k => $v) {
+                    $value[$k] = $this->unmarshalValue([$type[0] => $v]);
                 }
                 return new SetValue($value);
         }

--- a/tests/DynamoDb/MarshalerTest.php
+++ b/tests/DynamoDb/MarshalerTest.php
@@ -377,4 +377,16 @@ JSON;
         $this->assertEquals(3, count($set));
         $this->assertEquals(3, iterator_count($set));
     }
+
+    public function testUnmarshalItemDoesNotCreateReferences()
+    {
+        $m = new Marshaler();
+        $result = $m->unmarshalItem([
+            'foo' => ['S' => 'bar'],
+        ]);
+        $resultCopy = $result;
+        $resultCopy['foo_copy'] = $resultCopy['foo'];
+        $resultCopy['foo'] = 'baz';
+        $this->assertEquals('bar', $result['foo']);
+    }
 }


### PR DESCRIPTION
Some PHP versions will create references to keys instead of copying them
after doing a foreach-by-reference, which can cause unexpected state
mutations. Remove those foreach-by-reference calls to prevent that from
happening

Example: https://3v4l.org/jNSeb