### PR TITLE
Config option message fix

### DIFF
--- a/.changes/nextrelease/config_option_message_fix.json
+++ b/.changes/nextrelease/config_option_message_fix.json
@@ -2,6 +2,6 @@
   {
     "type": "bugfix",
     "category": "",
-    "description": "Correctly provide information on required parameters that are set to `null` when resolving a client."
+    "description": "Fixes a bug in `ClientResolver` that would provide incorrect information on required parameters set to `null` when resolving a client."
   }
 ]

--- a/.changes/nextrelease/config_option_message_fix.json
+++ b/.changes/nextrelease/config_option_message_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Correctly provide information on required parameters that are set to `null` when resolving a client."
+  }
+]

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -363,7 +363,7 @@ class ClientResolver
         foreach ($this->argDefinitions as $k => $a) {
             if (empty($a['required'])
                 || isset($a['default'])
-                || array_key_exists($k, $args)
+                || isset($args[$k])
             ) {
                 continue;
             }

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -491,6 +491,22 @@ EOT;
 
     /**
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A "version" configuration value is required
+     */
+    public function testHasSpecificMessageForNullRequiredVersion()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $list = new HandlerList();
+        $r->resolve([
+            'service'     => 'foo',
+            'region'      => 'x',
+            'credentials' => ['key' => 'a', 'secret' => 'b'],
+            'version'     => null,
+        ], $list);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage A "region" configuration value is required for the "foo" service
      */
     public function testHasSpecificMessageForMissingRegion()
@@ -498,6 +514,22 @@ EOT;
         $args = ClientResolver::getDefaultArguments()['region'];
         $r = new ClientResolver(['region' => $args]);
         $r->resolve(['service' => 'foo'], new HandlerList());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A "region" configuration value is required for the "foo" service
+     */
+    public function testHasSpecificMessageForNullRequiredRegion()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $list = new HandlerList();
+        $r->resolve([
+            'service'     => 'foo',
+            'region'      => null,
+            'credentials' => ['key' => 'a', 'secret' => 'b'],
+            'version'     => 'latest',
+        ], $list);
     }
 
     public function testAddsTraceMiddleware()


### PR DESCRIPTION
Correctly provide information on required parameters that are set to `null` when resolving a client.

Resolves the messaging issue from #1051