### PR TITLE
Fixed typo

### DIFF
--- a/build/docs/classes/DocsBuilder.php
+++ b/build/docs/classes/DocsBuilder.php
@@ -909,7 +909,7 @@ EOT;
             case 'integer': return 'int';
             case 'blob': return 'blob (string|resource|Psr\Http\Message\StreamInterface)';
             case 'char': return 'char (string)';
-            case 'timestamp': return 'timesamp (string|DateTime or anything parsable by strtotime)';
+            case 'timestamp': return 'timestamp (string|DateTime or anything parsable by strtotime)';
             case 'string':
                 if ($member['jsonvalue']){
                     return 'string (string|number|array|map or anything parsable by json_encode)';


### PR DESCRIPTION
Just wading into making my first contribution to the documentation. :-) Fixes typo, timestamp was mistyped as timesamp.