### PR TITLE
SQS Message Attribute Validation

### DIFF
--- a/.changes/nextrelease/sqs_message_attribute_validation.json
+++ b/.changes/nextrelease/sqs_message_attribute_validation.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "NEW_FEATURE",
+    "category": "SQS",
+    "description": "MD5 Validation of `MessageAttributes` is now being performed on `ReceiveMessage` calls. SQS uses a custom encoding for generating the hash input, [details on that scheme are available here.](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#sqs-attrib-md5)"
+  }
+]

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -112,7 +112,9 @@ class SqsClient extends AwsClient
      *                       Retrieved when using MessageAttributeNames on
      *                       ReceiveMessage.
      *
-     * @return string The md5 hash of the message attributes according to the encoding scheme.
+     * @return string|null The md5 hash of the message attributes according to
+     *                     the encoding scheme. Returns null when there are no
+     *                     attributes.
      * @link http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html#message-attributes-items-validation
      */
     public static function getExpectedMessageAttributesMd5($message)

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -120,7 +120,8 @@ class SqsClient extends AwsClient
     private static function calculateMessageAttributesMd5($message)
     {
         if (empty($message['MessageAttributes'])
-            || !is_array($message['MessageAttributes'])) {
+            || !is_array($message['MessageAttributes'])
+        ) {
             return null;
         }
 

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -147,7 +147,7 @@ class SqsClient extends AwsClient
 
     private static function calculateBodyMd5($message)
     {
-        return md5($message['body']);
+        return md5($message['Body']);
     }
 
     private static function getEncodedStringPiece($piece)


### PR DESCRIPTION
Validate SQS Message Attributes via MD5 with encoded input string, supplemented with tests. Checks are done in the same `validateMd5` function so users who unregister the `sqs.md5` receive no new exceptions.

PR to complete #1148 