### PR TITLE
Replace deprecated Guzzle Uri::resolve calls

### DIFF
--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -192,6 +192,6 @@ abstract class RestSerializer
 
         // Expand path place holders using Amazon's slightly different URI
         // template syntax.
-        return Psr7\Uri::resolve($this->endpoint, $relative);
+        return Psr7\UriResolver::resolve($this->endpoint, $relative);
     }
 }

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -87,7 +87,7 @@ class SqsClient extends AwsClient
                 RequestInterface $r = null
             ) use ($handler) {
                 if ($c->hasParam('QueueUrl')) {
-                    $uri = Uri::resolve($r->getUri(), $c['QueueUrl']);
+                    $uri = UriResolver::resolve($r->getUri(), $c['QueueUrl']);
                     $r = $r->withUri($uri);
                 }
                 return $handler($c, $r);


### PR DESCRIPTION
To avoid the "GuzzleHttp\Psr7\Uri::resolve is deprecated since version 1.4" error. Replaced with GuzzleHttp\Psr7\UriResolver::resolve.