### PR TITLE
Pass params through so multipart uploads work with SSE-C

### DIFF
--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -75,7 +75,7 @@ class ObjectUploader implements PromisorInterface
                     'bucket' => $this->bucket,
                     'key'    => $this->key,
                     'acl'    => $this->acl
-                ] + $this->options))->promise();
+                ] + $this->options['params']))->promise();
         } else {
             // Perform a regular PutObject operation.
             $command = $this->client->getCommand('PutObject', [


### PR DESCRIPTION
Fixes following:

```
[2017-05-21 07:19:50] ERROR: Aws\S3\Exception\S3MultipartUploadException: An exception occurred while uploading parts to a multipart upload. The following parts had errors:
- Part 1: Error executing "UploadPart" on "https://s3-eu-west-1.amazonaws.com/bucket-name/foobar/large-test.gz?partNumber=1&uploadId=1234.5678"; AWS HTTP error: Client error: `PUT https://s3-eu-west-1.amazonaws.com/bucket-name/foobar/large-test.gz?partNumber=1&uploadId=1234.5678` resulted in a `400 Bad Request` response:
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidRequest</Code><Message>The multipart upload initiate requeste (truncated...)
 InvalidRequest (client): The multipart upload initiate requested encryption. Subsequent part requests must include the appropriate encryption parameters. - <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidRequest</Code><Message>The multipart upload initiate requested encryption. Subsequent part requests must include the appropriate encryption parameters.</Message><RequestId>ABC123</RequestId><HostId>BLAH</HostId></Error>
```