### PR TITLE
Update MultiRegionClient and S3MultiRegionClient to honor middleware

### DIFF
--- a/src/Endpoint/Partition.php
+++ b/src/Endpoint/Partition.php
@@ -1,14 +1,16 @@
 <?php
 namespace Aws\Endpoint;
 
+use ArrayAccess;
+use Aws\HasDataTrait;
 use InvalidArgumentException as Iae;
 
 /**
  * Default implementation of an AWS partition.
  */
-final class Partition implements PartitionInterface
+final class Partition implements ArrayAccess, PartitionInterface
 {
-    private $data;
+    use HasDataTrait;
 
     /**
      * The partition constructor accepts the following options:

--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -70,8 +70,6 @@ class ObjectCopier implements PromisorInterface
      * Perform the configured copy asynchronously. Returns a promise that is
      * fulfilled with the result of the CompleteMultipartUpload or CopyObject
      * operation or rejected with an exception.
-     *
-     * @return \GuzzleHttp\Promise\Promise
      */
     public function promise()
     {

--- a/tests/MultiRegionClientTest.php
+++ b/tests/MultiRegionClientTest.php
@@ -95,7 +95,7 @@ class MultiRegionClientTest extends \PHPUnit_Framework_TestCase
             });
         $this->mockRegionalClient->expects($this->once())
             ->method('getCommand')
-            ->with('baz', ['foo' => 'bar'])
+            ->with('baz', ['foo' => 'bar', '@http' => []])
             ->willReturn(new Command('Baz', [], $mockHandler));
 
         $this->instance->baz(['foo' => 'bar']);
@@ -121,7 +121,6 @@ class MultiRegionClientTest extends \PHPUnit_Framework_TestCase
         return [
             ['getConfig', ['someOption']],
             ['getCredentials', []],
-            ['getHandlerList', []],
             ['getApi', []],
             ['getEndpoint', []],
         ];


### PR DESCRIPTION
This PR would resolve #1207.

The root cause of the issue was that 'regionalizing' commands within the `S3MultiRegionClient` was occurring inside the client's `executeAsync` method, where the command would be executed and, on failure, recreated using the appropriate region. The trouble with that approach was that the multipart uploader was keeping track of completed and failed parts by adding middleware to the UploadPart command's handler list, and this list was not shared between different regionalized commands.

This PR removes the custom implementation of `executeAsync` in favor of applying regionalization via a 'determine_region' middleware. MultiRegion clients now have and execute their own (usually empty) middleware stacks, the core handler of which executes the operation on the appropriate regionalized client.

/cc @mtdowling @cjyclaire @imshashank 