### PR TITLE
Fix for upcoming PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - nightly
   - hhvm
 
 sudo: false
@@ -16,6 +17,7 @@ env:
 matrix:
   allow_failures:
     - php: hhvm
+    - php: nightly
   fast_finish: true
 
 install:

--- a/src/History.php
+++ b/src/History.php
@@ -11,7 +11,7 @@ use Aws\Exception\AwsException;
 class History implements \Countable, \IteratorAggregate
 {
     private $maxEntries;
-    private $entries;
+    private $entries = array();
 
     /**
      * @param int $maxEntries Maximum number of entries to store.

--- a/src/LruArrayCache.php
+++ b/src/LruArrayCache.php
@@ -11,13 +11,13 @@ namespace Aws;
  * cache, if the number of cached items exceeds the allowed number, the first
  * N number of items are removed from the array.
  */
-class LruArrayCache implements CacheInterface
+class LruArrayCache implements CacheInterface, \Countable
 {
     /** @var int */
     private $maxItems;
 
     /** @var array */
-    private $items;
+    private $items = array();
 
     /**
      * @param int $maxItems Maximum number of allowed cache items.
@@ -70,5 +70,10 @@ class LruArrayCache implements CacheInterface
     public function remove($key)
     {
         unset($this->items[$key]);
+    }
+
+    public function count()
+    {
+        return count($this->items);
     }
 }

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Psr7\Stream;
 
 /**
  * @covers \Aws\DynamoDb\DynamoDbClient
+ * @runTestsInSeparateProcesses
  */
 class DynamoDbClientTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/DynamoDb/SessionHandlerTest.php
+++ b/tests/DynamoDb/SessionHandlerTest.php
@@ -6,6 +6,7 @@ use Aws\Test\UsesServiceTrait;
 
 /**
  * @covers Aws\DynamoDb\SessionHandler
+ * @runTestsInSeparateProcesses
  */
 class SessionHandlerTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/S3/BatchDeleteTest.php
+++ b/tests/S3/BatchDeleteTest.php
@@ -206,7 +206,7 @@ class BatchDeleteTest extends \PHPUnit_Framework_TestCase
         $batch->delete();
         $last = $mock->getLastCommand();
         $this->assertEquals('ListObjects', $last->getName());
-        $this->assertEquals(0, count($last['Delete']['Objects']));
+        $this->assertFalse(isset($last['Delete']['Objects']));
         $this->assertEquals('foo', $last['Bucket']);
     }
 }


### PR DESCRIPTION
Without this:
```
$ php72 vendor/bin/phpunit  -d memory_limit=1G  --testsuite=unit --no-coverage
PHPUnit 5.7.20 by Sebastian Bergmann and contributors.

.............................................................   61 / 2121 (  2%)
.............................................................  122 / 2121 (  5%)
.............................................................  183 / 2121 (  8%)
.............................................................  244 / 2121 ( 11%)
.............................................................  305 / 2121 ( 14%)
.............................................................  366 / 2121 ( 17%)
.................................................SSSSSSSSSSSS  427 / 2121 ( 20%)
SSSSSSSSSSSSSSSSSS..........................................E  488 / 2121 ( 23%)
...............................E.............................  549 / 2121 ( 25%)
......................EEE....................................  610 / 2121 ( 28%)
.............................................................  671 / 2121 ( 31%)
.............................................................  732 / 2121 ( 34%)
.............................................................  793 / 2121 ( 37%)
.............................................................  854 / 2121 ( 40%)
.............................................................  915 / 2121 ( 43%)
.............................................................  976 / 2121 ( 46%)
............................................................. 1037 / 2121 ( 48%)
.........................S..................SSSSSS........... 1098 / 2121 ( 51%)
..........E.................................................. 1159 / 2121 ( 54%)
............................................................. 1220 / 2121 ( 57%)
............................................................. 1281 / 2121 ( 60%)
............................................E................ 1342 / 2121 ( 63%)
............................................................. 1403 / 2121 ( 66%)
............................................................. 1464 / 2121 ( 69%)
............................................................. 1525 / 2121 ( 71%)
............................................................. 1586 / 2121 ( 74%)
............................................................. 1647 / 2121 ( 77%)
............................................................. 1708 / 2121 ( 80%)
............................................................. 1769 / 2121 ( 83%)
............................................................. 1830 / 2121 ( 86%)
............................................................. 1891 / 2121 ( 89%)
............................................................. 1952 / 2121 ( 92%)
...............E............................................. 2013 / 2121 ( 94%)
............................................................. 2074 / 2121 ( 97%)
...............................................               2121 / 2121 (100%)

Time: 3.24 seconds, Memory: 34.01MB

There were 8 errors:

1) Aws\Test\Credentials\CredentialProviderTest::testPersistsToCache
count(): Parameter must be an array or an object that implements Countable

/work/GIT/aws-sdk-php/tests/Credentials/CredentialProviderTest.php:120

2) Aws\Test\DynamoDb\DynamoDbClientTest::testRegisterSessionHandlerReturnsHandler
session_set_save_handler(): Cannot change save handler when headers already sent

/work/GIT/aws-sdk-php/src/DynamoDb/SessionHandler.php:88
/work/GIT/aws-sdk-php/src/DynamoDb/DynamoDbClient.php:76
/work/GIT/aws-sdk-php/tests/DynamoDb/DynamoDbClientTest.php:23

3) Aws\Test\DynamoDb\SessionHandlerTest::testHandlerFunctions
session_id(): Cannot change session id when headers already sent

/work/GIT/aws-sdk-php/tests/DynamoDb/SessionHandlerTest.php:50

4) Aws\Test\DynamoDb\SessionHandlerTest::testHandlerWhenNothingWritten
session_id(): Cannot change session id when headers already sent

/work/GIT/aws-sdk-php/tests/DynamoDb/SessionHandlerTest.php:68

5) Aws\Test\DynamoDb\SessionHandlerTest::testSessionDataCanBeWrittenToNewIdWithNoChanges
session_id(): Cannot change session id when headers already sent

/work/GIT/aws-sdk-php/tests/DynamoDb/SessionHandlerTest.php:92

6) Aws\Test\HistoryTest::testIsCountable
count(): Parameter must be an array or an object that implements Countable

/work/GIT/aws-sdk-php/src/History.php:26
/work/GIT/aws-sdk-php/tests/HistoryTest.php:18

7) Aws\Test\S3\BatchDeleteTest::testWithNoMatchingObjects
count(): Parameter must be an array or an object that implements Countable

/work/GIT/aws-sdk-php/tests/S3/BatchDeleteTest.php:209

8) Aws\Test\S3\StreamWrapperTest::testDeterminesIfFileOrDir with data set #0 ('s3://', array(), 'dir')
count(): Parameter must be an array or an object that implements Countable

/work/GIT/aws-sdk-php/src/History.php:26
/work/GIT/aws-sdk-php/tests/S3/StreamWrapperTest.php:665

ERRORS!
Tests: 2121, Assertions: 4944, Errors: 8, Skipped: 37.

```