### PR TITLE
Travis Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ install:
   - export AWS_SECRET_ACCESS_KEY=bar
   - 'if [ $(phpenv version-name) == "5.5" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) == "7.2" ] && [ -v COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.7.0"; fi'
-  -
+  - 'if [ $(phpenv version-name) == "7.2" ] && [ -v COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.7.10"; fi'
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - export AWS_SECRET_ACCESS_KEY=bar
   - 'if [ $(phpenv version-name) == "5.5" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) == "7.2" ] && [ -v $COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
+  - 'if [ $(phpenv version-name) == "7.2" ] && [ -v COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
   -
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - export AWS_SECRET_ACCESS_KEY=bar
   - 'if [ $(phpenv version-name) == "5.5" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) == "7.2" ] && [ -v COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
+  - 'if [ $(phpenv version-name) == "7.2" ] && [ -v COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.7.0"; fi'
   -
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - export AWS_SECRET_ACCESS_KEY=bar
   - 'if [ $(phpenv version-name) == "5.5" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) == "7.2" ] && [ ! ( -z "$COMPOSER_OPTS" ) ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
+  - 'if [ $(phpenv version-name) == "7.2" ] && [ ! [ -z "$COMPOSER_OPTS" ] ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ sudo: false
 install:
   - export AWS_ACCESS_KEY_ID=foo
   - export AWS_SECRET_ACCESS_KEY=bar
-  - 'if [ $(phpenv version-name) != "hhvm" -a $(phpenv version-name) != "nightly" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
+  - 'if [ $(phpenv version-name) == "5.5" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
+  - 'if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
+  - 'if [ $(phpenv version-name) == "7.2" ] && [ ! ( -z "$COMPOSER_OPTS" ) ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
 
 matrix:
   allow_failures:
-    - php: 7.2
-      env: COMPOSER_OPTS="--prefer-lowest"
     - php: hhvm
     - php: nightly
   fast_finish: true
@@ -27,7 +25,8 @@ install:
   - export AWS_SECRET_ACCESS_KEY=bar
   - 'if [ $(phpenv version-name) == "5.5" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ $(phpenv version-name) == "7.2" ] && [ ! [ -z "$COMPOSER_OPTS" ] ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
+  - 'if [ $(phpenv version-name) == "7.2" ] && [ -v $COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.4.0"; fi'
+  -
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 


### PR DESCRIPTION
* Only disable `xdebug` on 5.5, not all non `hhvm`/`nightly`. This should bring back codecov.
* Disable `xdebug`'s var_dump on all base PHP versions.
* Require `phpunit` '^5.7.10' in PHP 7.2, as it ups requirement on `comparator` to '^1.2.4'. Remove 7.2/`--prefer-lowest` from `allow_failures`.