### PR TITLE
Chore/sync protocol tests

### DIFF
--- a/src/Api/Serializer/XmlBody.php
+++ b/src/Api/Serializer/XmlBody.php
@@ -38,7 +38,7 @@ class XmlBody
         $xml = new XMLWriter();
         $xml->openMemory();
         $xml->startDocument('1.0', 'UTF-8');
-        $this->format($shape, $shape['locationName'], $args, $xml);
+        $this->format($shape, $shape['locationName'] ?: $shape['name'], $args, $xml);
         $xml->endDocument();
 
         return $xml->outputMemory();

--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -102,6 +102,13 @@ class AwsClient implements AwsClientInterface
      *   accepts a PSR-7 request object and returns a promise that is fulfilled
      *   with a PSR-7 response object or rejected with an array of exception
      *   data. NOTE: This option supersedes any provided "handler" option.
+     * - idempotency_auto_fill: (bool|callable) Set to false to disable SDK to
+     *   populate parameters that enabled 'idempotencyToken' trait with a random
+     *   UUID v4 value on your behalf. Using default value 'true' still allows
+     *   parameter value to be overwritten when provided. Note: auto-fill only
+     *   works when cryptographically secure random bytes generator functions
+     *   (random_bytes, openssl_random_pseudo_bytes or mcrypt_create_iv) can be
+     *   found. You may also provide a callable source of random bytes.
      * - profile: (string) Allows you to specify which profile to use when
      *   credentials are created from the AWS credentials file in your HOME
      *   directory. This setting overrides the AWS_PROFILE environment

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -185,6 +185,13 @@ class ClientResolver
             'fn'       => [__CLASS__, '_apply_user_agent'],
             'default'  => [],
         ],
+        'idempotency_auto_fill' => [
+            'type'      => 'value',
+            'valid'     => ['bool', 'callable'],
+            'doc'       => 'Set to false to disable SDK to populate parameters that enabled \'idempotencyToken\' trait with a random UUID v4 value on your behalf. Using default value \'true\' still allows parameter value to be overwritten when provided. Note: auto-fill only works when cryptographically secure random bytes generator functions(random_bytes, openssl_random_pseudo_bytes or mcrypt_create_iv) can be found. You may also provide a callable source of random bytes.',
+            'default'   => true,
+            'fn'        => [__CLASS__, '_apply_idempotency_auto_fill']
+        ],
     ];
 
     /**
@@ -559,6 +566,30 @@ class ClientResolver
         }
 
         $args['endpoint'] = $value;
+    }
+
+    public static function _apply_idempotency_auto_fill(
+        $value,
+        array &$args,
+        HandlerList $list
+    ) {
+        $enabled = false;
+        $generator = null;
+
+
+        if (is_bool($value)) {
+            $enabled = $value;
+        } elseif (is_callable($value)) {
+            $enabled = true;
+            $generator = $value;
+        }
+
+        if ($enabled) {
+            $list->prependInit(
+                IdempotencyTokenMiddleware::wrap($args['api'], $generator),
+                'idempotency_auto_fill'
+            );
+        }
     }
 
     public static function _default_endpoint_provider(array $args)

--- a/src/Ec2/Ec2Client.php
+++ b/src/Ec2/Ec2Client.php
@@ -5,8 +5,8 @@ use Aws\AwsClient;
 use Aws\Api\Service;
 use Aws\Api\DocModel;
 use Aws\Api\ApiProvider;
-use Aws\IdempotencyTokenMiddleware;
 use Aws\PresignUrlMiddleware;
+
 /**
  * Client used to interact with Amazon EC2.
  *
@@ -467,39 +467,6 @@ use Aws\PresignUrlMiddleware;
  */
 class Ec2Client extends AwsClient
 {
-    public static function getArguments()
-    {
-        $args = parent::getArguments();
-        return $args + [
-            'idempotency_auto_fill' => [
-                'type'    => 'config',
-                'valid'   => ['bool'],
-                'doc'     => 'Set to false to disable SDK to populate parameters that'
-                    . ' enabled \'idempotencyToken\' trait with a random UUID v4'
-                    . ' value on your behalf. Using default value \'true\' still allows'
-                    . ' parameter value to be overwritten when provided. Note:'
-                    . ' auto-fill only works when cryptographically secure random'
-                    . ' bytes generator functions(random_bytes, openssl_random_pseudo_bytes'
-                    . ' or mcrypt_create_iv) can be found.',
-                'default' => true,
-            ],
-        ];
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * In addition to the options available to
-     * {@see Aws\AwsClient::__construct}, Ec2Client accepts the following
-     * options:
-     *
-     * - idempotency_auto_fill: (bool) Set to false to disable SDK to populate
-     *   parameters that enabled 'idempotencyToken' trait with a default UUID v4
-     *   value on your behalf. Using default value 'true' still allows parameter
-     *   value to be overwritten when provided.
-     *
-     * @param array $args
-     */
     public function __construct(array $args)
     {
         $args['with_resolved'] = function (array $args) {
@@ -520,13 +487,6 @@ class Ec2Client extends AwsClient
         };
 
         parent::__construct($args);
-        if ($this->getConfig('idempotency_auto_fill')) {
-            $stack = $this->getHandlerList();
-            $stack->prependInit(
-                IdempotencyTokenMiddleware::wrap($this->getApi()),
-                'ec2.idempotency_auto_fill'
-            );
-        }
     }
 
     /**

--- a/src/IdempotencyTokenMiddleware.php
+++ b/src/IdempotencyTokenMiddleware.php
@@ -27,18 +27,30 @@ class IdempotencyTokenMiddleware
      *  - openssl_random_pseudo_bytes (requires 'openssl' module enabled)
      *  - mcrypt_create_iv (requires 'mcrypt' module enabled)
      *
+     * You may also supply a custom bytes generator as an optional second
+     * parameter.
+     *
      * @param \Aws\Api\Service $service
+     * @param callable|null $bytesGenerator
+     *
      * @return callable
      */
-    public static function wrap(Service $service)
-    {
-        return function (callable $handler) use ($service) {
-            return new self($handler, $service);
+    public static function wrap(
+        Service $service,
+        callable $bytesGenerator = null
+    ) {
+        return function (callable $handler) use ($service, $bytesGenerator) {
+            return new self($handler, $service, $bytesGenerator);
         };
     }
 
-    public function __construct(callable $nextHandler, Service $service) {
-        $this->bytesGenerator = $this->checkCompatibility();
+    public function __construct(
+        callable $nextHandler,
+        Service $service,
+        callable $bytesGenerator = null
+    ) {
+        $this->bytesGenerator = $bytesGenerator
+            ?: $this->findCompatibleRandomSource();
         $this->service = $service;
         $this->nextHandler = $nextHandler;
     }
@@ -52,11 +64,12 @@ class IdempotencyTokenMiddleware
             $operation = $this->service->getOperation($command->getName());
             $members = $operation->getInput()->getMembers();
             foreach ($members as $member => $value) {
-                if (!empty($value->toArray()['idempotencyToken'])) {
+                if ($value['idempotencyToken']) {
                     $bytes = call_user_func($this->bytesGenerator, 16);
                     // populating UUIDv4 only when the parameter is not set
-                    $command[$member] = $command[$member] ?: $this->getUUIDV4($bytes);
-                    // only one member could have the trait enabled as identifier
+                    $command[$member] = $command[$member]
+                        ?: $this->getUuidV4($bytes);
+                    // only one member could have the trait enabled
                     break;
                 }
             }
@@ -74,7 +87,7 @@ class IdempotencyTokenMiddleware
      * https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29
      * https://tools.ietf.org/html/rfc4122#page-14
      */
-    private static function getUUIDV4($bytes)
+    private static function getUuidV4($bytes)
     {
         // set version to 0100
         $bytes[6] = chr(ord($bytes[6]) & 0x0f | 0x40);
@@ -84,12 +97,11 @@ class IdempotencyTokenMiddleware
     }
 
     /**
-     * This function decides the PHP function used in
-     * generating random bytes.
+     * This function decides the PHP function used in generating random bytes.
      *
      * @return callable|null
      */
-    private function checkCompatibility()
+    private function findCompatibleRandomSource()
     {
         if (function_exists('random_bytes')) {
             return 'random_bytes';

--- a/src/Ssm/SsmClient.php
+++ b/src/Ssm/SsmClient.php
@@ -2,7 +2,6 @@
 namespace Aws\Ssm;
 
 use Aws\AwsClient;
-use Aws\IdempotencyTokenMiddleware;
 
 /**
  * Amazon EC2 Simple Systems Manager client.
@@ -168,50 +167,4 @@ use Aws\IdempotencyTokenMiddleware;
  * @method \Aws\Result updatePatchBaseline(array $args = [])
  * @method \GuzzleHttp\Promise\Promise updatePatchBaselineAsync(array $args = [])
  */
-class SsmClient extends AwsClient
-{
-    public static function getArguments()
-    {
-        $args = parent::getArguments();
-        return $args + [
-            'idempotency_auto_fill' => [
-                'type'    => 'config',
-                'valid'   => ['bool'],
-                'doc'     => 'Set to false to disable SDK to populate parameters that'
-                    . ' enabled \'idempotencyToken\' trait with a random UUID v4'
-                    . ' value on your behalf. Using default value \'true\' still allows'
-                    . ' parameter value to be overwritten when provided. Note:'
-                    . ' auto-fill only works when cryptographically secure random'
-                    . ' bytes generator functions(random_bytes, openssl_random_pseudo_bytes'
-                    . ' or mcrypt_create_iv) can be found.',
-                'default' => true,
-            ],
-        ];
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * In addition to the options available to
-     * {@see Aws\AwsClient::__construct}, SsmClient accepts the following
-     * options:
-     *
-     * - idempotency_auto_fill: (bool) Set to false to disable SDK to populate
-     *   parameters that enabled 'idempotencyToken' trait with a default UUID v4
-     *   value on your behalf. Using default value 'true' still allows parameter
-     *   value to be overwritten when provided.
-     *
-     * @param array $args
-     */
-    public function __construct(array $args)
-    {
-        parent::__construct($args);
-        if ($this->getConfig('idempotency_auto_fill')) {
-            $stack = $this->getHandlerList();
-            $stack->prependInit(
-                IdempotencyTokenMiddleware::wrap($this->getApi()),
-                'ssm.idempotency_auto_fill'
-            );
-        }
-    }
-}
+class SsmClient extends AwsClient {}

--- a/tests/Api/Serializer/ComplianceTest.php
+++ b/tests/Api/Serializer/ComplianceTest.php
@@ -6,15 +6,15 @@ use Aws\AwsClient;
 use Aws\Test\UsesServiceTrait;
 
 /**
- * @covers Aws\Api\Serializer\QuerySerializer
- * @covers Aws\Api\Serializer\JsonRpcSerializer
- * @covers Aws\Api\Serializer\RestSerializer
- * @covers Aws\Api\Serializer\RestJsonSerializer
- * @covers Aws\Api\Serializer\RestXmlSerializer
- * @covers Aws\Api\Serializer\JsonBody
- * @covers Aws\Api\Serializer\XmlBody
- * @covers Aws\Api\Serializer\Ec2ParamBuilder
- * @covers Aws\Api\Serializer\QueryParamBuilder
+ * @covers \Aws\Api\Serializer\QuerySerializer
+ * @covers \Aws\Api\Serializer\JsonRpcSerializer
+ * @covers \Aws\Api\Serializer\RestSerializer
+ * @covers \Aws\Api\Serializer\RestJsonSerializer
+ * @covers \Aws\Api\Serializer\RestXmlSerializer
+ * @covers \Aws\Api\Serializer\JsonBody
+ * @covers \Aws\Api\Serializer\XmlBody
+ * @covers \Aws\Api\Serializer\Ec2ParamBuilder
+ * @covers \Aws\Api\Serializer\QueryParamBuilder
  */
 class ComplianceTest extends \PHPUnit_Framework_TestCase
 {
@@ -79,6 +79,9 @@ class ComplianceTest extends \PHPUnit_Framework_TestCase
             'serializer'   => Service::createSerializer($service, $ep),
             'version'      => 'latest',
             'validate'     => false,
+            'idempotency_auto_fill' => function ($length) {
+                return str_repeat(chr(0x00), $length);
+            }
         ]);
 
         $command = $client->getCommand($name, $args);

--- a/tests/Api/test_cases/protocols/input/ec2.json
+++ b/tests/Api/test_cases/protocols/input/ec2.json
@@ -356,5 +356,59 @@
         }
       }
     ]
+  },
+  {
+    "description": "Idempotency token auto fill",
+    "metadata": {
+      "protocol": "ec2",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Token": {
+            "shape": "StringType",
+              "idempotencyToken": true
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Token": "abc123"
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {},
+          "body": "Action=OperationName&Version=2014-01-01&Token=abc123"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {},
+          "body": "Action=OperationName&Version=2014-01-01&Token=00000000-0000-4000-8000-000000000000"
+        }
+      }
+    ]
   }
 ]

--- a/tests/Api/test_cases/protocols/input/json.json
+++ b/tests/Api/test_cases/protocols/input/json.json
@@ -426,7 +426,7 @@
     "description": "Empty maps",
     "metadata": {
       "protocol": "json",
-      "jsonVersion": 1.1,
+      "jsonVersion": "1.1",
       "targetPrefix": "com.amazonaws.foo"
     },
     "shapes": {
@@ -472,6 +472,66 @@
             "Content-Type": "application/x-amz-json-1.1"
           },
           "uri": "/"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Idempotency token auto fill",
+    "metadata": {
+      "protocol": "json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Token": {
+            "shape": "StringType",
+              "idempotencyToken": true
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Token": "abc123"
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {},
+          "body": "{\"Token\": \"abc123\"}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {},
+          "body": "{\"Token\": \"00000000-0000-4000-8000-000000000000\"}"
         }
       }
     ]

--- a/tests/Api/test_cases/protocols/input/query.json
+++ b/tests/Api/test_cases/protocols/input/query.json
@@ -776,5 +776,65 @@
         }
       }
     ]
+  },
+  {
+    "description": "Idempotency token auto fill",
+    "metadata": {
+      "protocol": "query",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Token": {
+            "shape": "StringType",
+              "idempotencyToken": true
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Token": "abc123"
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {},
+          "body": "Action=OperationName&Version=2014-01-01&Token=abc123"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+        },
+        "serialized": {
+          "uri": "/",
+          "headers": {},
+          "body": "Action=OperationName&Version=2014-01-01&Token=00000000-0000-4000-8000-000000000000"
+        }
+      }
+    ]
   }
 ]

--- a/tests/Api/test_cases/protocols/input/rest-json.json
+++ b/tests/Api/test_cases/protocols/input/rest-json.json
@@ -658,7 +658,7 @@
       {
         "given": {
           "http": {
-            "method": "GET",
+            "method": "POST",
             "requestUri": "/2014-01-01/{Foo}"
           },
           "input": {
@@ -673,6 +673,142 @@
         "serialized": {
           "body": "{\"Bar\": \"QmxvYiBwYXJhbQ==\"}",
           "uri": "/2014-01-01/foo_name"
+        }
+      }
+    ]
+  },
+    {
+    "description": "Blob payload",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "FooShape"
+          }
+        }
+      },
+      "FooShape": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "foo": "bar"
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "bar",
+          "uri": "/"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Structure payload",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "FooShape"
+          }
+        }
+      },
+      "FooShape": {
+        "locationName": "foo",
+        "type": "structure",
+        "members": {
+          "baz": {
+            "shape": "BazShape"
+          }
+        }
+      },
+      "BazShape": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "foo": {
+            "baz": "bar"
+          }
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "{\"baz\": \"bar\"}",
+          "uri": "/"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {},
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/"
         }
       }
     ]
@@ -1056,6 +1192,111 @@
           "uri": "/path",
           "headers": {},
           "body": "{\"timestamp_location\": 1422172800}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "String payload",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "FooShape"
+          }
+        }
+      },
+      "FooShape": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "foo": "bar"
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "bar",
+          "uri": "/"
+        }
+      }
+    ]
+  },
+  {
+    "description": "Idempotency token auto fill",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Token": {
+            "shape": "StringType",
+              "idempotencyToken": true
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Token": "abc123"
+        },
+        "serialized": {
+          "uri": "/path",
+          "headers": {},
+          "body": "{\"Token\": \"abc123\"}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+        },
+        "serialized": {
+          "uri": "/path",
+          "headers": {},
+          "body": "{\"Token\": \"00000000-0000-4000-8000-000000000000\"}"
         }
       }
     ]

--- a/tests/Api/test_cases/protocols/input/rest-xml.json
+++ b/tests/Api/test_cases/protocols/input/rest-xml.json
@@ -725,7 +725,7 @@
   {
     "description": "Querystring list of strings",
     "metadata": {
-      "protocol": "rest-json",
+      "protocol": "rest-xml",
       "apiVersion": "2014-01-01"
     },
     "shapes": {
@@ -1627,6 +1627,68 @@
           "body": "",
           "uri": "/path",
           "headers": {"x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT"}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Idempotency token auto fill",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "Token": {
+            "shape": "StringType",
+              "idempotencyToken": true
+          }
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Token": "abc123"
+        },
+        "serialized": {
+          "uri": "/path",
+          "headers": {},
+          "body": "<InputShape><Token>abc123</Token></InputShape>"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST",
+            "requestUri": "/path"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+        },
+        "serialized": {
+          "uri": "/path",
+          "headers": {},
+          "body": "<InputShape><Token>00000000-0000-4000-8000-000000000000</Token></InputShape>"
         }
       }
     ]

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Test;
 
+use Aws\Api\Service;
 use Aws\ClientResolver;
 use Aws\CommandInterface;
 use Aws\Credentials\CredentialProvider;
@@ -647,6 +648,37 @@ EOT;
                 'signing_region',
                 'us-east-1',
             ],
+        ];
+    }
+
+    /**
+     * @dataProvider idempotencyAutoFillProvider
+     *
+     * @param mixed $value
+     * @param bool $shouldAddIdempotencyMiddleware
+     */
+    public function testIdempotencyTokenMiddlewareAddedAsAppropriate(
+        $value,
+        $shouldAddIdempotencyMiddleware
+    ){
+        $args = [
+            'api' => new Service([], function () { return []; }),
+        ];
+        $list = new HandlerList;
+
+        $this->assertSame(0, count($list));
+        ClientResolver::_apply_idempotency_auto_fill($value, $args, $list);
+        $this->assertSame($shouldAddIdempotencyMiddleware ? 1 : 0, count($list));
+    }
+
+    public function idempotencyAutoFillProvider()
+    {
+        return [
+            [true, true],
+            [false, false],
+            ['truthy', false],
+            ['openssl_random_pseudo_bytes', true],
+            [function ($length) { return 'foo'; }, true],
         ];
     }
 }


### PR DESCRIPTION
This PR syncs the SDK protocol tests. In order to get the idempotency token tests passing, I moved the `idempotency_auto_fill` option from an Ec2/Ssm customization to one that can be used with any client.

/cc @cjyclaire && @imshashank 