### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,27 @@ language: php
 
 dist: trusty
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm
-  - nightly
-
-sudo: false
-
-env:
-  - COMPOSER_OPTS=""
-  - COMPOSER_OPTS="--prefer-lowest"
-
 matrix:
+  php:
+    - 5.5
+    - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
+    - hhvm
+    - nightly
+  env:
+    - COMPOSER_OPTS=""
+    - COMPOSER_OPTS="--prefer-lowest"
   allow_failures:
+    - php: 7.2
+      env: COMPOSER_OPTS="--prefer-lowest"
     - php: hhvm
     - php: nightly
+      env: COMPOSER_OPTS="--prefer-lowest"
   fast_finish: true
+
+sudo: false
 
 install:
   - export AWS_ACCESS_KEY_ID=foo

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,26 @@ language: php
 
 dist: trusty
 
-matrix:
-  allow_failures:
-    - php: hhvm
-    - php: nightly
-  include:
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: hhvm
-    - php: nightly
-  fast_finish: true
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - hhvm
+  - nightly
 
 sudo: false
 
 env:
   - COMPOSER_OPTS=""
   - COMPOSER_OPTS="--prefer-lowest"
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: nightly
+  fast_finish: true
 
 install:
   - export AWS_ACCESS_KEY_ID=foo

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ sudo: false
 install:
   - export AWS_ACCESS_KEY_ID=foo
   - export AWS_SECRET_ACCESS_KEY=bar
-  - 'if [ $(phpenv version-name) != "hhvm" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
+  - 'if [ $(phpenv version-name) != "hhvm" -a $(phpenv version-name) != "nightly" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ install:
   - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.remote_autostart=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.remote_enable=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.profiler_enable=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
+  - 'if [ $(phpenv version-name) != "hhvm" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
+  - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,25 @@ language: php
 
 dist: trusty
 
-matrix:
-  php:
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - hhvm
-    - nightly
-  env:
-    - COMPOSER_OPTS=""
-    - COMPOSER_OPTS="--prefer-lowest"
-  allow_failures:
-    - php: 7.2
-      env: COMPOSER_OPTS="--prefer-lowest"
-    - php: hhvm
-    - php: nightly
-      env: COMPOSER_OPTS="--prefer-lowest"
-  fast_finish: true
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - hhvm
+  - nightly
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+allow_failures:
+  - php: 7.2
+    env: COMPOSER_OPTS="--prefer-lowest"
+  - php: hhvm
+  - php: nightly
+    env: COMPOSER_OPTS="--prefer-lowest"
+
+fast_finish: true
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: php
 
-dist: precise
+dist: trusty
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - nightly
-  - hhvm
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: nightly
+  include:
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: hhvm
+    - php: nightly
+  fast_finish: true
 
 sudo: false
 
 env:
   - COMPOSER_OPTS=""
   - COMPOSER_OPTS="--prefer-lowest"
-
-matrix:
-  allow_failures:
-    - php: hhvm
-    - php: nightly
-  fast_finish: true
 
 install:
   - export AWS_ACCESS_KEY_ID=foo

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,6 @@ sudo: false
 install:
   - export AWS_ACCESS_KEY_ID=foo
   - export AWS_SECRET_ACCESS_KEY=bar
-  - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.remote_autostart=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.remote_enable=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.profiler_enable=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 
-dist: trusty
-
 php:
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ php:
 env:
   - COMPOSER_OPTS=""
   - COMPOSER_OPTS="--prefer-lowest"
-allow_failures:
-  - php: 7.2
-    env: COMPOSER_OPTS="--prefer-lowest"
-  - php: hhvm
-  - php: nightly
-    env: COMPOSER_OPTS="--prefer-lowest"
 
-fast_finish: true
+matrix:
+  allow_failures:
+    - php: 7.2
+      env: COMPOSER_OPTS="--prefer-lowest"
+    - php: hhvm
+    - php: nightly
+  fast_finish: true
 
 sudo: false
 
@@ -28,6 +28,9 @@ install:
   - export AWS_ACCESS_KEY_ID=foo
   - export AWS_SECRET_ACCESS_KEY=bar
   - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
+  - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.remote_autostart=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
+  - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.remote_enable=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
+  - 'if [ $(phpenv version-name) != "hhvm" ]; then echo "xdebug.profiler_enable=0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 
 script:


### PR DESCRIPTION
Update Travis to run on defauly (Trusty). Disable xdebug in the container due to segfault issues on 5.5. Add 7.2 (previously nightly) to included list and allow failure on '--prefer-lowest' for it.