### PR TITLE
SSECMiddleware fix in order to use a custom base64-encoded encryption…

### DIFF
--- a/src/S3/SSECMiddleware.php
+++ b/src/S3/SSECMiddleware.php
@@ -63,7 +63,12 @@ class SSECMiddleware
     {
         // Base64 encode the provided key
         $key = $command[$prefix . 'SSECustomerKey'];
-        $command[$prefix . 'SSECustomerKey'] = base64_encode($key);
+        if(base64_encode(base64_decode($key, true)) === $key) {
+            $command[$prefix . 'SSECustomerKey'] = $key;
+            $key = base64_decode($key, true);
+        } else {
+            $command[$prefix . 'SSECustomerKey'] = base64_encode($key);
+        }
 
         // Base64 the provided MD5 or, generate an MD5 if not provided
         if ($md5 = $command[$prefix . 'SSECustomerKeyMD5']) {


### PR DESCRIPTION
The previous implementation only accepted printable ASCII characters as the password for the SSE encryption. This reduces the password strength since it is not possible to use the full 256 values per byte, and only around 95 (printable ascii) values, effectively limiting the possible password entropy. This solution accepts both options: a custom base64-encoded encryption key or a 32 characters string.

reference: https://en.wikipedia.org/wiki/Password_strength#Random_passwords