### PR TITLE
Fix bad version constraint in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
-        "guzzlehttp/psr7": "~1.3.1",
+        "guzzlehttp/psr7": "^1.3.1",
         "guzzlehttp/promises": "~1.0",
-        "mtdowling/jmespath.php": "~2.2"
+        "mtdowling/jmespath.php": "^2.2"
     },
     "require-dev": {
         "ext-openssl": "*",


### PR DESCRIPTION
I just ran `composer update` on a project and guzzlehttp/psr7 was upgraded to 1.4.0, which _downgraded_ the PHP SDK to version 3.18.23 because that was the most recent version of the PHP SDK which allows guzzlehttp/psr7 1.4. Presumably the `guzzlehttp/psr7: ~1.3.1` constraint, which is shorthand for `>=1.3.1,<1.4`, is not what was intended here, so I have changed the constraint accordingly to allow for non-BC-breaking changes to guzzlehttp/psr7. I have also changed `mtdowling/jmespath.php: ~2.2` to `^2.2` to prevent someone from making the same mistake there in future.