### PR TITLE
PresignUrlMiddleware 'require_different_region' Option

### DIFF
--- a/.changes/nextrelease/presign_sourceregion_fix.json
+++ b/.changes/nextrelease/presign_sourceregion_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Rds",
+    "description": "Update PresignUrlMiddleware to take an optional require_different_region, default false, for providing presigned urls only if the source and destination regions differ. Require this for RdsClient operations that use the middleware."
+  }
+]

--- a/src/PresignUrlMiddleware.php
+++ b/src/PresignUrlMiddleware.php
@@ -22,6 +22,8 @@ class PresignUrlMiddleware
     private $serviceName;
     /** @var string */
     private $presignParam;
+    /** @var bool */
+    private $requireDifferentRegion;
 
     public function __construct(
         array $options,
@@ -35,6 +37,7 @@ class PresignUrlMiddleware
         $this->commandPool = $options['operations'];
         $this->serviceName = $options['service'];
         $this->presignParam = $options['presign_param'];
+        $this->requireDifferentRegion = !empty($options['require_different_region']);
     }
 
     public static function wrap(
@@ -53,8 +56,13 @@ class PresignUrlMiddleware
         if (in_array($cmd->getName(), $this->commandPool)
             && (!isset($cmd->{'__skip' . $cmd->getName()}))
         ) {
-            $cmd[$this->presignParam] = $this->createPresignedUrl($this->client, $cmd);
             $cmd['DestinationRegion'] = $this->client->getRegion();
+            if (!$this->requireDifferentRegion
+                || (!empty($cmd['SourceRegion'])
+                    && $cmd['SourceRegion'] !== $cmd['DestinationRegion'])
+            ) {
+                $cmd[$this->presignParam] = $this->createPresignedUrl($this->client, $cmd);
+            }
         }
 
         $f = $this->nextHandler;

--- a/src/Rds/RdsClient.php
+++ b/src/Rds/RdsClient.php
@@ -209,6 +209,7 @@ class RdsClient extends AwsClient
                         ],
                         'service' => 'rds',
                         'presign_param' => 'PreSignedUrl',
+                        'require_different_region' => true,
                     ]
                 ),
                 'rds.presigner'

--- a/tests/PresignUrlMiddlewareTest.php
+++ b/tests/PresignUrlMiddlewareTest.php
@@ -82,4 +82,22 @@ class PresignUrlMiddlewareTest extends \PHPUnit_Framework_TestCase
             'TargetDBSnapshotIdentifier' => 'my-snapshot-copy',
         ]);
     }
+
+    public function testNoPreSignedUrlWhenDifferentSourceRegionRequired()
+    {
+        $rds = new RdsClient([
+            'region'  => 'us-east-2',
+            'version' => 'latest',
+            'handler' => function (CommandInterface $cmd, RequestInterface $r) {
+                $this->assertNull($cmd['PreSignedUrl']);
+                $this->assertSame('us-east-2', $cmd['DestinationRegion']);
+
+                return new Result;
+            },
+        ]);
+        $rds->createDBInstanceReadReplica([
+            'DBInstanceIdentifier' => 'test-replica',
+            'SourceDBInstanceIdentifier' => 'test-source',
+        ]);
+    }
 }

--- a/tests/Rds/RdsClientTest.php
+++ b/tests/Rds/RdsClientTest.php
@@ -8,7 +8,7 @@ use Aws\Result;
 /**
  * @covers Aws\Rds\RdsClient
  */
-class Ec2ClientTest extends \PHPUnit_Framework_TestCase
+class RdsClientTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddsCopySnapshotMiddleware()
     {


### PR DESCRIPTION
Update `PresignUrlMiddleware` to take an optional `'require_different_region'`, default `false`, for providing presigned urls only if the source and destination regions differ. Require this for `RdsClient` operations that use the middleware.

Fixes #1415