### PR TITLE
Allow request options in S3/ObjectCopier

### DIFF
--- a/src/S3/MultipartCopy.php
+++ b/src/S3/MultipartCopy.php
@@ -13,6 +13,8 @@ class MultipartCopy extends AbstractUploadManager
     private $source;
     /** @var ResultInterface */
     private $sourceMetadata;
+    /** @var array */
+    private $options;
 
     /**
      * Creates a multipart upload for copying an S3 object.
@@ -55,6 +57,7 @@ class MultipartCopy extends AbstractUploadManager
         array $config = []
     ) {
         $this->source = '/' . ltrim($source, '/');
+        $this->options = $config;
         parent::__construct($client, array_change_key_case($config) + [
             'source_metadata' => null
         ]);
@@ -98,6 +101,7 @@ class MultipartCopy extends AbstractUploadManager
                     $this->info['command']['upload'],
                     $this->createPart($partNumber, $parts)
                         + $this->getState()->getId()
+                        + $this->options
                 );
                 $command->getHandlerList()->appendSign($resultHandler, 'mup');
                 yield $command;

--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -75,7 +75,7 @@ class ObjectCopier implements PromisorInterface
     {
         return \GuzzleHttp\Promise\coroutine(function () {
             $objectStats = (yield $this->client->executeAsync(
-                $this->client->getCommand('HeadObject', $this->source)
+                $this->client->getCommand('HeadObject', $this->source + $this->options)
             ));
 
             if ($objectStats['ContentLength'] > $this->options['mup_threshold']) {

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -104,10 +104,14 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
             'CopySource' => '/bucket/key?versionId=V+ID',
         ];
 
+        $defaultOptions = (new \ReflectionClass(ObjectCopier::class))
+            ->getProperty('defaults');
+        $defaultOptions->setAccessible(true);
+
         $client->expects($this->exactly(2))
             ->method('getCommand')
             ->will($this->returnValueMap([
-                ['HeadObject', $headCommandParams, $headObjectCommand],
+                ['HeadObject', $headCommandParams + $defaultOptions->getValue(), $headObjectCommand],
                 ['CopyObject', $copyCommandParams, $copyObjectCommand],
             ]));
 


### PR DESCRIPTION
This PR attempts to fix https://github.com/aws/aws-sdk-php/issues/1232

`ObjectCopier` doesn't handle any option you specify.

A simple use case to reproduce this issue is to use `IfUnmodifiedSince` option with a big value(`-1000 days` for example) and see the SDK doesn't fail at the first Head request like he should do.

The changes brought by this PR are pretty simple and shouldn't affect anything else.
I decided to not validate the options to because I don't think we really need it.

Let me know what I need to do any modifications


