### PR TITLE
Fix Transfer Download Sink Resolution

### DIFF
--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -245,18 +245,19 @@ class Transfer implements PromisorInterface
             // Prepare the sink.
             $objectKey = preg_replace('/^' . preg_quote($prefix, '/') . '/', '', $object);
 
-            $sink = $this->destination['path'] . '/';
+            $resolveSink = $this->destination['path'] . '/';
             if (isset($parts['Key']) && strpos($objectKey, $parts['Key']) !== 0) {
-                $sink .= $parts['Key'] . '/';
+                $resolveSink .= $parts['Key'] . '/';
             }
-            $sink .= $objectKey;
+            $resolveSink .= $objectKey;
+            $sink = $this->destination['path'] . '/' . $objectKey;
 
             $command = $this->client->getCommand(
                 'GetObject',
                 $this->getS3Args($object) + ['@http'  => ['sink'  => $sink]]
             );
 
-            if (strpos($this->resolveUri($sink), $this->destination['path']) !== 0) {
+            if (strpos($this->resolveUri($resolveSink), $this->destination['path']) !== 0) {
                 throw new AwsException(
                     'Cannot download key ' . $objectKey
                     . ', its relative path resolves outside the'

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -258,8 +258,8 @@ class Transfer implements PromisorInterface
             );
 
             if (strpos(
-                $this->resolveUri($resolveSink),
-                $this->destination['path']
+                    $this->resolveUri($resolveSink),
+                    $this->destination['path']
                 ) !== 0
             ) {
                 throw new AwsException(

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -257,7 +257,11 @@ class Transfer implements PromisorInterface
                 $this->getS3Args($object) + ['@http'  => ['sink'  => $sink]]
             );
 
-            if (strpos($this->resolveUri($resolveSink), $this->destination['path']) !== 0) {
+            if (strpos(
+                $this->resolveUri($resolveSink),
+                $this->destination['path']
+                ) !== 0
+            ) {
                 throw new AwsException(
                     'Cannot download key ' . $objectKey
                     . ', its relative path resolves outside the'


### PR DESCRIPTION
Revert behavior to correctly download contents directly in to destination folder instead of the including the Key portion of the source path.

Fixes #1282