### PR TITLE
Refactored some tests with PHPUnit assert methods

### DIFF
--- a/.changes/nextrelease/refactoring-tests
+++ b/.changes/nextrelease/refactoring-tests
@@ -1,0 +1,7 @@
+[
+   {
+       "type": "enhancement",
+       "category": "Test",
+       "description": "Refactored some tests with PHPUnit assert methods."
+   }
+]

--- a/tests/AwsClientTest.php
+++ b/tests/AwsClientTest.php
@@ -288,7 +288,7 @@ class AwsClientTest extends \PHPUnit_Framework_TestCase
         $ref = new \ReflectionMethod($client, 'getSignatureProvider');
         $ref->setAccessible(true);
         $provider = $ref->invoke($client);
-        $this->assertTrue(is_callable($provider));
+        $this->assertInternalType('callable', $provider);
     }
 
     /**

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -198,7 +198,7 @@ class ClientResolverTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
         $res = $r->resolve([], new HandlerList());
-        $this->assertTrue(is_callable($callableFunction));
+        $this->assertInternalType('callable', $callableFunction);
         $this->assertEquals(
             '\Aws\test\ClientResolverTest::checkCallable',
             $res['foo']
@@ -544,7 +544,7 @@ EOT;
             'debug'       => ['logfn' => function ($value) use (&$str) { $str .= $value; }]
         ], $list);
         $value = $this->readAttribute($list, 'interposeFn');
-        $this->assertTrue(is_callable($value));
+        $this->assertInternalType('callable', $value);
     }
 
     public function testAppliesUserAgent()
@@ -784,9 +784,9 @@ EOT;
         ];
         $list = new HandlerList;
 
-        $this->assertSame(0, count($list));
+        $this->assertCount(0, $list);
         ClientResolver::_apply_idempotency_auto_fill($value, $args, $list);
-        $this->assertSame($shouldAddIdempotencyMiddleware ? 1 : 0, count($list));
+        $this->assertCount($shouldAddIdempotencyMiddleware ? 1 : 0, $list);
     }
 
     public function idempotencyAutoFillProvider()

--- a/tests/Credentials/AssumeRoleCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleCredentialProviderTest.php
@@ -28,10 +28,10 @@ class AssumeRoleCredentialProviderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider insufficientArguments
-     * 
+     *
      * @param array $config
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage  Missing required 'AssumeRoleCredentialProvider' configuration option: 
+     * @expectedExceptionMessage  Missing required 'AssumeRoleCredentialProvider' configuration option:
      */
     public function testEnsureSourceProfileProvidedForAssumeRole($config)
     {
@@ -94,7 +94,7 @@ class AssumeRoleCredentialProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo', $creds->getAccessKeyId());
         $this->assertEquals('bar', $creds->getSecretKey());
-        $this->assertEquals(null, $creds->getSecurityToken());
+        $this->assertNull($creds->getSecurityToken());
         $this->assertInternalType('int', $creds->getExpiration());
         $this->assertFalse($creds->isExpired());
     }

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -117,7 +117,7 @@ class CredentialProviderTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals(1, $timesCalled);
-        $this->assertEquals(1, count($cache));
+        $this->assertCount(1, $cache);
         $this->assertEquals($creds->getAccessKeyId(), $found->getAccessKeyId());
         $this->assertEquals($creds->getSecretKey(), $found->getSecretKey());
         $this->assertEquals($creds->getSecurityToken(), $found->getSecurityToken());
@@ -145,7 +145,7 @@ class CredentialProviderTest extends \PHPUnit_Framework_TestCase
         $creds = call_user_func(CredentialProvider::env())->wait();
         $this->assertEquals('abc', $creds->getAccessKeyId());
         $this->assertEquals('123', $creds->getSecretKey());
-        $this->assertEquals(NULL, $creds->getSecurityToken());
+        $this->assertNull($creds->getSecurityToken());
     }
 
     /**

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -62,7 +62,7 @@ class EcsCredentialProviderTest extends \PHPUnit_Framework_TestCase
         )->wait();
         $this->assertEquals('foo', $c->getAccessKeyId());
         $this->assertEquals('baz', $c->getSecretKey());
-        $this->assertEquals(null, $c->getSecurityToken());
+        $this->assertNull($c->getSecurityToken());
         $this->assertEquals($t, $c->getExpiration());
     }
 

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -59,7 +59,7 @@ class InstanceProfileProviderTest extends \PHPUnit_Framework_TestCase
         )->wait();
         $this->assertEquals('foo', $c->getAccessKeyId());
         $this->assertEquals('baz', $c->getSecretKey());
-        $this->assertEquals(null, $c->getSecurityToken());
+        $this->assertNull($c->getSecurityToken());
         $this->assertEquals($t, $c->getExpiration());
     }
 
@@ -118,7 +118,7 @@ class InstanceProfileProviderTest extends \PHPUnit_Framework_TestCase
         )->wait();
         $this->assertEquals('foo', $c->getAccessKeyId());
         $this->assertEquals('baz', $c->getSecretKey());
-        $this->assertEquals(null, $c->getSecurityToken());
+        $this->assertNull($c->getSecurityToken());
         $this->assertEquals($t, $c->getExpiration());
     }
 

--- a/tests/DynamoDb/LockingSessionConnectionTest.php
+++ b/tests/DynamoDb/LockingSessionConnectionTest.php
@@ -43,6 +43,6 @@ class LockingSessionConnectionTest extends \PHPUnit_Framework_TestCase
         $connection = new LockingSessionConnection($client);
         $data = $connection->read('session1');
 
-        $this->assertEquals(null, $data);
+        $this->assertNull($data);
     }
 }

--- a/tests/DynamoDb/MarshalerTest.php
+++ b/tests/DynamoDb/MarshalerTest.php
@@ -374,7 +374,7 @@ JSON;
         $set = new SetValue(['foo', 'bar', 'baz']);
         $this->assertEquals(['foo', 'bar', 'baz'], $set->toArray());
         $this->assertEquals('["foo","bar","baz"]', json_encode($set));
-        $this->assertEquals(3, count($set));
+        $this->assertCount(3, $set);
         $this->assertEquals(3, iterator_count($set));
     }
 

--- a/tests/Handler/GuzzleV5/HandlerTest.php
+++ b/tests/Handler/GuzzleV5/HandlerTest.php
@@ -128,7 +128,7 @@ EOXML;
             $this->assertInstanceOf(PsrResponse::class, $error['response']);
             $this->assertEquals(404, $error['response']->getStatusCode());
             $this->assertEquals($xml, $error['response']->getBody());
-            $this->assertEquals($xml, file_get_contents($sink));
+            $this->assertStringEqualsFile($sink, $xml);
             unlink($sink);
         }
 

--- a/tests/Integ/NativeStreamContext.php
+++ b/tests/Integ/NativeStreamContext.php
@@ -136,7 +136,7 @@ class NativeStreamContext extends \PHPUnit_Framework_Assert implements
      */
     public function theFileAtShouldContain($key, $contents)
     {
-        $this->assertSame($contents, file_get_contents($this->getS3Path($key)));
+        $this->assertStringEqualsFile($this->getS3Path($key), $contents);
     }
 
     /**

--- a/tests/Integ/S3Context.php
+++ b/tests/Integ/S3Context.php
@@ -128,10 +128,7 @@ class S3Context implements Context, SnippetAcceptingContext
      */
     public function theContentsAtThePresignedUrlShouldBe($body)
     {
-        Assert::assertSame(
-            $body,
-            file_get_contents((string) $this->presignedRequest->getUri())
-        );
+        Assert::assertStringEqualsFile($this->presignedRequest->getUri(), $body);
     }
 
     /**

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -866,6 +866,6 @@ EOXML;
             '@MaterialsProvider' => $provider,
             'SaveAs' => $file
         ]);
-        $this->assertEquals((string)$result['Body'], file_get_contents($file));
+        $this->assertStringEqualsFile($file, (string)$result['Body']);
     }
 }

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -849,7 +849,7 @@ EOXML;
             'region' => 'us-west-2',
             'http_handler' => function (RequestInterface $r, array $opts = []) {
                 $this->assertArrayHasKey('decode_content', $opts);
-                $this->assertSame(false, $opts['decode_content']);
+                $this->assertFalse($opts['decode_content']);
 
                 return Promise\promise_for(new Response);
             }
@@ -866,7 +866,7 @@ EOXML;
             'http' => ['decode_content' => false],
             'http_handler' => function (RequestInterface $r, array $opts = []) {
                 $this->assertArrayHasKey('decode_content', $opts);
-                $this->assertSame(false, $opts['decode_content']);
+                $this->assertFalse($opts['decode_content']);
 
                 return Promise\promise_for(new Response);
             }
@@ -882,7 +882,7 @@ EOXML;
             'region' => 'us-west-2',
             'http_handler' => function (RequestInterface $r, array $opts = []) {
                 $this->assertArrayHasKey('decode_content', $opts);
-                $this->assertSame(false, $opts['decode_content']);
+                $this->assertFalse($opts['decode_content']);
 
                 return Promise\promise_for(new Response);
             }

--- a/tests/S3/StreamWrapperPathStyleTest.php
+++ b/tests/S3/StreamWrapperPathStyleTest.php
@@ -707,7 +707,7 @@ class StreamWrapperPathStyleTest extends \PHPUnit_Framework_TestCase
         $this->addMockResults($this->client, [
             function ($cmd, $r) { return new S3Exception('404', $cmd); },
         ]);
-        $this->assertFalse(file_exists('s3://bucket/key'));
+        $this->assertFileNotExists('s3://bucket/key');
     }
 
     public function testProvidesDirectoriesForS3()

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -706,7 +706,7 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
         $this->addMockResults($this->client, [
             function ($cmd, $r) { return new S3Exception('404', $cmd); },
         ]);
-        $this->assertFalse(file_exists('s3://bucket/key'));
+        $this->assertFileNotExists('s3://bucket/key');
     }
 
     public function testProvidesDirectoriesForS3()

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -75,19 +75,19 @@ class SignatureV4Test extends \PHPUnit_Framework_TestCase
         $request = new Request('GET', 'http://www.example.com');
         $credentials = new Credentials('fizz', 'buzz');
         $sig->signRequest($request, $credentials);
-        $this->assertEquals(1, count($this->readAttribute($sig, 'cache')));
+        $this->assertCount(1, $this->readAttribute($sig, 'cache'));
 
         $credentials = new Credentials('fizz', 'baz');
         $sig->signRequest($request, $credentials);
-        $this->assertEquals(2, count($this->readAttribute($sig, 'cache')));
+        $this->assertCount(2, $this->readAttribute($sig, 'cache'));
 
         $credentials = new Credentials('fizz', 'paz');
         $sig->signRequest($request, $credentials);
-        $this->assertEquals(3, count($this->readAttribute($sig, 'cache')));
+        $this->assertCount(3, $this->readAttribute($sig, 'cache'));
 
         $credentials = new Credentials('fizz', 'foobar');
         $sig->signRequest($request, $credentials);
-        $this->assertEquals(1, count($this->readAttribute($sig, 'cache')));
+        $this->assertCount(1, $this->readAttribute($sig, 'cache'));
     }
 
     private function getFixtures()

--- a/tests/WrappedHttpHandlerTest.php
+++ b/tests/WrappedHttpHandlerTest.php
@@ -210,7 +210,7 @@ class WrappedHttpHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $handler = function ($request, array $options) {
             $this->assertArrayHasKey('http_stats_receiver', $options);
-            $this->assertTrue(is_callable($options['http_stats_receiver']));
+            $this->assertInternalType('callable', $options['http_stats_receiver']);
             return new Response;
         };
 


### PR DESCRIPTION
I've refactored some tests, using:
- `assertFileExists` and `assertFileNotExists` instead of `file_exists` method
- `assertInternalType` instead of `is_*` methods;
- `assertNull` instead of strict comparisons with `null` keyword;
- `assertFalse` instead of strict comparisons with `false` keyword;
- `assertStringEqualsFile` when comparing strings and file;
- `assertCount` instead of `count` method.