### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^5.3.1|^6.2.1",
+        "guzzlehttp/guzzle": "^5.3.1||^6.2.1",
         "guzzlehttp/psr7": "^1.3.1, !=1.4.0",
         "guzzlehttp/promises": "~1.0",
         "mtdowling/jmespath.php": "~2.2"


### PR DESCRIPTION
According to [the composer documentation](https://getcomposer.org/doc/articles/versions.md#range), a **double pipe** must be used to express a logical OR in version constraints.

Fixes #1205