### PR TITLE
Fix SQS' fifo Queue ARN Generation

### DIFF
--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -66,7 +66,7 @@ class SqsClient extends AwsClient
      */
     public function getQueueArn($queueUrl)
     {
-        $arn = strtr($queueUrl, array(
+        $queueArn = strtr($queueUrl, array(
             'http://'        => 'arn:aws:',
             'https://'       => 'arn:aws:',
             '.amazonaws.com' => '',
@@ -75,10 +75,10 @@ class SqsClient extends AwsClient
         ));
 
         // Cope with SQS' .fifo / :fifo arn inconsistency
-        if (substr($arn, -5) === ':fifo') {
-            $arn = substr_replace($arn, '.fifo', -5);
+        if (substr($queueArn, -5) === ':fifo') {
+            $queueArn = substr_replace($queueArn, '.fifo', -5);
         }
-        return $arn;
+        return $queueArn;
     }
 
     /**

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -66,13 +66,19 @@ class SqsClient extends AwsClient
      */
     public function getQueueArn($queueUrl)
     {
-        return strtr($queueUrl, array(
+        $arn = strtr($queueUrl, array(
             'http://'        => 'arn:aws:',
             'https://'       => 'arn:aws:',
             '.amazonaws.com' => '',
             '/'              => ':',
             '.'              => ':',
         ));
+
+        // Cope with SQS' .fifo / :fifo arn inconsistency
+        if (substr($arn, -5) === ':fifo') {
+            $arn = substr_replace($arn, '.fifo', -5);
+        }
+        return $arn;
     }
 
     /**

--- a/tests/Sqs/SqsClientTest.php
+++ b/tests/Sqs/SqsClientTest.php
@@ -24,6 +24,17 @@ class SqsClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($arn, $sqs->getQueueArn($url));
     }
 
+    public function testFifoQueueArn()
+    {
+        $url = 'https://sqs.us-east-1.amazonaws.com/057737625318/php-integ-sqs-queue-1359765974.fifo';
+        $arn = 'arn:aws:sqs:us-east-1:057737625318:php-integ-sqs-queue-1359765974.fifo';
+        $sqs = new SqsClient([
+            'region'  => 'us-east-1',
+            'version' => 'latest'
+        ]);
+        $this->assertEquals($arn, $sqs->getQueueArn($url));
+    }
+
     /**
      * @expectedException \Aws\Sqs\Exception\SqsException
      * @expectedExceptionMessage MD5 mismatch. Expected foo, found ddc35f88fa71b6ef142ae61f35364653


### PR DESCRIPTION
Cope with SQS' .fifo/:fifo ARN inconsistency, with included test.

Fix for #1255 