### PR TITLE
Fix for upcoming PHP 7.2 Supplement

### DIFF
--- a/.changes/nextrelease/php_72_updates.json
+++ b/.changes/nextrelease/php_72_updates.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "",
+    "description": "Support for changes regarding PHP 7.2 releases."
+  }
+]

--- a/tests/Integ/BatchingContext.php
+++ b/tests/Integ/BatchingContext.php
@@ -221,7 +221,13 @@ class BatchingContext extends \PHPUnit_Framework_Assert implements
      */
     public function messagesShouldHaveBeenDeletedFromTheQueue($messageCount)
     {
-        $this->assertSame((int) $messageCount, count($this->response['Failed'])
-            + count($this->response['Successful']));
+        $failedCount = !empty($this->response['Failed'])
+            ? count($this->response['Failed'])
+            : 0;
+        $successfulCount = !empty($this->response['Successful'])
+            ? count($this->response['Successful'])
+            : 0;
+
+        $this->assertSame((int) $messageCount, $failedCount + $successfulCount);
     }
 }


### PR DESCRIPTION
fix count(): Parameter must be an array or an object that implements Countable

Supplemental PR for #1298 