### PR TITLE
ResultPaginator createNextCommand Arguments Fix

### DIFF
--- a/.changes/nextrelease/pagination_next_command_params_fix.json
+++ b/.changes/nextrelease/pagination_next_command_params_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Override passed in starting token for a ResultPaginator when moving to the next command."
+  }
+]

--- a/src/ResultPaginator.php
+++ b/src/ResultPaginator.php
@@ -143,7 +143,7 @@ class ResultPaginator implements \Iterator
 
     private function createNextCommand(array $args, array $nextToken = null)
     {
-        return $this->client->getCommand($this->operation, $args + ($nextToken ?: []));
+        return $this->client->getCommand($this->operation, array_merge($args, ($nextToken ?: [])));
     }
 
     private function determineNextToken(Result $result)


### PR DESCRIPTION
Override passed in starting token for a `ResultPaginator` when moving to the next command.

Fixes #1396 