### PR TITLE
Preserve iterator keys in CommandPool

### DIFF
--- a/src/CommandPool.php
+++ b/src/CommandPool.php
@@ -58,7 +58,7 @@ class CommandPool implements PromisorInterface
                 if ($before) {
                     $before($command, $key);
                 }
-                yield $client->executeAsync($command);
+                yield $key => $client->executeAsync($command);
             }
         };
 


### PR DESCRIPTION
CommandPool was preserving iterator keys only in "before" section but not the others. 