### PR TITLE
Log on Broken Doc Shapes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ api: api-get-apigen
 
 api-models:
 	# Build custom docs
-	php build/docs.php
+	php build/docs.php $(if $(ISSUE-LOGGING-ENABLED),--issue-logging-enabled,)
 
 redirect-map:
 	# Build redirect map

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@echo "  integ          to run integration tests. Provide TEST to perform a specific test."
 	@echo "  guide          to build the user guide documentation"
 	@echo "  guide-show     to view the user guide"
-	@echo "  api            to build the API documentation"
+	@echo "  api            to build the API documentation. Provide ISSUE_LOGGING_ENABLED to save build issues to file."
 	@echo "  api-show       to view the API documentation"
 	@echo "  api-package    to build the API documentation as a ZIP"
 	@echo "  api-manifest   to build an API manifest JSON file for the SDK"
@@ -91,7 +91,7 @@ api: api-get-apigen
 
 api-models:
 	# Build custom docs
-	php build/docs.php $(if $(ISSUE-LOGGING-ENABLED),--issue-logging-enabled,)
+	php build/docs.php $(if $(ISSUE_LOGGING_ENABLED),--issue-logging-enabled,)
 
 redirect-map:
 	# Build redirect map

--- a/build/docs.php
+++ b/build/docs.php
@@ -34,6 +34,11 @@ foreach ($sourceDirs as $dir) {
     );
 }
 
+$issueLoggingEnabled = isset(getopt(
+    '',
+    array('issue-logging-enabled::')
+)['issue-logging-enabled']);
+
 // Generate API docs
 $builder = new DocsBuilder(
     $apiProvider,
@@ -41,6 +46,7 @@ $builder = new DocsBuilder(
     $template,
     $config['baseUrl'],
     $quickLinkServices,
-    $sourceFiles
+    $sourceFiles,
+    $issueLoggingEnabled
 );
 $builder->build();

--- a/build/docs/classes/CodeSnippetGenerator.php
+++ b/build/docs/classes/CodeSnippetGenerator.php
@@ -23,14 +23,14 @@ class CodeSnippetGenerator
         $this->service = $service;
     }
 
-    private function logIssue($shapeName, $message)
+    private function logIssue($shapeName, $message, $level=E_WARNING)
     {
         if (!isset($this->issues[$shapeName])) {
             $this->issues[$shapeName] = [];
         }
 
         if (!isset($this->issues[$shapeName][$message])) {
-            $this->issues[$shapeName][$message] = true;
+            $this->issues[$shapeName][$level][$message] = true;
         }
     }
 

--- a/build/docs/classes/CodeSnippetGenerator.php
+++ b/build/docs/classes/CodeSnippetGenerator.php
@@ -64,25 +64,19 @@ class CodeSnippetGenerator
     private function structure(StructureShape $shape, $value, $indent, $path, $comments)
     {
         $lines = ['['];
-        $discrepancy = false;
         foreach ($value as $key => $val) {
             $path[] = ".{$key}";
             $comment = $this->getCommentFor($path, $comments);
             try {
                 $shapeVal = $this->visit($shape->getMember($key), $val, "{$indent}    ", $path, $comments);
             } catch (\InvalidArgumentException $e) {
-                $discrepancy = true;
-                break;
+                trigger_error("Discrepancy in example documentation shape - Service={$this->service->getServiceName()}-{$this->service->getApiVersion()} Shape={$shape->getName()}. \n", E_USER_ERROR);
             }
             $lines[] = rtrim("{$indent}    '{$key}' => {$shapeVal}, {$comment}");
             array_pop($path);
         }
         $lines[] = "{$indent}]";
-        if ($discrepancy) {
-            echo "Skipping examples due to discrepancy in shape: {$shape->getName()}. \n";
-        } else {
-            return implode("\n", $lines);
-        }
+        return implode("\n", $lines);
     }
 
     private function arr(ListShape $shape, $value, $indent, $path, $comments)


### PR DESCRIPTION
Instead of skipping Code Snippets that have issues, track them and add an option to log them out to a file.