### PR TITLE
Bug Fix + Functionality Updates for MultipartUploader/Copy and ObjectUploader/Copier

### DIFF
--- a/.changes/nextrelease/multipart_params.json
+++ b/.changes/nextrelease/multipart_params.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "S3",
+    "description": "A new `params` option is available in the `MultipartUploader` and `MultipartCopy` classes for parameters that should be applied to all sub-commands of their upload functionality. This also improves functionality around passing `params` directly to `ObjectUploader` and `ObjectCopier`. A new `before_lookup` callback has been added to `ObjectCopier` for operating on the `HeadObject` command directly; `params` will be passed to HeadObject as well."
+  }
+]

--- a/.changes/nextrelease/multipart_params.json
+++ b/.changes/nextrelease/multipart_params.json
@@ -2,6 +2,6 @@
   {
     "type": "feature",
     "category": "S3",
-    "description": "A new `params` option is available in the `MultipartUploader` and `MultipartCopy` classes for parameters that should be applied to all sub-commands of their upload functionality. This also improves functionality around passing `params` directly to `ObjectUploader` and `ObjectCopier`. A new `before_lookup` callback has been added to `ObjectCopier` for operating on the `HeadObject` command directly; `params` will be passed to HeadObject as well."
+    "description": "A new `params` option is available in the `MultipartUploader` and `MultipartCopy` classes for parameters that should be applied to all sub-commands of their upload functionality. This also improves functionality around passing `params` directly to `ObjectUploader` and `ObjectCopier`. A new `before_lookup` callback has been added to `ObjectCopier` for operating on the `HeadObject` command directly; `params` will be passed to HeadObject as well. Since these are changes to existing options, they may alter current functionality."
   }
 ]

--- a/src/S3/MultipartCopy.php
+++ b/src/S3/MultipartCopy.php
@@ -35,6 +35,11 @@ class MultipartCopy extends AbstractUploadManager
      * - concurrency: (int, default=int(5)) Maximum number of concurrent
      *   `UploadPart` operations allowed during the multipart upload.
      * - key: (string, required) Key to use for the object being uploaded.
+     * - params: (array) An array of key/value parameters that will be applied
+     *   to each of the sub-commands run by the uploader as a base.
+     *   Auto-calculated options will override these parameters. If you need
+     *   more granularity over parameters to each sub-command, use the before_*
+     *   options detailed above to update the commands directly.
      * - part_size: (int, default=int(5242880)) Part size, in bytes, to use when
      *   doing a multipart upload. This must between 5 MB and 5 GB, inclusive.
      * - state: (Aws\Multipart\UploadState) An object that represents the state
@@ -107,19 +112,27 @@ class MultipartCopy extends AbstractUploadManager
 
     private function createPart($partNumber, $partsCount)
     {
+        $data = [];
+
+        // Apply custom params to UploadPartCopy data
+        $config = $this->getConfig();
+        $params = isset($config['params']) ? $config['params'] : [];
+        foreach ($params as $k => $v) {
+            $data[$k] = $v;
+        }
+
+        $data['CopySource'] = $this->source;
+        $data['PartNumber'] = $partNumber;
+
         $defaultPartSize = $this->determinePartSize();
         $startByte = $defaultPartSize * ($partNumber - 1);
-        $partSize = $partNumber < $partsCount
+        $data['ContentLength'] = $partNumber < $partsCount
             ? $defaultPartSize
             : $this->getSourceSize() - ($defaultPartSize * ($partsCount - 1));
-        $endByte = $startByte + $partSize - 1;
+        $endByte = $startByte + $data['ContentLength'] - 1;
+        $data['CopySourceRange'] = "bytes=$startByte-$endByte";
 
-        return [
-            'ContentLength' => $partSize,
-            'CopySource' => $this->source,
-            'CopySourceRange' => "bytes=$startByte-$endByte",
-            'PartNumber' => $partNumber,
-        ];
+        return $data;
     }
 
     protected function extractETag(ResultInterface $result)

--- a/src/S3/MultipartUploader.php
+++ b/src/S3/MultipartUploader.php
@@ -41,6 +41,11 @@ class MultipartUploader extends AbstractUploader
      * - concurrency: (int, default=int(5)) Maximum number of concurrent
      *   `UploadPart` operations allowed during the multipart upload.
      * - key: (string, required) Key to use for the object being uploaded.
+     * - params: (array) An array of key/value parameters that will be applied
+     *   to each of the sub-commands run by the uploader as a base.
+     *   Auto-calculated options will override these parameters. If you need
+     *   more granularity over parameters to each sub-command, use the before_*
+     *   options detailed above to update the commands directly.
      * - part_size: (int, default=int(5242880)) Part size, in bytes, to use when
      *   doing a multipart upload. This must between 5 MB and 5 GB, inclusive.
      * - state: (Aws\Multipart\UploadState) An object that represents the state
@@ -84,7 +89,16 @@ class MultipartUploader extends AbstractUploader
     protected function createPart($seekable, $number)
     {
         // Initialize the array of part data that will be returned.
-        $data = ['PartNumber' => $number];
+        $data = [];
+
+        // Apply custom params to UploadPart data
+        $config = $this->getConfig();
+        $params = isset($config['params']) ? $config['params'] : [];
+        foreach ($params as $k => $v) {
+            $data[$k] = $v;
+        }
+
+        $data['PartNumber'] = $number;
 
         // Read from the source to create the body stream.
         if ($seekable) {

--- a/src/S3/MultipartUploadingTrait.php
+++ b/src/S3/MultipartUploadingTrait.php
@@ -99,7 +99,7 @@ trait MultipartUploadingTrait
         $params = isset($config['params']) ? $config['params'] : [];
 
         if (isset($config['acl'])) {
-            $params['ACL'] = $this->getConfig()['acl'];
+            $params['ACL'] = $config['acl'];
         }
 
         // Set the content type

--- a/src/S3/MultipartUploadingTrait.php
+++ b/src/S3/MultipartUploadingTrait.php
@@ -61,9 +61,14 @@ trait MultipartUploadingTrait
 
     protected function getCompleteParams()
     {
-        return ['MultipartUpload' => [
+        $config = $this->getConfig();
+        $params = isset($config['params']) ? $config['params'] : [];
+
+        $params['MultipartUpload'] = [
             'Parts' => $this->getState()->getUploadedParts()
-        ]];
+        ];
+
+        return $params;
     }
 
     protected function determinePartSize()
@@ -90,9 +95,10 @@ trait MultipartUploadingTrait
 
     protected function getInitiateParams()
     {
-        $params = [];
+        $config = $this->getConfig();
+        $params = isset($config['params']) ? $config['params'] : [];
 
-        if (isset($this->getConfig()['acl'])) {
+        if (isset($config['acl'])) {
             $params['ACL'] = $this->getConfig()['acl'];
         }
 

--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -22,6 +22,7 @@ class ObjectCopier implements PromisorInterface
     private $options;
 
     private static $defaults = [
+        'before_lookup' => null,
         'before_upload' => null,
         'concurrency'   => 5,
         'mup_threshold' => self::DEFAULT_MULTIPART_THRESHOLD,
@@ -45,7 +46,9 @@ class ObjectCopier implements PromisorInterface
      * @param string            $acl            ACL to apply to the copy
      *                                          (default: private).
      * @param array             $options        Options used to configure the
-     *                                          copy process.
+     *                                          copy process. Options passed in
+     *                                          through 'params' are added to
+     *                                          the sub commands.
      *
      * @throws InvalidArgumentException
      */
@@ -74,8 +77,15 @@ class ObjectCopier implements PromisorInterface
     public function promise()
     {
         return \GuzzleHttp\Promise\coroutine(function () {
+            $headObjectCommand = $this->client->getCommand(
+                'HeadObject',
+                $this->options['params'] + $this->source
+            );
+            if (is_callable($this->options['before_lookup'])) {
+                $this->options['before_lookup']($headObjectCommand);
+            }
             $objectStats = (yield $this->client->executeAsync(
-                $this->client->getCommand('HeadObject', $this->source)
+                $headObjectCommand
             ));
 
             if ($objectStats['ContentLength'] > $this->options['mup_threshold']) {

--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -39,7 +39,9 @@ class ObjectUploader implements PromisorInterface
      * @param string            $acl            ACL to apply to the copy
      *                                          (default: private).
      * @param array             $options        Options used to configure the
-     *                                          copy process.
+     *                                          copy process. Options passed in
+     *                                          through 'params' are added to
+     *                                          the sub command(s).
      */
     public function __construct(
         S3ClientInterface $client,
@@ -66,11 +68,6 @@ class ObjectUploader implements PromisorInterface
         $mup_threshold = $this->options['mup_threshold'];
         if ($this->requiresMultipart($this->body, $mup_threshold)) {
             // Perform a multipart upload.
-            $this->options['before_initiate'] = function ($command) {
-                foreach ($this->options['params'] as $k => $v) {
-                    $command[$k] = $v;
-                }
-            };
             return (new MultipartUploader($this->client, $this->body, [
                     'bucket' => $this->bucket,
                     'key'    => $this->key,

--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -56,10 +56,7 @@ class ObjectUploader implements PromisorInterface
         $this->key = $key;
         $this->body = Psr7\stream_for($body);
         $this->acl = $acl;
-        $this->options = array_intersect_key(
-            $options + self::$defaults,
-            self::$defaults
-        );
+        $this->options = $options + self::$defaults;
     }
 
     public function promise()

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -221,6 +221,9 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
         $client = $this->getTestClient('s3');
         $copyOptions = [
             'params'          => ['RequestPayer' => 'test'],
+            'before_lookup'   => function($command) {
+                $this->assertEquals('test', $command['RequestPayer']);
+            },
             'before_upload'   => function($command) {
                 $this->assertEquals('test', $command['RequestPayer']);
             },
@@ -252,6 +255,9 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
         $copyOptions = [
             'mup_threshold'   => MultipartUploader::PART_MIN_SIZE,
             'params'          => ['RequestPayer' => 'test'],
+            'before_lookup'   => function($command) {
+                $this->assertEquals('test', $command['RequestPayer']);
+            },
             'before_initiate' => function($command) {
                 $this->assertEquals('test', $command['RequestPayer']);
             },

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -105,51 +105,64 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->mockQueueEmpty());
     }
 
-    public function getCopyTestCases()
+    private function getSmallPutObjectMockResult()
     {
         $smallHeadObject = new Result(['ContentLength' => 1024 * 1024 * 6]);
         $putObject = new Result();
+
+        return [$smallHeadObject, $putObject];
+    }
+    private function getMultipartMockResults()
+    {
+        $smallHeadObject = new Result(['ContentLength' => 1024 * 1024 * 6]);
         $partCount = ceil($smallHeadObject['ContentLength'] / MultipartUploader::PART_MIN_SIZE);
         $initiate = new Result(['UploadId' => 'foo']);
         $putPart = new Result(['ETag' => 'bar']);
         $complete = new Result(['Location' => 'https://bucket.s3.amazonaws.com/key']);
 
+        return array_merge(
+            [$smallHeadObject, $initiate],
+            array_fill(0, $partCount, $putPart),
+            [$complete]
+        );
+    }
+    public function getCopyTestCases()
+    {
         return [
             [
-                [$smallHeadObject, $putObject],
+                $this->getSmallPutObjectMockResult(),
                 []
             ],
             [
-                array_merge(
-                    [$smallHeadObject, $initiate],
-                    array_fill(0, $partCount, $putPart),
-                    [$complete]
-                ),
+                $this->getMultipartMockResults(),
                 ['mup_threshold' => MultipartUploader::PART_MIN_SIZE]
             ],
         ];
     }
 
-    public function getCopyTestCasesWithPathStyle()
+    private function getPathStyleMultipartMockResults()
     {
         $smallHeadObject = new Result(['ContentLength' => 1024 * 1024 * 6]);
-        $putObject = new Result();
         $partCount = ceil($smallHeadObject['ContentLength'] / MultipartUploader::PART_MIN_SIZE);
         $initiate = new Result(['UploadId' => 'foo']);
         $putPart = new Result(['ETag' => 'bar']);
         $complete = new Result(['Location' => 'https://s3.amazonaws.com/bucket/key']);
 
+        return array_merge(
+            [$smallHeadObject, $initiate],
+            array_fill(0, $partCount, $putPart),
+            [$complete]
+        );
+    }
+    public function getCopyTestCasesWithPathStyle()
+    {
         return [
             [
-                [$smallHeadObject, $putObject],
+                $this->getSmallPutObjectMockResult(),
                 []
             ],
             [
-                array_merge(
-                    [$smallHeadObject, $initiate],
-                    array_fill(0, $partCount, $putPart),
-                    [$complete]
-                ),
+                $this->getPathStyleMultipartMockResults(),
                 ['mup_threshold' => MultipartUploader::PART_MIN_SIZE]
             ],
         ];
@@ -202,4 +215,70 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
         ))->copy();
     }
 
+    public function testS3ObjectCopierCopyObjectParams()
+    {
+        /** @var \Aws\S3\S3Client $client */
+        $client = $this->getTestClient('s3');
+        $copyOptions = [
+            'params'          => ['RequestPayer' => 'test'],
+            'before_upload'   => function($command) {
+                $this->assertEquals('test', $command['RequestPayer']);
+            },
+        ];
+        $url = 'https://bucket.s3.amazonaws.com/key';
+
+        $this->addMockResults(
+            $client,
+            $this->getSmallPutObjectMockResult()
+        );
+
+        $uploader = new ObjectCopier(
+            $client,
+            ['Bucket' => 'sourceBucket', 'Key' => 'sourceKey'],
+            ['Bucket' => 'bucket', 'Key' => 'key'],
+            'private',
+            $copyOptions);
+        $this->assertFalse($this->mockQueueEmpty());
+        $result = $uploader->copy();
+
+        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertTrue($this->mockQueueEmpty());
+    }
+
+    public function testS3ObjectCopierMultipartParams()
+    {
+        /** @var \Aws\S3\S3Client $client */
+        $client = $this->getTestClient('s3');
+        $copyOptions = [
+            'mup_threshold'   => MultipartUploader::PART_MIN_SIZE,
+            'params'          => ['RequestPayer' => 'test'],
+            'before_initiate' => function($command) {
+                $this->assertEquals('test', $command['RequestPayer']);
+            },
+            'before_upload'   => function($command) {
+                $this->assertEquals('test', $command['RequestPayer']);
+            },
+            'before_complete' => function($command) {
+                $this->assertEquals('test', $command['RequestPayer']);
+            }
+        ];
+        $url = 'https://bucket.s3.amazonaws.com/key';
+
+        $this->addMockResults(
+            $client,
+            $this->getMultipartMockResults()
+        );
+
+        $uploader = new ObjectCopier(
+            $client,
+            ['Bucket' => 'sourceBucket', 'Key' => 'sourceKey'],
+            ['Bucket' => 'bucket', 'Key' => 'key'],
+            'private',
+            $copyOptions);
+        $this->assertFalse($this->mockQueueEmpty());
+        $result = $uploader->copy();
+
+        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertTrue($this->mockQueueEmpty());
+    }
 }

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -112,6 +112,7 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
 
         return [$smallHeadObject, $putObject];
     }
+
     private function getMultipartMockResults()
     {
         $smallHeadObject = new Result(['ContentLength' => 1024 * 1024 * 6]);
@@ -126,6 +127,7 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
             [$complete]
         );
     }
+
     public function getCopyTestCases()
     {
         return [
@@ -154,6 +156,7 @@ class ObjectCopierTest extends \PHPUnit_Framework_TestCase
             [$complete]
         );
     }
+
     public function getCopyTestCasesWithPathStyle()
     {
         return [


### PR DESCRIPTION
Added 'params' passthrough for MultipartUploader/Copy. Increased functionality of ObjectUploader/Copier with regards to 'params'. Added 'before_lookup' option to ObjectCopier to operate on its 'HeadObject' command.

Addresses #1312 / #1291 and #1232 / #1238 in a consistent way that upgrades functionality while maintaining the contract established by each high-level abstraction.