### PR TITLE
Prefer the signing name provided by the service model to that provided by the endpoint provider

### DIFF
--- a/features/smoke/application-autoscaling.feature
+++ b/features/smoke/application-autoscaling.feature
@@ -1,0 +1,8 @@
+# language: en
+@application-autoscaling
+Feature: Application Auto Scaling
+
+  Scenario: Making a request
+    When I call the "DescribeScalableTargets" API with:
+    | ServiceNamespace | ec2 |
+    Then the value at "ScalableTargets" should be a list

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -412,6 +412,14 @@ class ClientResolver
             ),
             $value
         );
+
+        if (
+            empty($args['config']['signing_name'])
+            && isset($api['metadata']['signingName'])
+        ) {
+            $args['config']['signing_name'] = $api['metadata']['signingName'];
+        }
+
         $args['api'] = $api;
         $args['parser'] = Service::createParser($api);
         $args['error_parser'] = Service::createErrorParser($api->getProtocol());
@@ -433,13 +441,25 @@ class ClientResolver
 
             $args['endpoint'] = $result['endpoint'];
 
-            if (isset($result['signatureVersion'])) {
-                $args['config']['signature_version'] = $result['signatureVersion'];
+            if (
+                empty($args['config']['signature_version'])
+                && isset($result['signatureVersion'])
+            ) {
+                $args['config']['signature_version']
+                    = $result['signatureVersion'];
             }
-            if (isset($result['signingRegion'])) {
+
+            if (
+                empty($args['config']['signing_region'])
+                && isset($result['signingRegion'])
+            ) {
                 $args['config']['signing_region'] = $result['signingRegion'];
             }
-            if (isset($result['signingName'])) {
+
+            if (
+                empty($args['config']['signing_name'])
+                && isset($result['signingName'])
+            ) {
                 $args['config']['signing_name'] = $result['signingName'];
             }
         }

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -94,6 +94,48 @@ class ClientResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('serializer', $conf);
     }
 
+    public function testAppliesApiProviderSigningNameToConfig()
+    {
+        $signingName = 'foo';
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $conf = $r->resolve([
+            'service'      => 'dynamodb',
+            'region'       => 'x',
+            'api_provider' => function () use ($signingName) {
+                return ['metadata' => [
+                    'protocol' => 'query',
+                    'signingName' => $signingName,
+                ]];
+            },
+            'version'      => 'latest'
+        ], new HandlerList());
+        $this->assertSame($conf['config']['signing_name'], $signingName);
+    }
+
+    public function testPrefersApiProviderNameToPartitionName()
+    {
+        $signingName = 'foo';
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $conf = $r->resolve([
+            'service'      => 'dynamodb',
+            'region'       => 'x',
+            'api_provider' => function () use ($signingName) {
+                return ['metadata' => [
+                    'protocol' => 'query',
+                    'signingName' => $signingName,
+                ]];
+            },
+            'endpoint_provider' => function () use ($signingName) {
+                return [
+                    'endpoint' => 'https://www.amazon.com',
+                    'signingName' => "not_$signingName",
+                ];
+            },
+            'version'      => 'latest'
+        ], new HandlerList());
+        $this->assertSame($conf['config']['signing_name'], $signingName);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Invalid configuration value provided for "foo". Expected string, but got int(-1)


### PR DESCRIPTION
This change addresses a regression introduced in #1192 that affects services that share an endpoint prefix. The `signingName` metadata member present in the service model is used instead of the one returned by the endpoint provider.

/cc @cjyclaire && @imshashank 