### PR TITLE
ContentLength Fix for MultipartUploader::createPart

### DIFF
--- a/.changes/nextrelease/contentlength_set.json
+++ b/.changes/nextrelease/contentlength_set.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Fixes an issue introduced in 3.31.0 that was not setting the ContentLength for all MultipartUploader::createPart streams, therefore potentially using an incorrect, $options['params'] value."
+  }
+]

--- a/src/S3/MultipartUploader.php
+++ b/src/S3/MultipartUploader.php
@@ -114,14 +114,16 @@ class MultipartUploader extends AbstractUploader
             Psr7\copy_to_stream($source, $body);
         }
 
+        $contentLength = $body->getSize();
+
         // Do not create a part if the body size is zero.
-        if ($body->getSize() === 0) {
+        if ($contentLength === 0) {
             return false;
         }
 
         $body->seek(0);
         $data['Body'] = $body;
-        $data['ContentLength'] = $body->getSize();
+        $data['ContentLength'] = $contentLength;
 
         return $data;
     }

--- a/src/S3/MultipartUploader.php
+++ b/src/S3/MultipartUploader.php
@@ -112,7 +112,6 @@ class MultipartUploader extends AbstractUploader
             $source = $this->decorateWithHashes($source, $data);
             $body = Psr7\stream_for();
             Psr7\copy_to_stream($source, $body);
-            $data['ContentLength'] = $body->getSize();
         }
 
         // Do not create a part if the body size is zero.
@@ -122,6 +121,7 @@ class MultipartUploader extends AbstractUploader
 
         $body->seek(0);
         $data['Body'] = $body;
+        $data['ContentLength'] = $body->getSize();
 
         return $data;
     }


### PR DESCRIPTION
Fixes #1326 - not setting the ContentLength for all MultipartUploader::createPart streams, therefore potentially using an incorrect, $options['params'] value.