### PR TITLE
Fix listing of root directory of bucket

### DIFF
--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -493,9 +493,11 @@ class StreamWrapper
         $this->objectIterator->next();
 
         // Remove the prefix from the result to emulate other stream wrappers.
-        return $this->openedBucketPrefix
+        $dir = $this->openedBucketPrefix
             ? substr($result, strlen($this->openedBucketPrefix))
             : $result;
+        // Do not return empty string, but a dot for the current directory
+        return $dir === '' ? '.' : $dir;
     }
 
     private function formatKey($key)


### PR DESCRIPTION
When I use `scandir('s3://bucket.name/')` the first result is an empty string,
representing the root directory of the bucket. This should rather be a dot.

This is especially required, when using `DirectoryIterator`, as an empty result
will yield this iterator to be empty as well, leading to an empty directory listing on root level.