### PR TITLE
Refactoring more tests

### DIFF
--- a/.changes/nextrelease/refactoring-more-tests
+++ b/.changes/nextrelease/refactoring-more-tests
@@ -1,0 +1,7 @@
+[
+   {
+       "type": "enhancement",
+       "category": "Test",
+       "description": "More refactored tests with PHPUnit assert methods."
+   }
+]

--- a/tests/Api/ShapeTest.php
+++ b/tests/Api/ShapeTest.php
@@ -18,13 +18,13 @@ class ShapeTest extends TestCase
         $this->assertNull($s['missing']);
         $s['abc'] = '123';
         $this->assertEquals('123', $s['abc']);
-        $this->assertTrue(isset($s['abc']));
+        $this->assertArrayHasKey('abc', $s);
         $this->assertEquals(
             ['metadata' => ['foo' => 'bar'], 'abc' => '123'],
             $s->toArray()
         );
         unset($s['abc']);
-        $this->assertFalse(isset($s['abc']));
+        $this->assertArrayNotHasKey('abc', $s);
     }
 
     /**

--- a/tests/Build/Changelog/ChangelogBuilderTest.php
+++ b/tests/Build/Changelog/ChangelogBuilderTest.php
@@ -86,8 +86,8 @@ class ChangelogBuilderTest extends TestCase
         $params['base_dir'] = $tempDir;
         $obj = new ChangelogBuilder($params);
         touch($tempDir . ".changes/nextrelease/temp.json");
-        $this->assertEquals(1, count(preg_grep('/^([^.])/', scandir($tempDir . ".changes/nextrelease/"))));
+        $this->assertCount(1, preg_grep('/^([^.])/', scandir($tempDir . ".changes/nextrelease/")));
         $obj->cleanNextReleaseFolder();
-        $this->assertEquals(0, count(preg_grep('/^([^.])/', scandir($tempDir . ".changes/nextrelease/"))));
+        $this->assertCount(0, preg_grep('/^([^.])/', scandir($tempDir . ".changes/nextrelease/")));
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -68,15 +68,15 @@ class CommandTest extends TestCase
         $this->assertEquals('baz', $c['bar']);
         $this->assertNull($c['boo']);
         $this->assertEquals('boo', $c['qux']);
-        $this->assertTrue(isset($c['qux']));
-        $this->assertFalse(isset($c['boo']));
+        $this->assertArrayHasKey('qux', $c);
+        $this->assertArrayNotHasKey('boo', $c);
 
         $c['boo'] = 'hi!';
-        $this->assertTrue(isset($c['boo']));
+        $this->assertArrayHasKey('boo', $c);
         $this->assertEquals('hi!', $c['boo']);
 
         unset($c['boo']);
-        $this->assertFalse(isset($c['boo']));
+        $this->assertArrayNotHasKey('boo', $c);
         $this->assertNull($c['boo']);
     }
 }

--- a/tests/DynamoDb/MarshalerTest.php
+++ b/tests/DynamoDb/MarshalerTest.php
@@ -376,7 +376,7 @@ JSON;
         $this->assertEquals(['foo', 'bar', 'baz'], $set->toArray());
         $this->assertEquals('["foo","bar","baz"]', json_encode($set));
         $this->assertCount(3, $set);
-        $this->assertEquals(3, iterator_count($set));
+        $this->assertCount(3, $set);
     }
 
     public function testUnmarshalItemDoesNotCreateReferences()

--- a/tests/S3/StreamWrapperPathStyleTest.php
+++ b/tests/S3/StreamWrapperPathStyleTest.php
@@ -165,7 +165,7 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
-        $this->assertEquals(1, count($history));
+        $this->assertCount(1, $history);
         $cmd = $history->getLastCommand();
         $this->assertEquals('PutObject', $cmd->getName());
         $this->assertEquals('bucket', $cmd['Bucket']);
@@ -205,7 +205,7 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
-        $this->assertEquals(2, count($history));
+        $this->assertCount(2, $history);
         $entries = $history->toArray();
         $c1 = $entries[0]['command'];
         $this->assertEquals('GetObject', $c1->getName());
@@ -237,7 +237,7 @@ class StreamWrapperPathStyleTest extends TestCase
             new Result(['@metadata' => ['statusCode' => 204]])
         ]);
         $this->assertTrue(unlink('s3://bucket/key'));
-        $this->assertEquals(1, count($history));
+        $this->assertCount(1, $history);
         $entries = $history->toArray();
         $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
         $this->assertEquals('/bucket/key', $entries[0]['request']->getUri()->getPath());
@@ -299,7 +299,7 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(mkdir('s3://bucket', 0601));
         $this->assertTrue(mkdir('s3://bucket', 0500));
 
-        $this->assertEquals(6, count($history));
+        $this->assertCount(6, $history);
         $entries = $history->toArray();
 
         $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
@@ -325,7 +325,7 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
 
         $this->assertTrue(mkdir('s3://bucket/key/', 0777));
-        $this->assertEquals(2, count($history));
+        $this->assertCount(2, $history);
         $entries = $history->toArray();
         $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
         $this->assertEquals('PUT', $entries[1]['request']->getMethod());
@@ -359,7 +359,7 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result()]);
         $this->assertTrue(rmdir('s3://bucket'));
-        $this->assertEquals(1, count($history));
+        $this->assertCount(1, $history);
         $entries = $history->toArray();
         $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
         $this->assertEquals('/bucket', $entries[0]['request']->getUri()->getPath());
@@ -403,7 +403,7 @@ class StreamWrapperPathStyleTest extends TestCase
             new Result()
         ]);
         $this->assertTrue(rmdir('s3://foo/bar'));
-        $this->assertEquals(2, count($history));
+        $this->assertCount(2, $history);
         $entries = $history->toArray();
         $this->assertEquals('GET', $entries[0]['request']->getMethod());
         $this->assertContains('prefix=bar%2F', $entries[0]['request']->getUri()->getQuery());
@@ -453,7 +453,7 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
         $this->assertTrue(rename('s3://bucket/key', 's3://other/new_key'));
         $entries = $history->toArray();
-        $this->assertEquals(3, count($entries));
+        $this->assertCount(3, $entries);
         $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
         $this->assertEquals('/bucket/key', $entries[0]['request']->getUri()->getPath());
         $this->assertEquals('PUT', $entries[1]['request']->getMethod());
@@ -487,7 +487,7 @@ class StreamWrapperPathStyleTest extends TestCase
             stream_context_create(['s3' => ['MetadataDirective' => 'REPLACE']])
         ));
         $entries = $history->toArray();
-        $this->assertEquals(3, count($entries));
+        $this->assertCount(3, $entries);
         $this->assertEquals('PUT', $entries[1]['request']->getMethod());
         $this->assertEquals('/other/new_key', $entries[1]['request']->getUri()->getPath());
         $this->assertEquals('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -162,7 +162,7 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
-        $this->assertEquals(1, count($history));
+        $this->assertCount(1, $history);
         $cmd = $history->getLastCommand();
         $this->assertEquals('PutObject', $cmd->getName());
         $this->assertEquals('bucket', $cmd['Bucket']);
@@ -202,7 +202,7 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
-        $this->assertEquals(2, count($history));
+        $this->assertCount(2, $history);
         $entries = $history->toArray();
         $c1 = $entries[0]['command'];
         $this->assertEquals('GetObject', $c1->getName());
@@ -234,7 +234,7 @@ class StreamWrapperTest extends TestCase
             new Result(['@metadata' => ['statusCode' => 204]])
         ]);
         $this->assertTrue(unlink('s3://bucket/key'));
-        $this->assertEquals(1, count($history));
+        $this->assertCount(1, $history);
         $entries = $history->toArray();
         $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
         $this->assertEquals('/key', $entries[0]['request']->getUri()->getPath());
@@ -296,7 +296,7 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(mkdir('s3://bucket', 0601));
         $this->assertTrue(mkdir('s3://bucket', 0500));
 
-        $this->assertEquals(6, count($history));
+        $this->assertCount(6, $history);
         $entries = $history->toArray();
 
         $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
@@ -322,7 +322,7 @@ class StreamWrapperTest extends TestCase
         ]);
 
         $this->assertTrue(mkdir('s3://bucket/key/', 0777));
-        $this->assertEquals(2, count($history));
+        $this->assertCount(2, $history);
         $entries = $history->toArray();
         $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
         $this->assertEquals('PUT', $entries[1]['request']->getMethod());
@@ -356,7 +356,7 @@ class StreamWrapperTest extends TestCase
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result()]);
         $this->assertTrue(rmdir('s3://bucket'));
-        $this->assertEquals(1, count($history));
+        $this->assertCount(1, $history);
         $entries = $history->toArray();
         $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
         $this->assertEquals('/', $entries[0]['request']->getUri()->getPath());
@@ -400,7 +400,7 @@ class StreamWrapperTest extends TestCase
             new Result()
         ]);
         $this->assertTrue(rmdir('s3://foo/bar'));
-        $this->assertEquals(2, count($history));
+        $this->assertCount(2, $history);
         $entries = $history->toArray();
         $this->assertEquals('GET', $entries[0]['request']->getMethod());
         $this->assertContains('prefix=bar%2F', $entries[0]['request']->getUri()->getQuery());
@@ -451,7 +451,7 @@ class StreamWrapperTest extends TestCase
         ]);
         $this->assertTrue(rename('s3://bucket/key', 's3://other/new_key'));
         $entries = $history->toArray();
-        $this->assertEquals(3, count($entries));
+        $this->assertCount(3, $entries);
         $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
         $this->assertEquals('/key', $entries[0]['request']->getUri()->getPath());
         $this->assertEquals('bucket.s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
@@ -486,7 +486,7 @@ class StreamWrapperTest extends TestCase
             stream_context_create(['s3' => ['MetadataDirective' => 'REPLACE']])
         ));
         $entries = $history->toArray();
-        $this->assertEquals(3, count($entries));
+        $this->assertCount(3, $entries);
         $this->assertEquals('PUT', $entries[1]['request']->getMethod());
         $this->assertEquals('/new_key', $entries[1]['request']->getUri()->getPath());
         $this->assertEquals('other.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());


### PR DESCRIPTION
Continuing to refactory tests, like #1430, I've used:
- `assertArrayHasKey` and `assertArrayNotHasKey` instead of `isset` function;
- `assertCount` instead of `count` and `iterator_count` ([`PHPUnit` handles it](https://github.com/sebastianbergmann/phpunit/blob/5.7/src/Framework/Constraint/Count.php#L61))