### PR TITLE
Update version constraint on guzzlehttp/psr7 to allow 1.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
-        "guzzlehttp/psr7": "~1.3.1",
+        "guzzlehttp/psr7": "^1.3.1, !=1.4.0",
         "guzzlehttp/promises": "~1.0",
         "mtdowling/jmespath.php": "~2.2"
     },

--- a/src/S3/PostObject.php
+++ b/src/S3/PostObject.php
@@ -132,7 +132,7 @@ class PostObject
             && strpos($this->bucket, '.') !== false
         ) {
             // Use path-style URLs
-            $uri = $uri->withPath($this->bucket);
+            $uri = $uri->withPath("/{$this->bucket}");
         } else {
             // Use virtual-style URLs
             $uri = $uri->withHost($this->bucket . '.' . $uri->getHost());

--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -21,7 +21,6 @@ class PostObjectV4
     private $bucket;
     private $formAttributes;
     private $formInputs;
-    private $jsonPolicy;
 
     /**
      * Constructs the PostObject.
@@ -149,7 +148,7 @@ class PostObjectV4
             && strpos($this->bucket, '.') !== false
         ) {
             // Use path-style URLs
-            $uri = $uri->withPath($this->bucket);
+            $uri = $uri->withPath("/{$this->bucket}");
         } else {
             // Use virtual-style URLs if haven't been set up already
             if (strpos($uri->getHost(), $this->bucket . '.') !== 0) {


### PR DESCRIPTION
This change allows the SDK to pull in new versions of the Guzzle PSR7 package other than 1.4.0. It also addresses deprecation notices that arise when using `Aws\S3\PostObject` and `Aws\S3\PostObjectV4`.

Resolves #1195 

/cc @cjyclaire && @imshashank 