### PR TITLE
S3EncryptionClient getObjectAsync CipherOptions Fix

### DIFF
--- a/.changes/nextrelease/aad_fix.json
+++ b/.changes/nextrelease/aad_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3\\Crypto",
+    "description": "Fixes an issue with loading @CipherOptions on getObject[Async] decryption."
+  }
+]

--- a/src/S3/Crypto/S3EncryptionClient.php
+++ b/src/S3/Crypto/S3EncryptionClient.php
@@ -320,8 +320,8 @@ class S3EncryptionClient extends AbstractCryptoClient
                         $result['Body'],
                         $provider,
                         $envelope,
-                        isset($loadArgs['@CipherOptions'])
-                            ? $loadArgs['@CipherOptions']
+                        isset($args['@CipherOptions'])
+                            ? $args['@CipherOptions']
                             : []
                     );
                     return $result;


### PR DESCRIPTION
Fixes an issue with loading @CipherOptions on getObject[Async] decryption.

/cc @jeskew 

Fixes #1426 