### PR TITLE
Add method to get service error message if available (like v2)

### DIFF
--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -87,7 +87,7 @@ class AwsException extends \RuntimeException
     /**
      * Get the concise error message if any.
      *
-     * @return string
+     * @return string|null
      */
     public function getErrorMessage()
     {

--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -21,6 +21,7 @@ class AwsException extends \RuntimeException
     private $errorCode;
     private $connectionError;
     private $transferInfo;
+    private $errorMessage;
 
     /**
      * @param string           $message Exception message
@@ -47,6 +48,9 @@ class AwsException extends \RuntimeException
         $this->transferInfo = isset($context['transfer_stats'])
             ? $context['transfer_stats']
             : [];
+        $this->errorMessage = isset($context['message'])
+            ? $context['message']
+            : null;
         parent::__construct($message, 0, $previous);
     }
 
@@ -78,6 +82,16 @@ class AwsException extends \RuntimeException
     public function getCommand()
     {
         return $this->command;
+    }
+
+    /**
+     * Get the concise error message if any.
+     *
+     * @return CommandInterface
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
     }
 
     /**

--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -87,7 +87,7 @@ class AwsException extends \RuntimeException
     /**
      * Get the concise error message if any.
      *
-     * @return CommandInterface
+     * @return string
      */
     public function getErrorMessage()
     {

--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -89,7 +89,7 @@ class AwsException extends \RuntimeException
      *
      * @return string|null
      */
-    public function getErrorMessage()
+    public function getAwsErrorMessage()
     {
         return $this->errorMessage;
     }

--- a/tests/Exception/AwsExceptionTest.php
+++ b/tests/Exception/AwsExceptionTest.php
@@ -59,7 +59,7 @@ class AwsExceptionTest extends \PHPUnit_Framework_TestCase
     {
         $command = new Command('foo');
         $e = new AwsException('Foo', $command, ['message' => "test error message"]);
-        $this->assertSame("test error message", $e->getErrorMessage());
+        $this->assertSame("test error message", $e->getAwsErrorMessage());
     }
 
     public function testProvidesFalseConnectionErrorFlag()

--- a/tests/Exception/AwsExceptionTest.php
+++ b/tests/Exception/AwsExceptionTest.php
@@ -55,6 +55,13 @@ class AwsExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($response, $e->getResponse());
     }
 
+    public function testProvidesErrorMessage()
+    {
+        $command = new Command('foo');
+        $e = new AwsException('Foo', $command, ['message' => "test error message"]);
+        $this->assertSame("test error message", $e->getErrorMessage());
+    }
+
     public function testProvidesFalseConnectionErrorFlag()
     {
         $command = new Command('foo');


### PR DESCRIPTION
Had a request from a customer to get a concise message like PHP SDK v2.

This is a simple PR to add a new method `getErrorMessage()`. 

Please review the PR.

@cjyclaire @jeskew 