### PR TITLE
Fix broken tests when SDK built in codebuild or ECS

### DIFF
--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -317,6 +317,7 @@ EOT;
 
     public function testCanUseCredentialsCache()
     {
+        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI');
         $credentialsEnvironment = [
             'home' => 'HOME',
             'key' => CredentialProvider::ENV_KEY,

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -18,6 +18,7 @@ class CredentialProviderTest extends \PHPUnit_Framework_TestCase
         putenv(CredentialProvider::ENV_KEY . '=');
         putenv(CredentialProvider::ENV_SECRET . '=');
         putenv(CredentialProvider::ENV_PROFILE . '=');
+        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI');
 
         $dir = sys_get_temp_dir() . '/.aws';
 


### PR DESCRIPTION
Environment Variable `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is set by Codebuild and ECS.

This PR unsets the variable during the unit tests.