### PR TITLE
S3 Transfer Download Patch

### DIFF
--- a/.changes/nextrelease/fix_transfer_download_directory_traversal.json
+++ b/.changes/nextrelease/fix_transfer_download_directory_traversal.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "NEW_FEATURE",
+    "category": "S3",
+    "description": "Fixed possible security issue in `Transfer`s download `transfer` operation where files could be downloaded to a directory outside the destination directory if the key contained relative paths. Ignoring files to continue with your transfer can be done through passing an iterator of files to download to `Transfer`s parameter: `$source`. These can be generated on `s3://` paths if you have registered the SDK's `StreamWrapper` via `\\Aws\\recursive_dir_iterator`."
+  }
+]


### PR DESCRIPTION
Add S3Exception for keys that leave the path root, supplemented by tests.