### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/.changes/nextrelease/use-phpunit-framework-test
+++ b/.changes/nextrelease/use-phpunit-framework-test
@@ -1,0 +1,7 @@
+[
+   {
+       "type": "enhancement",
+       "category": "Test",
+       "description": "use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase"
+   }
+]

--- a/.changes/nextrelease/use-phpunit-framework-test
+++ b/.changes/nextrelease/use-phpunit-framework-test
@@ -2,6 +2,6 @@
    {
        "type": "enhancement",
        "category": "Test",
-       "description": "use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase"
+       "description": "Use PHPUnit\\Framework\\TestCase instead of PHPUnit_Framework_TestCase"
    }
 ]

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "ext-openssl": "*",
         "ext-dom": "*",
-        "phpunit/phpunit": "^4.8.35|^5.4.0",
+        "phpunit/phpunit": "^4.8.35|^5.4.3",
         "behat/behat": "~3.0",
         "doctrine/cache": "~1.4",
         "aws/aws-php-sns-message-validator": "~1.0",

--- a/tests/Api/ApiProviderTest.php
+++ b/tests/Api/ApiProviderTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api;
 
 use Aws\Api\ApiProvider;
 use Aws\Exception\UnresolvedApiException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\ApiProvider
  */
-class ApiProviderTest extends \PHPUnit_Framework_TestCase
+class ApiProviderTest extends TestCase
 {
     /**
      * @return ApiProvider;

--- a/tests/Api/DateTimeResultTest.php
+++ b/tests/Api/DateTimeResultTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Api;
 
 use Aws\Api\DateTimeResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\DateTimeResult
  */
-class DateTimeResultTest extends \PHPUnit_Framework_TestCase
+class DateTimeResultTest extends TestCase
 {
     public function testCreatesFromEpoch()
     {

--- a/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
+++ b/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
@@ -3,12 +3,13 @@ namespace Aws\Test\Api\ErrorParser;
 
 use Aws\Api\ErrorParser\JsonRpcErrorParser;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\ErrorParser\JsonRpcErrorParser
  * @covers Aws\Api\ErrorParser\JsonParserTrait
  */
-class JsonRpcErrorParserTest extends \PHPUnit_Framework_TestCase
+class JsonRpcErrorParserTest extends TestCase
 {
     public function testParsesClientErrorResponses()
     {

--- a/tests/Api/ErrorParser/RestJsonErrorParserTest.php
+++ b/tests/Api/ErrorParser/RestJsonErrorParserTest.php
@@ -3,12 +3,13 @@ namespace Aws\Test\Api\ErrorParser;
 
 use Aws\Api\ErrorParser\RestJsonErrorParser;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\ErrorParser\RestJsonErrorParser
  * @covers Aws\Api\ErrorParser\JsonParserTrait
  */
-class RestJsonErrorParserTest extends \PHPUnit_Framework_TestCase
+class RestJsonErrorParserTest extends TestCase
 {
     public function testParsesClientErrorResponses()
     {

--- a/tests/Api/ErrorParser/XmlErrorParserTest.php
+++ b/tests/Api/ErrorParser/XmlErrorParserTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api\ErrorParser;
 
 use Aws\Api\ErrorParser\XmlErrorParser;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\ErrorParser\XmlErrorParser
  */
-class XmlErrorParserTest extends \PHPUnit_Framework_TestCase
+class XmlErrorParserTest extends TestCase
 {
     /**
      * @return array

--- a/tests/Api/ListShapeTest.php
+++ b/tests/Api/ListShapeTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api;
 
 use Aws\Api\ShapeMap;
 use Aws\Api\ListShape;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\ListShape
  */
-class ListShapeTest extends \PHPUnit_Framework_TestCase
+class ListShapeTest extends TestCase
 {
     public function testReturnsMember()
     {

--- a/tests/Api/MapShapeTest.php
+++ b/tests/Api/MapShapeTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api;
 
 use Aws\Api\ShapeMap;
 use Aws\Api\MapShape;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\MapShape
  */
-class MapShapeTest extends \PHPUnit_Framework_TestCase
+class MapShapeTest extends TestCase
 {
     public function testReturnsValue()
     {

--- a/tests/Api/OperationTest.php
+++ b/tests/Api/OperationTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api;
 
 use Aws\Api\ShapeMap;
 use Aws\Api\Operation;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\Operation
  */
-class OperationTest extends \PHPUnit_Framework_TestCase
+class OperationTest extends TestCase
 {
     public function testCreatesDefaultMethodAndUri()
     {

--- a/tests/Api/Parser/ComplianceTest.php
+++ b/tests/Api/Parser/ComplianceTest.php
@@ -6,6 +6,7 @@ use Aws\Api\Service;
 use Aws\Api\Shape;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Parser\AbstractParser
@@ -17,7 +18,7 @@ use GuzzleHttp\Psr7;
  * @covers Aws\Api\Parser\QueryParser
  * @covers Aws\Api\Parser\XmlParser
  */
-class ComplianceTest extends \PHPUnit_Framework_TestCase
+class ComplianceTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/Parser/Crc32ValidatingParserTest.php
+++ b/tests/Api/Parser/Crc32ValidatingParserTest.php
@@ -8,11 +8,12 @@ use Aws\Api\Service;
 use Aws\Command;
 use Aws\Exception\AwsException;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Parser\Crc32ValidatingParser
  */
-class Crc32ValidatingParserTest extends \PHPUnit_Framework_TestCase
+class Crc32ValidatingParserTest extends TestCase
 {
     private function getWrapped()
     {

--- a/tests/Api/Parser/JsonRpcParserTest.php
+++ b/tests/Api/Parser/JsonRpcParserTest.php
@@ -8,8 +8,9 @@ use Aws\Api\Service;
 use Aws\Api\Shape;
 use Aws\CommandInterface;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class JsonRpcParserTest extends \PHPUnit_Framework_TestCase
+class JsonRpcParserTest extends TestCase
 {
     public function testCanHandleNullResponses()
     {

--- a/tests/Api/Serializer/ComplianceTest.php
+++ b/tests/Api/Serializer/ComplianceTest.php
@@ -4,6 +4,7 @@ namespace Aws\Test\Api\Serializer;
 use Aws\Api\Service;
 use Aws\AwsClient;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\Serializer\QuerySerializer
@@ -16,7 +17,7 @@ use Aws\Test\UsesServiceTrait;
  * @covers \Aws\Api\Serializer\Ec2ParamBuilder
  * @covers \Aws\Api\Serializer\QueryParamBuilder
  */
-class ComplianceTest extends \PHPUnit_Framework_TestCase
+class ComplianceTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/Serializer/JsonBodyTest.php
+++ b/tests/Api/Serializer/JsonBodyTest.php
@@ -6,11 +6,12 @@ use Aws\Api\Service;
 use Aws\Api\Shape;
 use Aws\Api\ShapeMap;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Serializer\JsonBody
  */
-class JsonBodyTest extends \PHPUnit_Framework_TestCase
+class JsonBodyTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/Serializer/JsonRpcSerializerTest.php
+++ b/tests/Api/Serializer/JsonRpcSerializerTest.php
@@ -5,11 +5,12 @@ use Aws\Command;
 use Aws\Api\Serializer\JsonRpcSerializer;
 use Aws\Api\Service;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Serializer\JsonRpcSerializer
  */
-class JsonRpcSerializerTest extends \PHPUnit_Framework_TestCase
+class JsonRpcSerializerTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/Serializer/QuerySerializerTest.php
+++ b/tests/Api/Serializer/QuerySerializerTest.php
@@ -5,11 +5,12 @@ use Aws\Api\Serializer\QuerySerializer;
 use Aws\Api\Service;
 use Aws\Command;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Serializer\QuerySerializer
  */
-class QuerySerializerTest extends \PHPUnit_Framework_TestCase
+class QuerySerializerTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/Serializer/RestJsonSerializerTest.php
+++ b/tests/Api/Serializer/RestJsonSerializerTest.php
@@ -5,11 +5,12 @@ use Aws\Api\Service;
 use Aws\Command;
 use Aws\Api\Serializer\RestJsonSerializer;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Serializer\RestJsonSerializer
  */
-class RestJsonSerializerTest extends \PHPUnit_Framework_TestCase
+class RestJsonSerializerTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/Serializer/RestXmlSerializerTest.php
+++ b/tests/Api/Serializer/RestXmlSerializerTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api\Serializer;
 
 use Aws\Api\Serializer\RestXmlSerializer;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Serializer\RestXmlSerializer
  */
-class RestXmlSerializerTest extends \PHPUnit_Framework_TestCase
+class RestXmlSerializerTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/ServiceTest.php
+++ b/tests/Api/ServiceTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api;
 
 use Aws\Api\Service;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\Service
  */
-class ServiceTest extends \PHPUnit_Framework_TestCase
+class ServiceTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Api/ShapeMapTest.php
+++ b/tests/Api/ShapeMapTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Api;
 
 use Aws\Api\ShapeMap;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\ShapeMap
  */
-class ShapeMapTest extends \PHPUnit_Framework_TestCase
+class ShapeMapTest extends TestCase
 {
     public function testReturnsShapeName()
     {

--- a/tests/Api/ShapeTest.php
+++ b/tests/Api/ShapeTest.php
@@ -3,12 +3,13 @@ namespace Aws\Test\Api;
 
 use Aws\Api\Shape;
 use Aws\Api\ShapeMap;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\Shape
  * @covers \Aws\Api\AbstractModel
  */
-class ShapeTest extends \PHPUnit_Framework_TestCase
+class ShapeTest extends TestCase
 {
     public function testImplementsArray()
     {

--- a/tests/Api/StructureShapeTest.php
+++ b/tests/Api/StructureShapeTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api;
 
 use Aws\Api\ShapeMap;
 use Aws\Api\StructureShape;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\StructureShape
  */
-class StructureShapeTest extends \PHPUnit_Framework_TestCase
+class StructureShapeTest extends TestCase
 {
     public function testReturnsWhenMembersAreEmpty()
     {

--- a/tests/Api/TimestampShapeTest.php
+++ b/tests/Api/TimestampShapeTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Api;
 
 use Aws\Api\TimestampShape;
 use Aws\Api\ShapeMap;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Api\TimestampShape
  */
-class TimestampShapeTest extends \PHPUnit_Framework_TestCase
+class TimestampShapeTest extends TestCase
 {
     public function formatProvider()
     {

--- a/tests/Api/ValidatorTest.php
+++ b/tests/Api/ValidatorTest.php
@@ -5,11 +5,12 @@ use Aws\Api\Shape;
 use Aws\Api\ShapeMap;
 use Aws\Api\Validator;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Validator
  */
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     public function validationProvider()
     {

--- a/tests/AwsClientTest.php
+++ b/tests/AwsClientTest.php
@@ -15,11 +15,12 @@ use Aws\Sts\StsClient;
 use Aws\WrappedHttpHandler;
 use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\AwsClient
  */
-class AwsClientTest extends \PHPUnit_Framework_TestCase
+class AwsClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Build/Changelog/ChangelogBuilderTest.php
+++ b/tests/Build/Changelog/ChangelogBuilderTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Build\Changelog;
 
 use Aws\Build\Changelog\ChangelogBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Build\Changelog\ChangelogBuilder
  */
-class ChangelogBuilderTest extends \PHPUnit_Framework_TestCase
+class ChangelogBuilderTest extends TestCase
 {
 
     private $RESOURCE_DIR = "tests/Build/Changelog/resources/";

--- a/tests/Build/Docs/CodeSnippetGeneratorTest.php
+++ b/tests/Build/Docs/CodeSnippetGeneratorTest.php
@@ -5,8 +5,9 @@ namespace Aws\Test\Build\Docs;
 use Aws\Api\ApiProvider;
 use Aws\Api\Service;
 use Aws\Build\Docs\CodeSnippetGenerator;
+use PHPUnit\Framework\TestCase;
 
-class CodeSnippetGeneratorTest extends \PHPUnit_Framework_TestCase
+class CodeSnippetGeneratorTest extends TestCase
 {
     /**
      * @dataProvider exampleProvider

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -16,11 +16,12 @@ use Aws\Result;
 use Aws\WrappedHttpHandler;
 use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\ClientResolver
  */
-class ClientResolverTest extends \PHPUnit_Framework_TestCase
+class ClientResolverTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/CloudFront/CloudFrontClientTest.php
+++ b/tests/CloudFront/CloudFrontClientTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\CloudFront;
 
 use Aws\CloudFront\CloudFrontClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\CloudFront\CloudFrontClient
  */
-class CloudFrontClientTest extends \PHPUnit_Framework_TestCase
+class CloudFrontClientTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/CloudFront/CookieSignerTest.php
+++ b/tests/CloudFront/CookieSignerTest.php
@@ -3,8 +3,9 @@ namespace Aws\Test\CloudFront;
 
 use Aws\CloudFront\CookieSigner;
 use Aws\CloudFront\Policy;
+use PHPUnit\Framework\TestCase;
 
-class CookieSignerTest extends \PHPUnit_Framework_TestCase
+class CookieSignerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -3,8 +3,9 @@ namespace Aws\Test\CloudFront;
 
 use Aws\CloudFront\Policy;
 use Aws\CloudFront\Signer;
+use PHPUnit\Framework\TestCase;
 
-class SignerTest extends \PHPUnit_Framework_TestCase
+class SignerTest extends TestCase
 {
     /** @var Signer */
     private $instance;

--- a/tests/CloudFront/UrlSignerTest.php
+++ b/tests/CloudFront/UrlSignerTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\CloudFront;
 use Aws\CloudFront\CloudFrontClient;
 use Aws\CloudFront\UrlSigner;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\CloudFront\UrlSigner
  */
-class UrlSignerTest extends \PHPUnit_Framework_TestCase
+class UrlSignerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/CloudSearchDomain/CloudSearchDomainTest.php
+++ b/tests/CloudSearchDomain/CloudSearchDomainTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\CloudSearchDomain;
 use Aws\CloudSearchDomain\CloudSearchDomainClient;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\CloudSearchDomain\CloudSearchDomainClient
  */
-class CloudSearchDomainTest extends \PHPUnit_Framework_TestCase
+class CloudSearchDomainTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/CloudTrail/LogFileIteratorTest.php
+++ b/tests/CloudTrail/LogFileIteratorTest.php
@@ -8,11 +8,12 @@ use Aws\Result;
 use Aws\S3\S3Client;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\CloudTrail\LogFileIterator
  */
-class LogFileIteratorTest extends \PHPUnit_Framework_TestCase
+class LogFileIteratorTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/CloudTrail/LogFileReaderTest.php
+++ b/tests/CloudTrail/LogFileReaderTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\CloudTrail;
 use Aws\CloudTrail\LogFileReader;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\CloudTrail\LogFileReader
  */
-class LogFileReaderTest extends \PHPUnit_Framework_TestCase
+class LogFileReaderTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/CloudTrail/LogRecordIteratorTest.php
+++ b/tests/CloudTrail/LogRecordIteratorTest.php
@@ -8,11 +8,12 @@ use Aws\CloudTrail\LogFileReader;
 use Aws\CloudTrail\LogRecordIterator;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\CloudTrail\LogRecordIterator
  */
-class LogRecordIteratorTest extends \PHPUnit_Framework_TestCase
+class LogRecordIteratorTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/CognitoIdentity/CognitoIdentityProviderTest.php
+++ b/tests/CognitoIdentity/CognitoIdentityProviderTest.php
@@ -6,8 +6,9 @@ use Aws\CognitoIdentity\CognitoIdentityProvider;
 use Aws\MockHandler;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
-class CognitoIdentityProviderTest extends \PHPUnit_Framework_TestCase
+class CognitoIdentityProviderTest extends TestCase
 {
     public function testCreatesFromCognitoIdentity()
     {

--- a/tests/CognitoSync/CognitoSyncClientTest.php
+++ b/tests/CognitoSync/CognitoSyncClientTest.php
@@ -5,8 +5,9 @@ use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class CognitoSyncClientTest extends \PHPUnit_Framework_TestCase
+class CognitoSyncClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/CommandPoolTest.php
+++ b/tests/CommandPoolTest.php
@@ -5,11 +5,12 @@ use Aws\Command;
 use Aws\CommandPool;
 use Aws\Exception\AwsException;
 use Aws\Result;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\CommandPool
  */
-class CommandPoolTest extends \PHPUnit_Framework_TestCase
+class CommandPoolTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -3,12 +3,13 @@ namespace Aws\Test;
 
 use Aws\Command;
 use Aws\HandlerList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Command
  * @covers Aws\HasDataTrait
  */
-class CommandTest extends \PHPUnit_Framework_TestCase
+class CommandTest extends TestCase
 {
     public function testHasName()
     {

--- a/tests/Credentials/AssumeRoleCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleCredentialProviderTest.php
@@ -16,11 +16,12 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Credentials\AssumeRoleCredentialProvider
  */
-class AssumeRoleCredentialProviderTest extends \PHPUnit_Framework_TestCase
+class AssumeRoleCredentialProviderTest extends TestCase
 {
     const SAMPLE_ROLE_ARN = 'arn:aws:iam::012345678910:role/role_name';
 

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -5,11 +5,12 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\LruArrayCache;
 use Aws\Sts\StsClient;
-use GuzzleHttp\Promise;
+use GuzzleHttp\Promise;use PHPUnit\Framework\TestCase;
+
 /**
  * @covers \Aws\Credentials\CredentialProvider
  */
-class CredentialProviderTest extends \PHPUnit_Framework_TestCase
+class CredentialProviderTest extends TestCase
 {
     private $home, $homedrive, $homepath, $key, $secret, $profile;
 

--- a/tests/Credentials/CredentialsTest.php
+++ b/tests/Credentials/CredentialsTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Credentials;
 
 use Aws\Credentials\Credentials;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Credentials\Credentials
  */
-class CredentialsTest extends \PHPUnit_Framework_TestCase
+class CredentialsTest extends TestCase
 {
     public function testHasGetters()
     {

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -5,11 +5,12 @@ use Aws\Credentials\EcsCredentialProvider;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Credentials\EcsCredentialProvider
  */
-class EcsCredentialProviderTest extends \PHPUnit_Framework_TestCase
+class EcsCredentialProviderTest extends TestCase
 {
     private $uripath;
 

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -6,11 +6,12 @@ use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Credentials\InstanceProfileProvider
  */
-class InstanceProfileProviderTest extends \PHPUnit_Framework_TestCase
+class InstanceProfileProviderTest extends TestCase
 {
     private function getCredentialArray(
         $key, $secret, $token = null, $time = null, $success = true

--- a/tests/Crypto/AesDecryptingStreamTest.php
+++ b/tests/Crypto/AesDecryptingStreamTest.php
@@ -6,8 +6,9 @@ use Aws\Crypto\Cipher\Cbc;
 use Aws\Crypto\Cipher\CipherMethod;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
-class AesDecryptingStreamTest extends \PHPUnit_Framework_TestCase
+class AesDecryptingStreamTest extends TestCase
 {
     const KB = 1024;
     const MB = 1048576;

--- a/tests/Crypto/AesEncryptingStreamTest.php
+++ b/tests/Crypto/AesEncryptingStreamTest.php
@@ -7,8 +7,9 @@ use Aws\Crypto\Cipher\Cbc;
 use Aws\Crypto\Cipher\CipherMethod;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
-class AesEncryptingStreamTest extends \PHPUnit_Framework_TestCase
+class AesEncryptingStreamTest extends TestCase
 {
     const KB = 1024;
     const MB = 1048576;

--- a/tests/Crypto/AesGcmDecryptingStreamTest.php
+++ b/tests/Crypto/AesGcmDecryptingStreamTest.php
@@ -4,8 +4,9 @@ namespace Aws\Test\Crypto;
 use Aws\Crypto\AesGcmDecryptingStream;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
-class AesGcmDecryptingStreamTest extends \PHPUnit_Framework_TestCase
+class AesGcmDecryptingStreamTest extends TestCase
 {
     use AesEncryptionStreamTestTrait;
 

--- a/tests/Crypto/AesGcmEncryptingStreamTest.php
+++ b/tests/Crypto/AesGcmEncryptingStreamTest.php
@@ -4,8 +4,9 @@ namespace Aws\Test\Crypto;
 use Aws\Crypto\AesGcmEncryptingStream;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
-class AesGcmEncryptingStreamTest extends \PHPUnit_Framework_TestCase
+class AesGcmEncryptingStreamTest extends TestCase
 {
     use AesEncryptionStreamTestTrait;
 

--- a/tests/Crypto/Cipher/CbcTest.php
+++ b/tests/Crypto/Cipher/CbcTest.php
@@ -2,8 +2,9 @@
 namespace Aws\Test\EncryptionStreams;
 
 use Aws\Crypto\Cipher\Cbc;
+use PHPUnit\Framework\TestCase;
 
-class CbcTest extends \PHPUnit_Framework_TestCase
+class CbcTest extends TestCase
 {
     public function testShouldReportCipherMethodOfCBC()
     {

--- a/tests/Crypto/KmsMaterialsProviderTest.php
+++ b/tests/Crypto/KmsMaterialsProviderTest.php
@@ -6,11 +6,12 @@ use Aws\Crypto\MetadataEnvelope;
 use Aws\Kms\KmsClient;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Crypto\KmsMaterialsProvider
  */
-class KmsMaterialsProviderTest extends \PHPUnit_Framework_TestCase
+class KmsMaterialsProviderTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Crypto/MetadataEnvelopeTest.php
+++ b/tests/Crypto/MetadataEnvelopeTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Crypto;
 
 use Aws\Crypto\MetadataEnvelope;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Crypto\MetadataEnvelope
  */
-class MetadataEnvelopeTest extends \PHPUnit_Framework_TestCase
+class MetadataEnvelopeTest extends TestCase
 {
     use UsesMetadataEnvelopeTrait;
 

--- a/tests/DoctrineCacheAdapterTest.php
+++ b/tests/DoctrineCacheAdapterTest.php
@@ -4,8 +4,9 @@ namespace Aws\Test;
 use Aws\CacheInterface;
 use Aws\DoctrineCacheAdapter;
 use Doctrine\Common\Cache\Cache;
+use PHPUnit\Framework\TestCase;
 
-class DoctrineCacheAdapterTest extends \PHPUnit_Framework_TestCase
+class DoctrineCacheAdapterTest extends TestCase
 {
     public function testProxiesCallsToDoctrine()
     {

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -9,12 +9,13 @@ use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\DynamoDb\DynamoDbClient
  * @runTestsInSeparateProcesses
  */
-class DynamoDbClientTest extends \PHPUnit_Framework_TestCase
+class DynamoDbClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/DynamoDb/LockingSessionConnectionTest.php
+++ b/tests/DynamoDb/LockingSessionConnectionTest.php
@@ -5,11 +5,12 @@ use Aws\DynamoDb\Exception\DynamoDbException;
 use Aws\DynamoDb\LockingSessionConnection;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\DynamoDb\LockingSessionConnection
  */
-class LockingSessionConnectionTest extends \PHPUnit_Framework_TestCase
+class LockingSessionConnectionTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/DynamoDb/MarshalerTest.php
+++ b/tests/DynamoDb/MarshalerTest.php
@@ -6,11 +6,12 @@ use Aws\DynamoDb\BinaryValue;
 use Aws\DynamoDb\NumberValue;
 use Aws\DynamoDb\SetValue;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\DynamoDb\Marshaler
  */
-class MarshalerTest extends \PHPUnit_Framework_TestCase
+class MarshalerTest extends TestCase
 {
     const ERROR = 'ERROR';
 

--- a/tests/DynamoDb/SessionHandlerTest.php
+++ b/tests/DynamoDb/SessionHandlerTest.php
@@ -3,12 +3,13 @@ namespace Aws\Test\DynamoDb;
 
 use Aws\DynamoDb\SessionHandler;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\DynamoDb\SessionHandler
  * @runTestsInSeparateProcesses
  */
-class SessionHandlerTest extends \PHPUnit_Framework_TestCase
+class SessionHandlerTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/DynamoDb/StandardSessionConnectionTest.php
+++ b/tests/DynamoDb/StandardSessionConnectionTest.php
@@ -6,11 +6,12 @@ use Aws\DynamoDb\StandardSessionConnection;
 use Aws\Middleware;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\DynamoDb\StandardSessionConnection
  */
-class StandardSessionConnectionTest extends \PHPUnit_Framework_TestCase
+class StandardSessionConnectionTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/DynamoDb/WriteRequestBatchTest.php
+++ b/tests/DynamoDb/WriteRequestBatchTest.php
@@ -7,11 +7,12 @@ use Aws\MockHandler;
 use Aws\Result;
 use Aws\DynamoDb\WriteRequestBatch;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\DynamoDb\WriteRequestBatch
  */
-class WriteRequestBatchTest extends \PHPUnit_Framework_TestCase
+class WriteRequestBatchTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Ec2/Ec2ClientTest.php
+++ b/tests/Ec2/Ec2ClientTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\Ec2;
 use Aws\Ec2\Ec2Client;
 use Aws\MockHandler;
 use Aws\Result;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Ec2\Ec2Client
  */
-class Ec2ClientTest extends \PHPUnit_Framework_TestCase
+class Ec2ClientTest extends TestCase
 {
     public function testAddsCopySnapshotMiddleware()
     {

--- a/tests/ElasticLoadBalancingV2/ElasticLoadBalancingV2ClientTest.php
+++ b/tests/ElasticLoadBalancingV2/ElasticLoadBalancingV2ClientTest.php
@@ -8,11 +8,12 @@ use Aws\Test\UsesServiceTrait;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client
  */
-class ElasticLoadBalancingV2ClientTest extends \PHPUnit_Framework_TestCase
+class ElasticLoadBalancingV2ClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Endpoint/EndpointProviderTest.php
+++ b/tests/Endpoint/EndpointProviderTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test;
 
 use Aws\Endpoint\EndpointProvider;
 use Aws\Endpoint\PartitionEndpointProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Endpoint\EndpointProvider
  */
-class EndpointProviderTest extends \PHPUnit_Framework_TestCase
+class EndpointProviderTest extends TestCase
 {
     /**
      * @expectedException \Aws\Exception\UnresolvedEndpointException

--- a/tests/Endpoint/PartitionEndpointProviderTest.php
+++ b/tests/Endpoint/PartitionEndpointProviderTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test;
 use Aws\Endpoint\EndpointProvider;
 use Aws\Endpoint\Partition;
 use Aws\Endpoint\PartitionEndpointProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Endpoint\PartitionEndpointProvider
  */
-class PartitionEndpointProviderTest extends \PHPUnit_Framework_TestCase
+class PartitionEndpointProviderTest extends TestCase
 {
     /**
      * @dataProvider endpointProvider

--- a/tests/Endpoint/PartitionTest.php
+++ b/tests/Endpoint/PartitionTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test;
 
 use Aws\Endpoint\Partition;
 use Aws\Endpoint\PartitionInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Endpoint\Partition
  */
-class PartitionTest extends \PHPUnit_Framework_TestCase
+class PartitionTest extends TestCase
 {
     /**
      * @dataProvider partitionDefinitionProvider

--- a/tests/Endpoint/PatternEndpointProviderTest.php
+++ b/tests/Endpoint/PatternEndpointProviderTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test;
 
 use Aws\Endpoint\EndpointProvider;
 use Aws\Endpoint\PatternEndpointProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Endpoint\PatternEndpointProvider
  */
-class PatternEndpointProviderTest extends \PHPUnit_Framework_TestCase
+class PatternEndpointProviderTest extends TestCase
 {
     public function testReturnsNullWhenUnresolved()
     {

--- a/tests/Exception/AwsExceptionTest.php
+++ b/tests/Exception/AwsExceptionTest.php
@@ -6,11 +6,12 @@ use Aws\Exception\AwsException;
 use Aws\Result;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Exception\AwsException
  */
-class AwsExceptionTest extends \PHPUnit_Framework_TestCase
+class AwsExceptionTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Exception/CouldNotCreateChecksumExceptionTest.php
+++ b/tests/Exception/CouldNotCreateChecksumExceptionTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Exception;
 
 use Aws\Exception\CouldNotCreateChecksumException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Exception\CouldNotCreateChecksumException
  */
-class CouldNotCreateChecksumExceptionTest extends \PHPUnit_Framework_TestCase
+class CouldNotCreateChecksumExceptionTest extends TestCase
 {
     public function testUsesCorrectWords()
     {

--- a/tests/Exception/MultipartUploadExceptionTest.php
+++ b/tests/Exception/MultipartUploadExceptionTest.php
@@ -5,11 +5,12 @@ use Aws\Command;
 use Aws\Exception\AwsException;
 use Aws\Exception\MultipartUploadException;
 use Aws\Multipart\UploadState;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Exception\MultipartUploadException
  */
-class MultipartUploadExceptionTest extends \PHPUnit_Framework_TestCase
+class MultipartUploadExceptionTest extends TestCase
 {
     /**
      * @dataProvider getTestCases

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -5,8 +5,9 @@ use Aws;
 use Aws\MockHandler;
 use Aws\Result;
 use Aws\S3\S3Client;
+use PHPUnit\Framework\TestCase;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
     /**
      * @covers Aws\recursive_dir_iterator()

--- a/tests/Glacier/GlacierClientTest.php
+++ b/tests/Glacier/GlacierClientTest.php
@@ -7,11 +7,12 @@ use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Glacier\GlacierClient
  */
-class GlacierClientTest extends \PHPUnit_Framework_TestCase
+class GlacierClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Glacier/MultipartUploaderTest.php
+++ b/tests/Glacier/MultipartUploaderTest.php
@@ -6,11 +6,12 @@ use Aws\Result;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Glacier\MultipartUploader
  */
-class MultipartUploaderTest extends \PHPUnit_Framework_TestCase
+class MultipartUploaderTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Glacier/TreeHashTest.php
+++ b/tests/Glacier/TreeHashTest.php
@@ -2,8 +2,9 @@
 namespace Aws\Test\Glacier;
 
 use Aws\Glacier\TreeHash;
+use PHPUnit\Framework\TestCase;
 
-class TreeHashTest extends \PHPUnit_Framework_TestCase
+class TreeHashTest extends TestCase
 {
     /**
      * @covers Aws\Glacier\TreeHash::__construct

--- a/tests/Handler/GuzzleV5/HandlerTest.php
+++ b/tests/Handler/GuzzleV5/HandlerTest.php
@@ -18,11 +18,12 @@ use GuzzleHttp\Ring\Client\MockHandler;
 use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Tests\Ring\Client\MockHandlerTest;
 use React\Promise\Deferred;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Handler\GuzzleV5\GuzzleHandler
  */
-class HandlerTest extends \PHPUnit_Framework_TestCase
+class HandlerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Handler/GuzzleV5/StreamTest.php
+++ b/tests/Handler/GuzzleV5/StreamTest.php
@@ -5,12 +5,13 @@ use Aws\Handler\GuzzleV5\GuzzleStream as GuzzleStreamAdapter;
 use Aws\Handler\GuzzleV5\PsrStream as PsrStreamAdapter;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Stream\Stream as GuzzleStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Handler\GuzzleV5\GuzzleStream
  * @covers Aws\Handler\GuzzleV5\PsrStream
  */
-class StreamTest extends \PHPUnit_Framework_TestCase
+class StreamTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Handler/GuzzleV6/HandlerTest.php
+++ b/tests/Handler/GuzzleV6/HandlerTest.php
@@ -11,11 +11,12 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\TransferStats;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Handler\GuzzleV6\GuzzleHandler
  */
-class HandlerTest extends \PHPUnit_Framework_TestCase
+class HandlerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/HandlerListTest.php
+++ b/tests/HandlerListTest.php
@@ -6,11 +6,12 @@ use Aws\CommandInterface;
 use Aws\HandlerList;
 use Aws\Middleware;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\HandlerList
  */
-class HandlerListTest extends \PHPUnit_Framework_TestCase
+class HandlerListTest extends TestCase
 {
     /**
      * @expectedException \LogicException

--- a/tests/HashingStreamTest.php
+++ b/tests/HashingStreamTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test;
 use GuzzleHttp\Psr7;
 use Aws\PhpHash;
 use Aws\HashingStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\HashingStream
  */
-class HashingStreamTest extends \PHPUnit_Framework_TestCase
+class HashingStreamTest extends TestCase
 {
     public function testCanCreateRollingMd5()
     {

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -6,11 +6,12 @@ use Aws\Command;
 use Aws\History;
 use Aws\Exception\AwsException;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\History
  */
-class HistoryTest extends \PHPUnit_Framework_TestCase
+class HistoryTest extends TestCase
 {
     public function testIsCountable()
     {

--- a/tests/IdempotencyTokenMiddlewareTest.php
+++ b/tests/IdempotencyTokenMiddlewareTest.php
@@ -9,11 +9,12 @@ use Aws\Api\ApiProvider;
 use Aws\Api\Service;
 use Aws\Command;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\IdempotencyTokenMiddleware
  */
-class IdempotencyTokenMiddlewareTest extends \PHPUnit_Framework_TestCase
+class IdempotencyTokenMiddlewareTest extends TestCase
 {
     public function testAutoFillsMemberWithIdempotencyTrait()
     {

--- a/tests/Integ/GuzzleV5HandlerTest.php
+++ b/tests/Integ/GuzzleV5HandlerTest.php
@@ -6,8 +6,9 @@ use GuzzleHttp\Promise\RejectionException;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class GuzzleV5HandlerTest extends \PHPUnit_Framework_TestCase
+class GuzzleV5HandlerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Integ/GuzzleV6StreamHandlerTest.php
+++ b/tests/Integ/GuzzleV6StreamHandlerTest.php
@@ -2,8 +2,9 @@
 namespace Aws\Test\Integ;
 
 use GuzzleHttp\Handler\StreamHandler;
+use PHPUnit\Framework\TestCase;
 
-class GuzzleV6StreamHandlerTest extends \PHPUnit_Framework_TestCase
+class GuzzleV6StreamHandlerTest extends TestCase
 {
     use IntegUtils;
 

--- a/tests/JsonCompilerTest.php
+++ b/tests/JsonCompilerTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test;
 
 use Aws\JsonCompiler;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\JsonCompiler
  */
-class JsonCompilerTest extends \PHPUnit_Framework_TestCase
+class JsonCompilerTest extends TestCase
 {
     private $models;
 

--- a/tests/LruArrayCacheTest.php
+++ b/tests/LruArrayCacheTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test;
 
 use Aws\LruArrayCache;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\LruArrayCache
  */
-class LruArrayCacheTest extends \PHPUnit_Framework_TestCase
+class LruArrayCacheTest extends TestCase
 {
     public function testSetRemoveAndRetrieve()
     {

--- a/tests/MachineLearning/MachineLearningClientTest.php
+++ b/tests/MachineLearning/MachineLearningClientTest.php
@@ -6,11 +6,12 @@ use Aws\MachineLearning\MachineLearningClient;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\MachineLearning\MachineLearningClient
  */
-class MachineLearningClientTest extends \PHPUnit_Framework_TestCase
+class MachineLearningClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -19,11 +19,12 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Middleware
  */
-class MiddlewareTest extends \PHPUnit_Framework_TestCase
+class MiddlewareTest extends TestCase
 {
     public function setup()
     {

--- a/tests/MockHandlerTest.php
+++ b/tests/MockHandlerTest.php
@@ -9,11 +9,12 @@ use Aws\Result;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\MockHandler
  */
-class MockHandlerTest extends \PHPUnit_Framework_TestCase
+class MockHandlerTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/MultiRegionClientTest.php
+++ b/tests/MultiRegionClientTest.php
@@ -11,8 +11,9 @@ use Aws\Result;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class MultiRegionClientTest extends \PHPUnit_Framework_TestCase
+class MultiRegionClientTest extends TestCase
 {
     /** @var MultiRegionClient */
     private $instance;

--- a/tests/Multipart/AbstractUploaderTest.php
+++ b/tests/Multipart/AbstractUploaderTest.php
@@ -8,11 +8,12 @@ use Aws\Multipart\UploadState;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Multipart\AbstractUploader
  */
-class AbstractUploaderTest extends \PHPUnit_Framework_TestCase
+class AbstractUploaderTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Multipart/UploadStateTest.php
+++ b/tests/Multipart/UploadStateTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Multipart;
 
 use Aws\Multipart\UploadState;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Multipart\UploadState
  */
-class UploadStateTest extends \PHPUnit_Framework_TestCase
+class UploadStateTest extends TestCase
 {
     public function testCanManageStatusAndUploadId()
     {

--- a/tests/PhpHashTest.php
+++ b/tests/PhpHashTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test;
 
 use Aws\PhpHash;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\PhpHash
  */
-class PhpHashTest extends \PHPUnit_Framework_TestCase
+class PhpHashTest extends TestCase
 {
     public function testHashesData()
     {

--- a/tests/Polly/PollyClientTest.php
+++ b/tests/Polly/PollyClientTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\Polly;
 
 use Aws\Credentials\Credentials;
 use Aws\Polly\PollyClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Polly\PollyClient
  */
-class PollyClientTest extends \PHPUnit_Framework_TestCase
+class PollyClientTest extends TestCase
 {
     public function testCanGeneratePreSignedUrlForSynthesizeSpeech()
     {

--- a/tests/PresignUrlMiddlewareTest.php
+++ b/tests/PresignUrlMiddlewareTest.php
@@ -7,11 +7,12 @@ use Aws\Rds\RdsClient;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\PresignUrlMiddleware
  */
-class PresignUrlMiddlewareTest extends \PHPUnit_Framework_TestCase
+class PresignUrlMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/PsrCacheAdapterTest.php
+++ b/tests/PsrCacheAdapterTest.php
@@ -4,8 +4,9 @@ namespace Aws\Test;
 use Aws\PsrCacheAdapter;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use PHPUnit\Framework\TestCase;
 
-class PsrCacheAdapterTest extends \PHPUnit_Framework_TestCase
+class PsrCacheAdapterTest extends TestCase
 {
     /** @var CacheItemPoolInterface|\PHPUnit_Framework_MockObject_MockObject $wrappedCache */
     private $wrapped;

--- a/tests/Rds/AuthTokenGeneratorTest.php
+++ b/tests/Rds/AuthTokenGeneratorTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\Rds;
 use Aws\Credentials\Credentials;
 use Aws\Rds\AuthTokenGenerator;
 use GuzzleHttp\Promise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Rds\AuthTokenGenerator
  */
-class AuthTokenGeneratorTest extends \PHPUnit_Framework_TestCase
+class AuthTokenGeneratorTest extends TestCase
 {
     public function testCanCreateAuthTokenWthCredentialInstance()
     {

--- a/tests/Rds/RdsClientTest.php
+++ b/tests/Rds/RdsClientTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\Rds;
 use Aws\Rds\RdsClient;
 use Aws\MockHandler;
 use Aws\Result;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Rds\RdsClient
  */
-class RdsClientTest extends \PHPUnit_Framework_TestCase
+class RdsClientTest extends TestCase
 {
     public function testAddsCopySnapshotMiddleware()
     {

--- a/tests/ResultPaginatorTest.php
+++ b/tests/ResultPaginatorTest.php
@@ -6,11 +6,12 @@ use Aws\CommandInterface;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Result;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\ResultPaginator
  */
-class ResultPaginatorTest extends \PHPUnit_Framework_TestCase
+class ResultPaginatorTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test;
 
 use Aws\Result;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Result
  */
-class ResultTest extends \PHPUnit_Framework_TestCase
+class ResultTest extends TestCase
 {
     public function testHasData()
     {

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -12,11 +12,12 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\RetryMiddleware
  */
-class RetryMiddlewareTest extends \PHPUnit_Framework_TestCase
+class RetryMiddlewareTest extends TestCase
 {
     public function testAddRetryHeader()
     {

--- a/tests/Route53/RouteClient53Test.php
+++ b/tests/Route53/RouteClient53Test.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Route53;
 
 use Aws\Route53\Route53Client;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Route53\Route53Client
  */
-class Route53ClientTest extends \PHPUnit_Framework_TestCase
+class Route53ClientTest extends TestCase
 {
     public function testCleansIds()
     {

--- a/tests/S3/AmbiguousSuccessParserTest.php
+++ b/tests/S3/AmbiguousSuccessParserTest.php
@@ -6,8 +6,9 @@ use Aws\CommandInterface;
 use Aws\S3\AmbiguousSuccessParser;
 use Aws\S3\Exception\S3Exception;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
-class AmbiguousSuccessParserTest extends \PHPUnit_Framework_TestCase
+class AmbiguousSuccessParserTest extends TestCase
 {
     private $instance;
 

--- a/tests/S3/ApplyChecksumMiddlewareTest.php
+++ b/tests/S3/ApplyChecksumMiddlewareTest.php
@@ -5,11 +5,12 @@ use Aws\Middleware;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\ApplyChecksumMiddleware
  */
-class ApplyChecksumMiddlewareTest extends \PHPUnit_Framework_TestCase
+class ApplyChecksumMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/BatchDeleteTest.php
+++ b/tests/S3/BatchDeleteTest.php
@@ -7,11 +7,12 @@ use Aws\Result;
 use Aws\S3\BatchDelete;
 use Aws\S3\Exception\DeleteMultipleObjectsException;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\BatchDelete
  */
-class BatchDeleteTest extends \PHPUnit_Framework_TestCase
+class BatchDeleteTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/BucketEndpointMiddlewareTest.php
+++ b/tests/S3/BucketEndpointMiddlewareTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\S3;
 
 use Aws\Middleware;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\BucketEndpointMiddleware
  */
-class BucketEndpointMiddlewareTest extends \PHPUnit_Framework_TestCase
+class BucketEndpointMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/Crypto/HeadersMetadataStrategyTest.php
+++ b/tests/S3/Crypto/HeadersMetadataStrategyTest.php
@@ -3,11 +3,12 @@ namespace Aws\Test\S3\Crypto;
 
 use Aws\S3\Crypto\HeadersMetadataStrategy;
 use Aws\Test\Crypto\UsesMetadataEnvelopeTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\Crypto\HeadersMetadataStrategy
  */
-class HeadersMetadataStrategyTest extends \PHPUnit_Framework_TestCase
+class HeadersMetadataStrategyTest extends TestCase
 {
     use UsesMetadataEnvelopeTrait;
 

--- a/tests/S3/Crypto/InstructionFileMetadataStrategyTest.php
+++ b/tests/S3/Crypto/InstructionFileMetadataStrategyTest.php
@@ -6,11 +6,12 @@ use Aws\Result;
 use Aws\S3\S3Client;
 use Aws\Test\Crypto\UsesMetadataEnvelopeTrait;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\Crypto\InstructionFileMetadataStrategy
  */
-class InstructionFileMetadataStrategyTest extends \PHPUnit_Framework_TestCase
+class InstructionFileMetadataStrategyTest extends TestCase
 {
     use UsesMetadataEnvelopeTrait, UsesServiceTrait;
 

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -18,8 +18,9 @@ use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class S3EncryptionClientTest extends \PHPUnit_Framework_TestCase
+class S3EncryptionClientTest extends TestCase
 {
     use UsesServiceTrait, UsesMetadataEnvelopeTrait;
 

--- a/tests/S3/Exception/DeleteMultipleObjectsExceptionTest.php
+++ b/tests/S3/Exception/DeleteMultipleObjectsExceptionTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\S3\Exception;
 
 use Aws\S3\Exception\DeleteMultipleObjectsException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\Exception\DeleteMultipleObjectsException
  */
-class DeleteMultipleObjectsExceptionTest extends \PHPUnit_Framework_TestCase
+class DeleteMultipleObjectsExceptionTest extends TestCase
 {
     public function testReturnsData()
     {

--- a/tests/S3/Exception/S3MultipartUploadExceptionTest.php
+++ b/tests/S3/Exception/S3MultipartUploadExceptionTest.php
@@ -6,11 +6,12 @@ use Aws\Exception\AwsException;
 use Aws\S3\Exception\S3MultipartUploadException;
 use Aws\Multipart\UploadState;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\Exception\S3MultipartUploadException
  */
-class S3MultipartUploadExceptionTest extends \PHPUnit_Framework_TestCase
+class S3MultipartUploadExceptionTest extends TestCase
 {
     public function testCanProviderFailedTransferFilePathInfo()
     {

--- a/tests/S3/GetBucketLocationParserTest.php
+++ b/tests/S3/GetBucketLocationParserTest.php
@@ -6,11 +6,12 @@ use Aws\S3\GetBucketLocationParser;
 use Aws\Command;
 use Aws\Result;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\GetBucketLocationParser
  */
-class GetBucketLocationParserTest extends \PHPUnit_Framework_TestCase
+class GetBucketLocationParserTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/MultipartCopyTest.php
+++ b/tests/S3/MultipartCopyTest.php
@@ -5,8 +5,9 @@ use Aws\Result;
 use Aws\ResultInterface;
 use Aws\S3\MultipartCopy;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
-class MultipartCopyTest extends \PHPUnit_Framework_TestCase
+class MultipartCopyTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/MultipartUploaderTest.php
+++ b/tests/S3/MultipartUploaderTest.php
@@ -6,11 +6,12 @@ use Aws\Result;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\MultipartUploader
  */
-class MultipartUploaderTest extends \PHPUnit_Framework_TestCase
+class MultipartUploaderTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -8,8 +8,9 @@ use Aws\S3\ObjectCopier;
 use Aws\S3\S3Client;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Promise;
+use PHPUnit\Framework\TestCase;
 
-class ObjectCopierTest extends \PHPUnit_Framework_TestCase
+class ObjectCopierTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/ObjectUploaderTest.php
+++ b/tests/S3/ObjectUploaderTest.php
@@ -7,8 +7,9 @@ use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
-class ObjectUploaderTest extends \PHPUnit_Framework_TestCase
+class ObjectUploaderTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/PermanentRedirectMiddlewareTest.php
+++ b/tests/S3/PermanentRedirectMiddlewareTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\S3;
 
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\PermanentRedirectMiddleware
  */
-class PermanentRedirectTest extends \PHPUnit_Framework_TestCase
+class PermanentRedirectTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/PostObjectTest.php
+++ b/tests/S3/PostObjectTest.php
@@ -5,11 +5,12 @@ use Aws\Credentials\Credentials;
 use Aws\S3\PostObject;
 use Aws\S3\S3Client;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\PostObject
  */
-class PostObjectTest extends \PHPUnit_Framework_TestCase
+class PostObjectTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/PostObjectV4Test.php
+++ b/tests/S3/PostObjectV4Test.php
@@ -7,11 +7,12 @@ use Aws\S3\S3Client;
 use Aws\Test\UsesServiceTrait;
 
 require_once __DIR__ . '/sig_hack.php';
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\PostObject
  */
-class PostObjectV4Test extends \PHPUnit_Framework_TestCase
+class PostObjectV4Test extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/PutObjectUrlMiddlewareTest.php
+++ b/tests/S3/PutObjectUrlMiddlewareTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\S3;
 
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\PutObjectUrlMiddleware
  */
-class PutObjectUrlTest extends \PHPUnit_Framework_TestCase
+class PutObjectUrlTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/RetryableMalformedResponseParserTest.php
+++ b/tests/S3/RetryableMalformedResponseParserTest.php
@@ -7,8 +7,9 @@ use Aws\CommandInterface;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\RetryableMalformedResponseParser;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
-class RetryableMalformedResponseParserTest extends \PHPUnit_Framework_TestCase
+class RetryableMalformedResponseParserTest extends TestCase
 {
     /**
      * @expectedException \Aws\S3\Exception\S3Exception

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -18,11 +18,12 @@ use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\S3Client
  */
-class S3ClientTest extends \PHPUnit_Framework_TestCase
+class S3ClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/S3EndpointMiddlewareTest.php
+++ b/tests/S3/S3EndpointMiddlewareTest.php
@@ -7,8 +7,9 @@ use Aws\S3\S3EndpointMiddleware;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class S3EndpointMiddlewareTest extends \PHPUnit_Framework_TestCase
+class S3EndpointMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/S3MultiRegionClientTest.php
+++ b/tests/S3/S3MultiRegionClientTest.php
@@ -16,8 +16,9 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class S3MultiRegionClientTest extends \PHPUnit_Framework_TestCase
+class S3MultiRegionClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/S3UriParserTest.php
+++ b/tests/S3/S3UriParserTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\S3;
 
 use Aws\S3\S3UriParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\S3UriParser
  */
-class S3UriParserTest extends \PHPUnit_Framework_TestCase
+class S3UriParserTest extends TestCase
 {
     public function uriProvider()
     {

--- a/tests/S3/SSECMiddlewareTest.php
+++ b/tests/S3/SSECMiddlewareTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\S3;
 use Aws\Middleware;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\SSECMiddleware
  */
-class SseCpkListenerTest extends \PHPUnit_Framework_TestCase
+class SseCpkListenerTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/StreamWrapperPathStyleTest.php
+++ b/tests/S3/StreamWrapperPathStyleTest.php
@@ -11,11 +11,12 @@ use Aws\S3\S3Client;
 use Aws\S3\StreamWrapper;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\StreamWrapper
  */
-class StreamWrapperPathStyleTest extends \PHPUnit_Framework_TestCase
+class StreamWrapperPathStyleTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -11,11 +11,12 @@ use Aws\S3\S3Client;
 use Aws\S3\StreamWrapper;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\StreamWrapper
  */
-class StreamWrapperTest extends \PHPUnit_Framework_TestCase
+class StreamWrapperTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -8,11 +8,12 @@ use Aws\S3\Transfer;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Promise;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\S3\Transfer
  */
-class TransferTest extends \PHPUnit_Framework_TestCase
+class TransferTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -5,11 +5,12 @@ use Aws\AwsClientInterface;
 use Aws\MultiRegionClient;
 use Aws\S3\S3MultiRegionClient;
 use Aws\Sdk;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Sdk
  */
-class SdkTest extends \PHPUnit_Framework_TestCase
+class SdkTest extends TestCase
 {
     /**
      * @expectedException \BadMethodCallException

--- a/tests/Ses/SesClientTest.php
+++ b/tests/Ses/SesClientTest.php
@@ -3,8 +3,9 @@ namespace Aws\Test\Ses;
 
 use Aws\Credentials\Credentials;
 use Aws\Ses\SesClient;
+use PHPUnit\Framework\TestCase;
 
-class SesClientTest extends \PHPUnit_Framework_TestCase
+class SesClientTest extends TestCase
 {
     public function testCanGenerateSmtpPasswordFromCredentials()
     {

--- a/tests/Signature/AnonymousSignatureTest.php
+++ b/tests/Signature/AnonymousSignatureTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\Signature;
 use Aws\Credentials\Credentials;
 use Aws\Signature\AnonymousSignature;
 use GuzzleHttp\Psr7\Request;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Signature\AnonymousSignature
  */
-class AnonymousTest extends \PHPUnit_Framework_TestCase
+class AnonymousTest extends TestCase
 {
     public function testDoesNotSignsRequests()
     {

--- a/tests/Signature/S3SignatureV4Test.php
+++ b/tests/Signature/S3SignatureV4Test.php
@@ -7,11 +7,12 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 
 require_once __DIR__ . '/sig_hack.php';
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Signature\S3SignatureV4
  */
-class S3SignatureV4Test extends \PHPUnit_Framework_TestCase
+class S3SignatureV4Test extends TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Signature/SignatureProviderTest.php
+++ b/tests/Signature/SignatureProviderTest.php
@@ -2,11 +2,12 @@
 namespace Aws\Test\Signature;
 
 use Aws\Signature\SignatureProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Signature\SignatureProvider
  */
-class SignatureProviderTest extends \PHPUnit_Framework_TestCase
+class SignatureProviderTest extends TestCase
 {
     public function versionProvider()
     {

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -8,11 +8,12 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\NoSeekStream;
 
 require_once __DIR__ . '/sig_hack.php';
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Signature\SignatureV4
  */
-class SignatureV4Test extends \PHPUnit_Framework_TestCase
+class SignatureV4Test extends TestCase
 {
     const DEFAULT_KEY = 'AKIDEXAMPLE';
     const DEFAULT_SECRET = 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY';

--- a/tests/Sqs/SqsClientTest.php
+++ b/tests/Sqs/SqsClientTest.php
@@ -5,11 +5,12 @@ use Aws\Middleware;
 use Aws\Result;
 use Aws\Sqs\SqsClient;
 use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Sqs\SqsClient
  */
-class SqsClientTest extends \PHPUnit_Framework_TestCase
+class SqsClientTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/Ssm/SsmClientTest.php
+++ b/tests/Ssm/SsmClientTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\Ssm;
 use Aws\Ssm\SsmClient;
 use Aws\MockHandler;
 use Aws\Result;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Ssm\SsmClient
  */
-class SsmClientTest extends \PHPUnit_Framework_TestCase
+class SsmClientTest extends TestCase
 {
     public function testCanDisableAutoFillPerClient()
     {

--- a/tests/Sts/StsClientTest.php
+++ b/tests/Sts/StsClientTest.php
@@ -4,11 +4,12 @@ namespace Aws\Test\Sts;
 use Aws\Api\DateTimeResult;
 use Aws\Result;
 use Aws\Sts\StsClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Sts\StsClient
  */
-class StsClientTest extends \PHPUnit_Framework_TestCase
+class StsClientTest extends TestCase
 {
     public function testCanCreateCredentialsObjectFromStsResult()
     {

--- a/tests/TraceMiddlewareTest.php
+++ b/tests/TraceMiddlewareTest.php
@@ -10,11 +10,12 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Promise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\TraceMiddleware
  */
-class TraceMiddlewareTest extends \PHPUnit_Framework_TestCase
+class TraceMiddlewareTest extends TestCase
 {
     public function testEmitsDebugInfo()
     {

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -15,11 +15,12 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Waiter
  */
-class WaiterTest extends \PHPUnit_Framework_TestCase
+class WaiterTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/WrappedHttpHandlerTest.php
+++ b/tests/WrappedHttpHandlerTest.php
@@ -14,11 +14,12 @@ use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\WrappedHttpHandler
  */
-class WrappedHttpHandlerTest extends \PHPUnit_Framework_TestCase
+class WrappedHttpHandlerTest extends TestCase
 {
     public function testParsesResponses()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.