### PR TITLE
Set ContentType only when no params ContentType

### DIFF
--- a/src/S3/MultipartUploadingTrait.php
+++ b/src/S3/MultipartUploadingTrait.php
@@ -102,8 +102,8 @@ trait MultipartUploadingTrait
             $params['ACL'] = $config['acl'];
         }
 
-        // Set the content type
-        if ($type = $this->getSourceMimeType()) {
+        // Set the content type if ContentType is not set
+        if (!isset($params['ContentType']) && $type = $this->getSourceMimeType()) {
             $params['ContentType'] = $type;
         }
 


### PR DESCRIPTION
I have an issue when upload pdf to S3 storage. It always has content type 'application/octet-stream' even though I force it to 'application/pdf' but It's still the same.

I thought it was pdf is too big and It call getSourceMimeType before it generate finish. That makes it wrong ContentType.

If anything go wrong please suggest me. This is my first time. 
Thank you