### PR TITLE
SSECMiddleware fix in order to use a custom base64-encoded encryption key

### DIFF
--- a/src/S3/SSECMiddleware.php
+++ b/src/S3/SSECMiddleware.php
@@ -63,7 +63,7 @@ class SSECMiddleware
     {
         // Base64 encode the provided key
         $key = $command[$prefix . 'SSECustomerKey'];
-        if(base64_encode(base64_decode($key, true)) === $key) {
+        if($command['SSEBase64Key']) {
             $command[$prefix . 'SSECustomerKey'] = $key;
             $key = base64_decode($key, true);
         } else {

--- a/src/S3/SSECMiddleware.php
+++ b/src/S3/SSECMiddleware.php
@@ -63,7 +63,7 @@ class SSECMiddleware
     {
         // Base64 encode the provided key
         $key = $command[$prefix . 'SSECustomerKey'];
-        if($command['SSEBase64Key']) {
+        if($command['SSECustomerKeyIsBase64']) {
             $command[$prefix . 'SSECustomerKey'] = $key;
             $key = base64_decode($key, true);
         } else {

--- a/src/S3/SSECMiddleware.php
+++ b/src/S3/SSECMiddleware.php
@@ -63,8 +63,12 @@ class SSECMiddleware
     {
         // Base64 encode the provided key
         $key = $command[$prefix . 'SSECustomerKey'];
-        $command[$prefix . 'SSECustomerKey'] = base64_encode($key);
-
+        if(base64_encode(base64_decode($key, true)) === $key) {
+            $command[$prefix . 'SSECustomerKey'] = $key;
+            $key = base64_decode($key, true);
+        } else {
+            $command[$prefix . 'SSECustomerKey'] = base64_encode($key);
+        }
         // Base64 the provided MD5 or, generate an MD5 if not provided
         if ($md5 = $command[$prefix . 'SSECustomerKeyMD5']) {
             $command[$prefix . 'SSECustomerKeyMD5'] = base64_encode($md5);

--- a/tests/S3/SSECMiddlewareTest.php
+++ b/tests/S3/SSECMiddlewareTest.php
@@ -71,6 +71,19 @@ class SseCpkListenerTest extends \PHPUnit_Framework_TestCase
                     'SSECustomerKeyMD5' => null,
                 ]
             ],
+            [
+                'PutObject',
+                [
+                    'Bucket' => 'a',
+                    'Key' => 'b',
+                    'SSECustomerKey' => 'OUI3RDJDMzRBMzY2QkY4OTBDNzMwNjQxRTZDRUNGNkY=',
+                    'SSECustomerKeyMD5' => 'bar',
+                ],
+                [
+                    'SSECustomerKey' => 'OUI3RDJDMzRBMzY2QkY4OTBDNzMwNjQxRTZDRUNGNkY=',
+                    'SSECustomerKeyMD5' => base64_encode('bar'),
+                ]
+            ],
         ];
     }
 

--- a/tests/S3/SSECMiddlewareTest.php
+++ b/tests/S3/SSECMiddlewareTest.php
@@ -78,6 +78,7 @@ class SseCpkListenerTest extends \PHPUnit_Framework_TestCase
                     'Key' => 'b',
                     'SSECustomerKey' => 'OUI3RDJDMzRBMzY2QkY4OTBDNzMwNjQxRTZDRUNGNkY=',
                     'SSECustomerKeyMD5' => 'bar',
+                    'SSECustomerKeyIsBase64' => true
                 ],
                 [
                     'SSECustomerKey' => 'OUI3RDJDMzRBMzY2QkY4OTBDNzMwNjQxRTZDRUNGNkY=',


### PR DESCRIPTION
The previous implementation only accepted printable ASCII characters as the password for the SSE encryption. This reduces the password strength since it is not possible to use the full 256 values per byte, and only around 95 (printable ascii) values, effectively limiting the possible password entropy. This solution accepts both options: a custom base64-encoded encryption key or a 32 characters string.

reference: https://en.wikipedia.org/wiki/Password_strength#Random_passwords

