### PR TITLE
Fix for S3MultiRegionClient receiving AuthorizationHeaderMalformed with host-style

### DIFF
--- a/.changes/nextrelease/multiregion_auth_header_fix.json
+++ b/.changes/nextrelease/multiregion_auth_header_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Properly handle reading mismatched regions from S3's AuthorizationHeaderMalformed exception for S3MultiRegionClient."
+  }
+]

--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\S3;
 
+use Aws\Api\Parser\PayloadParserTrait;
 use Aws\CommandInterface;
 use Aws\Exception\AwsException;
 use Aws\HandlerList;
@@ -15,6 +16,8 @@ use GuzzleHttp\Promise\RejectedPromise;
  */
 trait S3ClientTrait
 {
+    use PayloadParserTrait;
+
     /**
      * @see S3ClientInterface::upload()
      */
@@ -213,13 +216,36 @@ trait S3ClientTrait
         return $handler($command)
             ->then(static function (ResultInterface $result) {
                 return $result['@metadata']['headers']['x-amz-bucket-region'];
-            }, static function (AwsException $exception) {
-                $response = $exception->getResponse();
+            }, function (AwsException $e) {
+                $response = $e->getResponse();
                 if ($response === null) {
-                    throw $exception;
+                    throw $e;
                 }
+
+                if ($e->getAwsErrorCode() === 'AuthorizationHeaderMalformed') {
+                    $region = $this->determineBucketRegionFromExceptionBody(
+                        $response->getBody()
+                    );
+                    if (!empty($region)) {
+                        return $region;
+                    }
+                }
+
                 return $response->getHeaderLine('x-amz-bucket-region');
             });
+    }
+
+    private function determineBucketRegionFromExceptionBody($responseBody)
+    {
+        try {
+            $element = $this->parseXml($responseBody);
+            if (!empty($element->Region)) {
+                return (string)$element->Region;
+            }
+        } catch (\Exception $e) {
+            return null;
+        }
+        return null;
     }
 
     /**

--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -244,7 +244,7 @@ trait S3ClientTrait
                 return (string)$element->Region;
             }
         } catch (\Exception $e) {
-            return false;
+            // Fallthrough on exceptions from parsing
         }
         return false;
     }

--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -229,6 +229,7 @@ trait S3ClientTrait
                     if (!empty($region)) {
                         return $region;
                     }
+                    throw $e;
                 }
 
                 return $response->getHeaderLine('x-amz-bucket-region');
@@ -243,9 +244,9 @@ trait S3ClientTrait
                 return (string)$element->Region;
             }
         } catch (\Exception $e) {
-            return null;
+            return false;
         }
-        return null;
+        return false;
     }
 
     /**

--- a/src/S3/S3MultiRegionClient.php
+++ b/src/S3/S3MultiRegionClient.php
@@ -243,14 +243,14 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
                             );
                             if (!empty($region)) {
                                 $this->cache->set($cacheKey, $region);
-                            } else {
-                                $region = $this->getDetermineBucketRegionGenerator(
-                                    $command['Bucket']
-                                );
-                            }
 
-                            $command['@region'] = $region;
-                            yield $handler($command);
+                                $command['@region'] = $region;
+                                yield $handler($command);
+                            } else {
+                                throw $e;
+                            }
+                        } else {
+                            throw $e;
                         }
                     }
                 });
@@ -306,19 +306,6 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
                     $this->cache->set($cacheKey, $region);
 
                     return $region;
-                },
-                function (AwsException $e) use ($cacheKey) {
-                    if ($e->getAwsErrorCode() === 'AuthorizationHeaderMalformed') {
-                        $region = $this->determineBucketRegionFromExceptionBody(
-                            $e->getResponse()->getBody()
-                        );
-                        if (!empty($region)) {
-                            $this->cache->set($cacheKey, $region);
-
-                            return $region;
-                        }
-                    }
-                    throw $e;
                 }
             );
     }

--- a/src/S3/S3MultiRegionClient.php
+++ b/src/S3/S3MultiRegionClient.php
@@ -1,10 +1,12 @@
 <?php
 namespace Aws\S3;
 
+use Aws\Api\Parser\PayloadParserTrait;
 use Aws\CacheInterface;
 use Aws\CommandInterface;
 use Aws\LruArrayCache;
 use Aws\MultiRegionClient as BaseClient;
+use Aws\Exception\AwsException;
 use Aws\S3\Exception\PermanentRedirectException;
 use GuzzleHttp\Promise;
 
@@ -198,7 +200,8 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
         );
     }
 
-    private function determineRegionMiddleware() {
+    private function determineRegionMiddleware()
+    {
         return function (callable $handler) {
             return function (CommandInterface $command) use ($handler) {
                 $cacheKey = $this->getCacheKey($command['Bucket']);
@@ -224,17 +227,31 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
                         $region = null;
                         if (isset($result['@metadata']['headers']['x-amz-bucket-region'])) {
                             $region = $result['@metadata']['headers']['x-amz-bucket-region'];
+                            $this->cache->set($cacheKey, $region);
                         } else {
-                            /** @var S3ClientInterface $client */
-                            $client = $this->getClientFromPool();
-                            $region = (yield $client->determineBucketRegionAsync(
+                            $region = $this->getDetermineBucketRegionGenerator(
                                 $command['Bucket']
-                            ));
+                            );
                         }
 
-                        $this->cache->set($cacheKey, $region);
                         $command['@region'] = $region;
                         yield $handler($command);
+                    } catch (AwsException $e) {
+                        if ($e->getAwsErrorCode() === 'AuthorizationHeaderMalformed') {
+                            $region = $this->determineBucketRegionFromExceptionBody(
+                                $e->getResponse()->getBody()
+                            );
+                            if (!empty($region)) {
+                                $this->cache->set($cacheKey, $region);
+                            } else {
+                                $region = $this->getDetermineBucketRegionGenerator(
+                                    $command['Bucket']
+                                );
+                            }
+
+                            $command['@region'] = $region;
+                            yield $handler($command);
+                        }
                     }
                 });
             };
@@ -269,6 +286,11 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
         return $regionalClient->getObjectUrl($bucket, $key);
     }
 
+    public function getDetermineBucketRegionGenerator($bucketName)
+    {
+        yield $this->determineBucketRegionAsync($bucketName);
+    }
+
     public function determineBucketRegionAsync($bucketName)
     {
         $cacheKey = $this->getCacheKey($bucketName);
@@ -279,11 +301,26 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
         /** @var S3ClientInterface $regionalClient */
         $regionalClient = $this->getClientFromPool();
         return $regionalClient->determineBucketRegionAsync($bucketName)
-            ->then(function ($region) use ($cacheKey) {
-                $this->cache->set($cacheKey, $region);
+            ->then(
+                function ($region) use ($cacheKey) {
+                    $this->cache->set($cacheKey, $region);
 
-                return $region;
-            });
+                    return $region;
+                },
+                function (AwsException $e) use ($cacheKey) {
+                    if ($e->getAwsErrorCode() === 'AuthorizationHeaderMalformed') {
+                        $region = $this->determineBucketRegionFromExceptionBody(
+                            $e->getResponse()->getBody()
+                        );
+                        if (!empty($region)) {
+                            $this->cache->set($cacheKey, $region);
+
+                            return $region;
+                        }
+                    }
+                    throw $e;
+                }
+            );
     }
 
     private function getCacheKey($bucketName)

--- a/src/S3/S3MultiRegionClient.php
+++ b/src/S3/S3MultiRegionClient.php
@@ -229,9 +229,9 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
                             $region = $result['@metadata']['headers']['x-amz-bucket-region'];
                             $this->cache->set($cacheKey, $region);
                         } else {
-                            $region = $this->getDetermineBucketRegionGenerator(
+                            $region = (yield $this->determineBucketRegionAsync(
                                 $command['Bucket']
-                            );
+                            ));
                         }
 
                         $command['@region'] = $region;
@@ -284,11 +284,6 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
         );
 
         return $regionalClient->getObjectUrl($bucket, $key);
-    }
-
-    public function getDetermineBucketRegionGenerator($bucketName)
-    {
-        yield $this->determineBucketRegionAsync($bucketName);
     }
 
     public function determineBucketRegionAsync($bucketName)

--- a/tests/S3/S3MultiRegionClientTest.php
+++ b/tests/S3/S3MultiRegionClientTest.php
@@ -308,26 +308,6 @@ EOXML;
         $this->assertSame('us-west-2', $this->readAttribute($client, 'cache')->get('aws:s3:foo:location'));
     }
 
-    public function testCachesBucketLocationWithPathStyleViaDetermine()
-    {
-        $client = new S3MultiRegionClient([
-            'region' => 'us-east-1',
-            'version' => 'latest',
-            'credentials' => ['key' => 'foo', 'secret' => 'bar'],
-            'http_handler' => function (RequestInterface $request) {
-                if ($request->getUri()->getHost() === 's3.amazonaws.com') {
-                    return Promise\promise_for(new Response(301));
-                }
-
-                return Promise\promise_for(new Response(200, [], 'object!'));
-            },
-            'use_path_style_endpoint' => true
-        ]);
-
-        $client->getObject(['Bucket' => 'foo', 'Key' => 'bar']);
-        $this->assertSame('us-west-2', $this->readAttribute($client, 'cache')->get('aws:s3:foo:location'));
-    }
-
     public function testReadsBucketLocationFromCache()
     {
         $cache = $this->getMockBuilder(CacheInterface::class)->getMock();

--- a/tests/S3/S3MultiRegionClientTest.php
+++ b/tests/S3/S3MultiRegionClientTest.php
@@ -4,6 +4,7 @@ namespace Aws\Test\S3;
 use Aws\CacheInterface;
 use Aws\CommandInterface;
 use Aws\Endpoint\Partition;
+use Aws\Exception\AwsException;
 use Aws\LruArrayCache;
 use Aws\ResultInterface;
 use Aws\S3\S3ClientInterface;
@@ -57,6 +58,32 @@ class S3MultiRegionClientTest extends \PHPUnit_Framework_TestCase
 EOXML;
     }
 
+    private function getAuthHeaderMalformedXmlWithoutRegion()
+    {
+        return <<<EOXML
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+    <Code>AuthorizationHeaderMalformed</Code>
+    <Message>The authorization header is malformed;</Message>
+    <RequestId>656c76696e6727732072657175657374</RequestId>
+    <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
+</Error>
+EOXML;
+    }
+
+    private function getSocketTimeoutResponse()
+    {
+        return <<<EOXML
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+    <Code>RequestTimeout</Code>
+    <Message>Your socket connection to the server was not read from or written to within the timeout period. Idle connections will be closed.</Message>
+    <RequestId>REQUEST_ID</RequestId>
+    <HostId>HOST_ID</HostId>
+</Error>
+EOXML;
+    }
+
     public function testCreatesPresignedRequestsForCorrectRegion()
     {
         $client = new S3MultiRegionClient([
@@ -83,6 +110,34 @@ EOXML;
         $this->assertContains('X-Amz-Expires=', $url);
         $this->assertContains('X-Amz-Credential=', $url);
         $this->assertContains('X-Amz-Signature=', $url);
+    }
+
+    /**
+     * @expectedException \Aws\Exception\AwsException
+     * @expectedExceptionMessageRegExp /The authorization header is malformed/
+     */
+    public function testRethrowsOnAuthHeaderMalformedWithoutRegion()
+    {
+        $client = new S3MultiRegionClient([
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'credentials' => ['key' => 'foo', 'secret' => 'bar'],
+            'http_handler' => function (RequestInterface $request) {
+                if ($request->getUri()->getHost() === 'foo.s3.amazonaws.com') {
+                    return new RejectedPromise([
+                        'exception' => $this->getMockBuilder(RequestException::class)
+                            ->disableOriginalConstructor()
+                            ->getMock(),
+                        'response' => new Response(400, [], $this->getAuthHeaderMalformedXmlWithoutRegion()),
+                    ]);
+                }
+
+                return Promise\promise_for(new Response);
+            },
+        ]);
+
+        $command = $client->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'bar']);
+        $client->createPresignedRequest($command, 1342138769)->getUri();
     }
 
     public function testCreatesPresignedRequestsForCorrectRegionWithPathStyle()
@@ -175,6 +230,60 @@ EOXML;
 
         $client->getObject(['Bucket' => 'foo', 'Key' => 'bar']);
         $this->assertSame('us-west-2', $this->readAttribute($client, 'cache')->get('aws:s3:foo:location'));
+    }
+
+    /**
+     * @expectedException \Aws\Exception\AwsException
+     * @expectedExceptionMessageRegExp /Your socket connection to the server was not read from or written to within the timeout period./
+     */
+    public function testRethrowsAwsExceptionViaMiddleware()
+    {
+        $client = new S3MultiRegionClient([
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'credentials' => ['key' => 'foo', 'secret' => 'bar'],
+            'http_handler' => function (RequestInterface $request) {
+                if ($request->getUri()->getHost() === 'foo.s3.amazonaws.com') {
+                    return new RejectedPromise([
+                        'exception' => $this->getMockBuilder(RequestException::class)
+                            ->disableOriginalConstructor()
+                            ->getMock(),
+                        'response' => new Response(400, [], $this->getSocketTimeoutResponse()),
+                    ]);
+                }
+
+                return Promise\promise_for(new Response(200, [], 'object!'));
+            },
+        ]);
+
+        $client->getObject(['Bucket' => 'foo', 'Key' => 'bar']);
+    }
+
+    /**
+     * @expectedException \Aws\Exception\AwsException
+     * @expectedExceptionMessageRegExp /The authorization header is malformed/
+     */
+    public function testRethrowsOnAuthHeaderMalformedWithoutRegionViaMiddleware()
+    {
+        $client = new S3MultiRegionClient([
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'credentials' => ['key' => 'foo', 'secret' => 'bar'],
+            'http_handler' => function (RequestInterface $request) {
+                if ($request->getUri()->getHost() === 'foo.s3.amazonaws.com') {
+                    return new RejectedPromise([
+                        'exception' => $this->getMockBuilder(RequestException::class)
+                            ->disableOriginalConstructor()
+                            ->getMock(),
+                        'response' => new Response(400, [], $this->getAuthHeaderMalformedXmlWithoutRegion()),
+                    ]);
+                }
+
+                return Promise\promise_for(new Response(200, [], 'object!'));
+            },
+        ]);
+
+        $client->getObject(['Bucket' => 'foo', 'Key' => 'bar']);
     }
 
     public function testCachesBucketLocationWithPathStyle()


### PR DESCRIPTION
Properly handle reading mismatched regions from S3's AuthorizationHeaderMalformed exception for S3MultiRegionClient, updated host-style tests to reflect correct behavior.

Fixes #1324 