### PR TITLE
Guzzle5 Exception SaveAs Fix

### DIFF
--- a/.changes/nextrelease/guzzle5_SaveAs_file_fix
+++ b/.changes/nextrelease/guzzle5_SaveAs_file_fix
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Fixes an issue where exceptions weren't being fully loaded when using a `SaveAs` parameter set to a file path on Guzzle v5."
+  }
+]

--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -81,9 +81,9 @@ class GuzzleHandler
                 return $this->createPsr7Response($response);
             },
             function (Exception $exception) use ($options) {
-                // If we got a 'sink' that's a path, the body is now the path
-                // and the actual response body is in the file, let's load it
-                // to properly build up the exception.
+                // If we got a 'sink' that's a path, set the response body to
+                // the contents of the file. This will build the resulting
+                // exception with more information.
                 if ($exception instanceof RequestException) {
                     if (isset($options['sink'])) {
                         if (!($options['sink'] instanceof Psr7StreamInterface)) {

--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -162,7 +162,7 @@ class GuzzleHandler
         $request->setHeader(
             'User-Agent',
             $request->getHeader('User-Agent')
-            . ' ' . Client::getDefaultUserAgent()
+                . ' ' . Client::getDefaultUserAgent()
         );
 
         // Make sure the delay is configured, if provided.

--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Message\ResponseInterface as GuzzleResponse;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Response as Psr7Response;
+use GuzzleHttp\Stream\Stream;
 use Psr\Http\Message\RequestInterface as Psr7Request;
 use Psr\Http\Message\StreamInterface as Psr7StreamInterface;
 
@@ -79,7 +80,21 @@ class GuzzleHandler
                 // Adapt the Guzzle 5 Future to a Guzzle 6 ResponsePromise.
                 return $this->createPsr7Response($response);
             },
-            function (Exception $exception) {
+            function (Exception $exception) use ($options) {
+                // If we got a 'sink' that's a path, the body is now the path
+                // and the actual response body is in the file, let's load it
+                // to properly build up the exception.
+                if ($exception instanceof RequestException) {
+                    if (isset($options['sink'])) {
+                        if (!($options['sink'] instanceof Psr7StreamInterface)) {
+                            $exception->getResponse()->setBody(
+                                Stream::factory(
+                                    file_get_contents($options['sink'])
+                                )
+                            );
+                        }
+                    }
+                }
                 // Reject with information about the error.
                 return new Promise\RejectedPromise($this->prepareErrorData($exception));
             }
@@ -147,7 +162,7 @@ class GuzzleHandler
         $request->setHeader(
             'User-Agent',
             $request->getHeader('User-Agent')
-                . ' ' . Client::getDefaultUserAgent()
+            . ' ' . Client::getDefaultUserAgent()
         );
 
         // Make sure the delay is configured, if provided.

--- a/tests/Handler/GuzzleV5/HandlerTest.php
+++ b/tests/Handler/GuzzleV5/HandlerTest.php
@@ -4,16 +4,19 @@ namespace Aws\Test\Handler\GuzzleV5;
 use Aws\Handler\GuzzleV5\GuzzleHandler;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Message\FutureResponse;
 use GuzzleHttp\Message\Request as GuzzleRequest;
 use GuzzleHttp\Message\Response as GuzzleResponse;
 use GuzzleHttp\Message\Response;
 use GuzzleHttp\Promise\RejectionException;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Stream as PsrStream;
 use GuzzleHttp\Psr7\Request as PsrRequest;
 use GuzzleHttp\Psr7\Response as PsrResponse;
 use GuzzleHttp\Ring\Client\MockHandler;
 use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Stream\LazyOpenStream;
 use GuzzleHttp\Tests\Ring\Client\MockHandlerTest;
 use React\Promise\Deferred;
 
@@ -79,6 +82,98 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($wasRejected, 'Reject callback was not triggered.');
     }
 
+    private function getErrorXml()
+    {
+        return <<<EOXML
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NoSuchKey</Code>
+  <Message>The specified key does not exist.</Message>
+  <Key>test.png</Key>
+  <RequestId>656c76696e6727732072657175657374</RequestId>
+  <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
+</Error>
+EOXML;
+    }
+
+    public function testHandlerWorksWithFailedRequestFileSink()
+    {
+        $xml = $this->getErrorXml();
+        $sink = sys_get_temp_dir() . '/test_error_sink.txt';
+        $deferred = new Deferred();
+        $handler = $this->getHandler($deferred, $xml);
+        $wasRejected = false;
+
+        $promise = $handler(
+            new PsrRequest('GET', 'http://example.com'),
+            ['delay' => 500, 'sink' => $sink]
+        );
+        $promise->then(null, function (array $error) use (&$wasRejected) {
+            $wasRejected = true;
+        });
+
+        $deferred->reject(new RequestException(
+            'message',
+            new GuzzleRequest('GET', 'http://example.com'),
+            new GuzzleResponse('404')
+        ));
+
+        try {
+            $promise->wait();
+            unlink($sink);
+            $this->fail('An exception should have been thrown.');
+        } catch (RejectionException $e) {
+            $error = $e->getReason();
+            $this->assertInstanceOf(RequestException::class, $error['exception']);
+            $this->assertFalse($error['connection_error']);
+            $this->assertInstanceOf(PsrResponse::class, $error['response']);
+            $this->assertEquals(404, $error['response']->getStatusCode());
+            $this->assertEquals($xml, $error['response']->getBody());
+            $this->assertEquals($xml, file_get_contents($sink));
+            unlink($sink);
+        }
+
+        $this->assertTrue($wasRejected, 'Reject callback was not triggered.');
+    }
+
+    public function testHandlerWorksWithFailedRequestStreamSink()
+    {
+        $xml = $this->getErrorXml();
+        $sink = Psr7\stream_for();
+        $deferred = new Deferred();
+        $handler = $this->getHandler($deferred, $xml);
+        $wasRejected = false;
+
+        $promise = $handler(
+            new PsrRequest('GET', 'http://example.com'),
+            ['delay' => 500, 'sink' => $sink]
+        );
+        $promise->then(null, function (array $error) use (&$wasRejected) {
+            $wasRejected = true;
+        });
+
+        $deferred->reject(new RequestException(
+            'message',
+            new GuzzleRequest('GET', 'http://example.com'),
+            new GuzzleResponse('404', [], Stream::factory($xml))
+        ));
+
+        try {
+            $promise->wait();
+            $this->fail('An exception should have been thrown.');
+        } catch (RejectionException $e) {
+            $error = $e->getReason();
+            $this->assertInstanceOf(RequestException::class, $error['exception']);
+            $this->assertFalse($error['connection_error']);
+            $this->assertInstanceOf(PsrResponse::class, $error['response']);
+            $this->assertEquals(404, $error['response']->getStatusCode());
+            $this->assertEquals($xml, (string)$error['response']->getBody());
+            $this->assertEquals($xml, (string)$sink);
+        }
+
+        $this->assertTrue($wasRejected, 'Reject callback was not triggered.');
+    }
+
     public function testHandlerWorksWithEmptyBody()
     {
         $deferred = new Deferred();
@@ -105,16 +200,20 @@ class HandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($wasCalled);
     }
 
-    private function getHandler(Deferred $deferred)
+    private function getHandler(Deferred $deferred, $output = 'foo')
     {
         $client = $this->getMock('GuzzleHttp\Client', ['send']);
         $future = new FutureResponse($deferred->promise());
         $client->method('send')->willReturn($future);
 
-        return function ($request, $options = []) use ($client) {
+        return function ($request, $options = []) use ($client, $output) {
             /** @var $client \GuzzleHttp\Client */
             if (isset($options['sink'])) {
-                $options['sink']->write('foo');
+                if ($options['sink'] instanceof PsrStream) {
+                    $options['sink']->write($output);
+                } else {
+                    file_put_contents($options['sink'], $output);
+                }
             }
             return call_user_func(new GuzzleHandler($client), $request, $options);
         };

--- a/tests/Handler/GuzzleV5/HandlerTest.php
+++ b/tests/Handler/GuzzleV5/HandlerTest.php
@@ -16,7 +16,6 @@ use GuzzleHttp\Psr7\Request as PsrRequest;
 use GuzzleHttp\Psr7\Response as PsrResponse;
 use GuzzleHttp\Ring\Client\MockHandler;
 use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Stream\LazyOpenStream;
 use GuzzleHttp\Tests\Ring\Client\MockHandlerTest;
 use React\Promise\Deferred;
 


### PR DESCRIPTION
Fixes an issue where exceptions weren't being fully loaded when using a `SaveAs` parameter set to a file path on Guzzle v5.

Fixes #1355 