### PR TITLE
S3 Host-Style URIs By Default

### DIFF
--- a/.changes/nextrelease/host_style_default.json
+++ b/.changes/nextrelease/host_style_default.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "NEW_FEATURE",
+    "category": "S3",
+    "description": "S3 calls are now done with a host style URL by default. Options for path style on the client and command levels are available as `use_path_style_endpoint` and `@use_path_style_endpoint`, respectively. [More details on the differences between the styles can be found here.](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro)"
+  }
+]

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -215,7 +215,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
                 'secret' => 'bar'
             ],
             'handler' => $mock,
-            'signature_version' => 'v4'
+            'signature_version' => 'v4',
         ];
 
         $client = new S3Client($conf);
@@ -225,12 +225,9 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
             'Body'   => '123'
         ]);
         $request = \Aws\serialize($command);
-        $this->assertEquals('/foo/bar', $request->getRequestTarget());
+        $this->assertEquals('/bar', $request->getRequestTarget());
         $this->assertEquals('PUT', $request->getMethod());
-        $this->assertEquals(
-            's3.amazonaws.com',
-            $request->getHeaderLine('Host')
-        );
+        $this->assertEquals('foo.s3.amazonaws.com', $request->getHeaderLine('Host'));
         $this->assertTrue($request->hasHeader('Authorization'));
         $this->assertTrue($request->hasHeader('X-Amz-Content-Sha256'));
         $this->assertTrue($request->hasHeader('X-Amz-Date'));

--- a/tests/Integ/GuzzleV6StreamHandlerTest.php
+++ b/tests/Integ/GuzzleV6StreamHandlerTest.php
@@ -18,7 +18,10 @@ class GuzzleV6StreamHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $handler = new StreamHandler();
 
-        $s3 = $this->getSdk()->createS3(['http_handler' => $handler]);
+        $s3 = $this->getSdk()->createS3([
+            'http_handler' => $handler,
+            'use_path_style_endpoint' => true
+        ]);
         $result = $s3->listBuckets();
         $this->assertNotEmpty($result->search('Owner.ID'));
 

--- a/tests/S3/BucketEndpointMiddlewareTest.php
+++ b/tests/S3/BucketEndpointMiddlewareTest.php
@@ -11,9 +11,25 @@ class BucketEndpointMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
     use UsesServiceTrait;
 
-    public function testUsesPathStyleByDefault()
+    public function testUsesHostStyleByDefault()
     {
         $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [[]]);
+        $command = $s3->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'Bar/Baz']);
+        $command->getHandlerList()->appendSign(
+            Middleware::tap(function ($cmd, $req) {
+                $this->assertEquals('foo.s3.amazonaws.com', $req->getUri()->getHost());
+                $this->assertEquals('/Bar/Baz', $req->getRequestTarget());
+            })
+        );
+        $s3->execute($command);
+    }
+
+    public function testUsesPathStyle()
+    {
+        $s3 = $this->getTestClient('s3', [
+            'use_path_style_endpoint' => true
+        ]);
         $this->addMockResults($s3, [[]]);
         $command = $s3->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'Bar/Baz']);
         $command->getHandlerList()->appendSign(
@@ -28,6 +44,22 @@ class BucketEndpointMiddlewareTest extends \PHPUnit_Framework_TestCase
     public function testIgnoresExcludedCommands()
     {
         $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [['bucket_endpoint' => true]]);
+        $command = $s3->getCommand('GetBucketLocation', ['Bucket' => 'foo']);
+        $command->getHandlerList()->appendSign(
+            Middleware::tap(function ($cmd, $req) {
+                $this->assertEquals('foo.s3.amazonaws.com', $req->getUri()->getHost());
+                $this->assertEquals('/?location', $req->getRequestTarget());
+            })
+        );
+        $s3->execute($command);
+    }
+
+    public function testPathStyleIgnoresExcludedCommands()
+    {
+        $s3 = $this->getTestClient('s3', [
+            'use_path_style_endpoint' => true
+        ]);
         $this->addMockResults($s3, [['bucket_endpoint' => true]]);
         $command = $s3->getCommand('GetBucketLocation', ['Bucket' => 'foo']);
         $command->getHandlerList()->appendSign(

--- a/tests/S3/ObjectUploaderTest.php
+++ b/tests/S3/ObjectUploaderTest.php
@@ -25,6 +25,25 @@ class ObjectUploaderTest extends \PHPUnit_Framework_TestCase
         $this->addMockResults($client, $mockedResults);
         $result = (new ObjectUploader($client, 'bucket', 'key', $body, 'private', $options))
             ->upload();
+        $this->assertEquals('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
+        $this->assertTrue($this->mockQueueEmpty());
+    }
+
+    /**
+     * @dataProvider getUploadTestCasesWithPathStyle
+     */
+    public function testDoesCorrectOperationWithPathStyle(
+        StreamInterface $body,
+        array $mockedResults,
+        array $options
+    ) {
+        /** @var \Aws\S3\S3Client $client */
+        $client = $this->getTestClient('S3', [
+            'use_path_style_endpoint' => true
+        ]);
+        $this->addMockResults($client, $mockedResults);
+        $result = (new ObjectUploader($client, 'bucket', 'key', $body, 'private', $options))
+            ->upload();
         $this->assertEquals('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
@@ -44,10 +63,77 @@ class ObjectUploaderTest extends \PHPUnit_Framework_TestCase
             ->promise();
         $this->assertFalse($this->mockQueueEmpty());
         $result = $promise->wait();
+        $this->assertEquals('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
+    }
+
+    /**
+     * @dataProvider getUploadTestCasesWithPathStyle
+     */
+    public function testDoesCorrectOperationAsynchronouslyWithPathStyle(
+        StreamInterface $body,
+        array $mockedResults,
+        array $options
+    ) {
+        /** @var \Aws\S3\S3Client $client */
+        $client = $this->getTestClient('S3', [
+            'use_path_style_endpoint' => true
+        ]);
+        $this->addMockResults($client, $mockedResults);
+        $promise = (new ObjectUploader($client, 'bucket', 'key', $body, 'private', $options))
+            ->promise();
+        $this->assertFalse($this->mockQueueEmpty());
+        $result = $promise->wait();
         $this->assertEquals('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
     }
 
     public function getUploadTestCases()
+    {
+        $putObject = new Result();
+        $initiate = new Result(['UploadId' => 'foo']);
+        $putPart = new Result(['ETag' => 'bar']);
+        $complete = new Result(['Location' => 'https://bucket.s3.amazonaws.com/key']);
+
+        return [
+            [
+                // 3 MB, known-size stream (put)
+                $this->generateStream(1024 * 1024 * 3),
+                [$putObject],
+                ['before_upload' => function () {}]
+            ],
+            [
+                // 3 MB, unknown-size stream (put)
+                $this->generateStream(1024 * 1024 * 3, false),
+                [$putObject],
+                []
+            ],
+            [
+                // 6 MB, known-size stream (put)
+                $this->generateStream(1024 * 1024 * 6),
+                [$putObject],
+                []
+            ],
+            [
+                // 6 MB, known-size stream, above threshold (mup)
+                $this->generateStream(1024 * 1024 * 6),
+                [$initiate, $putPart, $putPart, $complete],
+                ['mup_threshold' => 1024 * 1024 * 4]
+            ],
+            [
+                // 6 MB, unknown-size stream (mup)
+                $this->generateStream(1024 * 1024 * 6, false),
+                [$initiate, $putPart, $putPart, $complete],
+                []
+            ],
+            [
+                // 6 MB, unknown-size, non-seekable stream (mup)
+                $this->generateStream(1024 * 1024 * 6, false, false),
+                [$initiate, $putPart, $putPart, $complete],
+                []
+            ]
+        ];
+    }
+
+    public function getUploadTestCasesWithPathStyle()
     {
         $putObject = new Result();
         $initiate = new Result(['UploadId' => 'foo']);
@@ -93,7 +179,6 @@ class ObjectUploaderTest extends \PHPUnit_Framework_TestCase
             ]
         ];
     }
-
 
     private function generateStream($size, $sizeKnown = true, $seekable = true)
     {


### PR DESCRIPTION
Change the default URI to use host style over path style, including with dual-stack, with a fallback for incompatibilities. Configuration options have been added and detailed for the S3Client and its sub-command. Tests that relied on path-style but did not alter the URI have been updated to bucket style. A significant amount of tests that relied on it and altered the URI have been duplicated to verify both the host style and path style.