### PR TITLE
Replace deprecated Guzzle Uri::resolve calls

### DIFF
--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -193,7 +193,7 @@ abstract class RestSerializer
         // Expand path place holders using Amazon's slightly different URI
         // template syntax.
         if(class_exists('GuzzleHttp\Psr7\UriResolver')){
-            return Psr7\UriResolver::resolve($this->endpoint, $relative);
+            return Psr7\UriResolver::resolve($this->endpoint, Psr7\uri_for($relative));
         }
         return Psr7\Uri::resolve($this->endpoint, $relative);
     }

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -192,7 +192,7 @@ abstract class RestSerializer
 
         // Expand path place holders using Amazon's slightly different URI
         // template syntax.
-        if(class_exists('GuzzleHttp\Psr7\UriResolver')){
+        if(class_exists('GuzzleHttp\Psr7\UriResolver') && method_exists('GuzzleHttp\Psr7\UriResolver', 'resolve')){
             return Psr7\UriResolver::resolve($this->endpoint, Psr7\uri_for($relative));
         }
         return Psr7\Uri::resolve($this->endpoint, $relative);

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -192,6 +192,9 @@ abstract class RestSerializer
 
         // Expand path place holders using Amazon's slightly different URI
         // template syntax.
+        if(class_exists('GuzzleHttp\Psr7\UriResolver')){
+            return Psr7\UriResolver::resolve($this->endpoint, $relative);
+        }
         return Psr7\Uri::resolve($this->endpoint, $relative);
     }
 }

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -87,7 +87,7 @@ class SqsClient extends AwsClient
                 RequestInterface $r = null
             ) use ($handler) {
                 if ($c->hasParam('QueueUrl')) {
-                    if(class_exists('GuzzleHttp\Psr7\UriResolver')){
+                    if(class_exists('GuzzleHttp\Psr7\UriResolver') && method_exists('GuzzleHttp\Psr7\UriResolver', 'resolve')){
                         $uri = GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(), Psr7\uri_for($c['QueueUrl']));
                     }
                     else{

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -88,7 +88,7 @@ class SqsClient extends AwsClient
             ) use ($handler) {
                 if ($c->hasParam('QueueUrl')) {
                     if(class_exists('GuzzleHttp\Psr7\UriResolver') && method_exists('GuzzleHttp\Psr7\UriResolver', 'resolve')){
-                        $uri = GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(), Psr7\uri_for($c['QueueUrl']));
+                        $uri = GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(),  GuzzleHttp\Psr7\uri_for($c['QueueUrl']));
                     }
                     else{
                         $uri = Uri::resolve($r->getUri(), $c['QueueUrl']);

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -87,8 +87,8 @@ class SqsClient extends AwsClient
                 RequestInterface $r = null
             ) use ($handler) {
                 if ($c->hasParam('QueueUrl')) {
-                    if(class_exists('GuzzleHttp\Psr7\UriResolver') && method_exists('GuzzleHttp\Psr7\UriResolver', 'resolve')){
-                        $uri = GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(),  GuzzleHttp\Psr7\uri_for($c['QueueUrl']));
+                    if(class_exists('\GuzzleHttp\Psr7\UriResolver') && method_exists('\GuzzleHttp\Psr7\UriResolver', 'resolve')){
+                        $uri = \GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(),  \GuzzleHttp\Psr7\uri_for($c['QueueUrl']));
                     }
                     else{
                         $uri = Uri::resolve($r->getUri(), $c['QueueUrl']);

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -88,7 +88,7 @@ class SqsClient extends AwsClient
             ) use ($handler) {
                 if ($c->hasParam('QueueUrl')) {
                     if(class_exists('GuzzleHttp\Psr7\UriResolver')){
-                        $uri = GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(), $c['QueueUrl']);
+                        $uri = GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(), Psr7\uri_for($c['QueueUrl']));
                     }
                     else{
                         $uri = Uri::resolve($r->getUri(), $c['QueueUrl']);

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -87,7 +87,12 @@ class SqsClient extends AwsClient
                 RequestInterface $r = null
             ) use ($handler) {
                 if ($c->hasParam('QueueUrl')) {
-                    $uri = Uri::resolve($r->getUri(), $c['QueueUrl']);
+                    if(class_exists('GuzzleHttp\Psr7\UriResolver')){
+                        $uri = GuzzleHttp\Psr7\UriResolver::resolve($r->getUri(), $c['QueueUrl']);
+                    }
+                    else{
+                        $uri = Uri::resolve($r->getUri(), $c['QueueUrl']);
+                    }
                     $r = $r->withUri($uri);
                 }
                 return $handler($c, $r);


### PR DESCRIPTION
Same idea as #1210 , with unit tests passing

Checks for existence of UriResolver::resolve at runtime and uses it preferentially.

A workaround until guzzle/psr7 PR is merged (https://github.com/guzzle/psr7/pull/140)

(I realise @jeskew argued against resorting to this runtime check, but some people just need this to be working again)
  