### PR TITLE
Fix getEndpoint Naming Collision

### DIFF
--- a/src/Pinpoint/PinpointClient.php
+++ b/src/Pinpoint/PinpointClient.php
@@ -1,6 +1,9 @@
 <?php
 namespace Aws\Pinpoint;
 
+use Aws\Api\ApiProvider;
+use Aws\Api\DocModel;
+use Aws\Api\Service;
 use Aws\AwsClient;
 
 /**
@@ -126,4 +129,47 @@ use Aws\AwsClient;
  * @method \Aws\Result updateSmsChannel(array $args = [])
  * @method \GuzzleHttp\Promise\Promise updateSmsChannelAsync(array $args = [])
  */
-class PinpointClient extends AwsClient {}
+class PinpointClient extends AwsClient
+{
+    private static $nameCollisionOverrides = [
+        'GetUserEndpoint' => 'GetEndpoint',
+        'GetUserEndpointAsync' => 'GetEndpointAsync',
+        'UpdateUserEndpoint' => 'UpdateEndpoint',
+        'UpdateUserEndpointAsync' => 'UpdateEndpointAsync',
+        'UpdateUserEndpointsBatch' => 'UpdateEndpointsBatch',
+        'UpdateUserEndpointsBatchAsync' => 'UpdateEndpointsBatchAsync',
+    ];
+
+    public function __call($name, array $args)
+    {
+        // Overcomes a naming collision with `AwsClient::getEndpoint`.
+        if (isset(self::$nameCollisionOverrides[ucfirst($name)])) {
+            $name = self::$nameCollisionOverrides[ucfirst($name)];
+        }
+
+        return parent::__call($name, $args);
+    }
+
+    /**
+     * @internal
+     * @codeCoverageIgnore
+     */
+    public static function applyDocFilters(array $api, array $docs)
+    {
+        foreach (self::$nameCollisionOverrides as $overrideName => $operationName) {
+            if (substr($overrideName, -5) === 'Async') {
+                continue;
+            }
+            // Overcomes a naming collision with `AwsClient::getEndpoint`.
+            $api['operations'][$overrideName] = $api['operations'][$operationName];
+            $docs['operations'][$overrideName] = $docs['operations'][$operationName];
+            unset($api['operations'][$operationName], $docs['operations'][$operationName]);
+        }
+        ksort($api['operations']);
+
+        return [
+            new Service($api, ApiProvider::defaultProvider()),
+            new DocModel($docs)
+        ];
+    }
+}


### PR DESCRIPTION
Overcomes a `PinpointClient::getEndpoint` naming collision with `AwsClient::getEndpoint` by creating alias calls with `UserEndpoint` for each of the endpoint related service operations.

Similar to [the fix for `CloudHsm::getConfig`](https://github.com/aws/aws-sdk-php/blob/master/src/CloudHsm/CloudHsmClient.php#L55).