### PR TITLE
Update integration scenario to not use PHP7+ functionality

### DIFF
--- a/features/streams/streamWrapper.feature
+++ b/features/streams/streamWrapper.feature
@@ -45,11 +45,9 @@ Feature: S3 Stream Wrapper
       | key1 | testing!      | 8    | te     | sting!      |
       | key2 | foo, bar, baz | 13   | fo     | o, bar, baz |
 
-  Scenario: No errors raised for missing files
-    Given I have cleared the last error
+  Scenario: No File Exists
     When I call file_exists on the jkfdsalhjkgdfhsurew path
     Then the call should return false
-    And no errors should have been raised
 
   Scenario: Traversing empty directories
     Given I have a file at "/empty/" with no content

--- a/tests/Integ/NativeStreamContext.php
+++ b/tests/Integ/NativeStreamContext.php
@@ -164,24 +164,6 @@ class NativeStreamContext extends \PHPUnit_Framework_Assert implements
     }
 
     /**
-     * @Given I have cleared the last error
-     */
-    public function iHaveClearedTheLastError()
-    {
-        while (error_get_last()) {
-            error_clear_last();
-        }
-    }
-
-    /**
-     * @Then no errors should have been raised
-     */
-    public function errorsShouldHaveBeenRaised()
-    {
-        $this->assertNull(error_get_last());
-    }
-
-    /**
      * @Then scanning the directory at :dir should return a list with one member named :file
      */
     public function scanningTheDirectoryAtShouldReturnAListWithOneMemberNamed($dir, $file)


### PR DESCRIPTION
This scenario relied on the use of error_clear_last for its Given, which is only available in PHP 7.0+. Given/And clauses of the scenario have been removed, along with their context functions, and the scenario has been renamed.