### PR TITLE
Fix appstream endpoint prefix

### DIFF
--- a/src/Appstream/AppstreamClient.php
+++ b/src/Appstream/AppstreamClient.php
@@ -42,4 +42,16 @@ use Aws\AwsClient;
  * @method \Aws\Result updateStack(array $args = [])
  * @method \GuzzleHttp\Promise\Promise updateStackAsync(array $args = [])
  */
-class AppstreamClient extends AwsClient {}
+class AppstreamClient extends AwsClient {
+
+    public function __construct(array $args)
+    {
+        if (!isset($args['endpoint'])) {
+            $scheme = isset($args['scheme'])? $args['scheme'] : 'https';
+            $args['endpoint'] =
+                "{$scheme}://appstream2.{$args['region']}.amazonaws.com";
+        }
+
+        parent::__construct($args);
+    }
+}


### PR DESCRIPTION
Appstream has a customized `endpointPrefix` as `appstream2`.
This PR works as a quick fix to address the issue.

Similar issue happened with `elasticloadbalancingv2` in the past. In the long run, we might perhaps need to consider injecting `endpoint_prefix` metadata into our endpoint sourcing chain.

@imshashank @jeskew 