### PR TITLE
Obey 'use_path_style_endpoint' in PostObject[V4]

### DIFF
--- a/.changes/nextrelease/path_style_abstraction_updates.json
+++ b/.changes/nextrelease/path_style_abstraction_updates.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "PostObject[V4] classes now obey use_path_style_endpoint client configuration in form generation."
+  }
+]

--- a/src/S3/PostObject.php
+++ b/src/S3/PostObject.php
@@ -128,8 +128,9 @@ class PostObject
     {
         $uri = new Uri($this->client->getEndpoint());
 
-        if ($uri->getScheme() === 'https'
-            && strpos($this->bucket, '.') !== false
+        if ($this->client->getConfig('use_path_style_endpoint') === true
+            || ($uri->getScheme() === 'https'
+            && strpos($this->bucket, '.') !== false)
         ) {
             // Use path-style URLs
             $uri = $uri->withPath("/{$this->bucket}");

--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -143,8 +143,9 @@ class PostObjectV4
     {
         $uri = new Uri($this->client->getEndpoint());
 
-        if ($uri->getScheme() === 'https'
-            && strpos($this->bucket, '.') !== false
+        if ($this->client->getConfig('use_path_style_endpoint') === true
+            || ($uri->getScheme() === 'https'
+            && strpos($this->bucket, '.') !== false)
         ) {
             // Use path-style URLs
             $uri = $uri->withPath("/{$this->bucket}");

--- a/tests/S3/PostObjectTest.php
+++ b/tests/S3/PostObjectTest.php
@@ -71,4 +71,43 @@ class PostObjectTest extends \PHPUnit_Framework_TestCase
             $formAttrs['action']
         );
     }
+
+    /**
+     * @dataProvider pathStyleProvider
+     *
+     * @param string $endpoint
+     * @param string $bucket
+     * @param string $expected
+     */
+    public function testCanHandleForcedPathStyleEndpoint($endpoint, $bucket, $expected)
+    {
+        $s3 = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-east-1',
+            'credentials' => [
+                'key' => 'akid',
+                'secret' => 'secret',
+            ],
+            'endpoint' => $endpoint,
+            'use_path_style_endpoint' => true,
+        ]);
+        $policy = [
+            'expiration' => '2007-12-01T12:00:00.000Z',
+            'conditions' => [
+                'acl' => 'public-read'
+            ]
+        ];
+        $postObject = new PostObject($s3, $bucket, [], $policy);
+        $formAttrs = $postObject->getFormAttributes();
+        $this->assertEquals($expected, $formAttrs['action']);
+    }
+
+    public function pathStyleProvider()
+    {
+        return [
+            ['http://s3.amazonaws.com', 'foo', 'http://s3.amazonaws.com/foo'],
+            ['http://s3.amazonaws.com', 'foo.bar', 'http://s3.amazonaws.com/foo.bar'],
+            ['http://foo.com', 'foo.com', 'http://foo.com/foo.com'],
+        ];
+    }
 }

--- a/tests/S3/PostObjectV4Test.php
+++ b/tests/S3/PostObjectV4Test.php
@@ -269,4 +269,37 @@ class PostObjectV4Test extends \PHPUnit_Framework_TestCase
             ['http://foo.com', 'foo.com', 'http://foo.com.foo.com'],
         ];
     }
+
+    /**
+     * @dataProvider pathStyleProvider
+     *
+     * @param string $endpoint
+     * @param string $bucket
+     * @param string $expected
+     */
+    public function testCanHandleForcedPathStyleEndpoint($endpoint, $bucket, $expected)
+    {
+        $s3 = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-east-1',
+            'credentials' => [
+                'key' => 'akid',
+                'secret' => 'secret',
+            ],
+            'endpoint' => $endpoint,
+            'use_path_style_endpoint' => true,
+        ]);
+        $postObject = new PostObjectV4($s3, $bucket, []);
+        $formAttrs = $postObject->getFormAttributes();
+        $this->assertEquals($expected, $formAttrs['action']);
+    }
+
+    public function pathStyleProvider()
+    {
+        return [
+            ['http://s3.amazonaws.com', 'foo', 'http://s3.amazonaws.com/foo'],
+            ['http://s3.amazonaws.com', 'foo.bar', 'http://s3.amazonaws.com/foo.bar'],
+            ['http://foo.com', 'foo.com', 'http://foo.com/foo.com'],
+        ];
+    }
 }


### PR DESCRIPTION
`PostObject[V4]` classes now obey the `'use_path_style_endpoint'` client configuration in form generation.

Fixes #1399 