### PR TITLE
Add required IAM permissions for DDB Session Handler

### DIFF
--- a/docs/service/dynamodb-session-handler.rst
+++ b/docs/service/dynamodb-session-handler.rst
@@ -240,3 +240,25 @@ Best Practices
 #. Instead of using PHP's built-in session garbage collection triggers, schedule your garbage collection via a cron job,
    or another scheduling mechanism, to run during off-peak hours. Use the ``'batch_config'`` option to your advantage.
 
+
+Required IAM Permissions
+------------------------
+
+.. code-block:: js
+
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "dynamodb:GetItem",
+            "dynamodb:UpdateItem",
+            "dynamodb:DeleteItem",
+            "dynamodb:Scan",
+            "dynamodb:BatchWriteItem"
+          ],
+          "Effect": "Allow",
+          "Resource": "arn:aws:dynamodb:ap-southeast-2:<account-id>:table/<table-name>"
+        }
+      ]
+    }

--- a/docs/service/dynamodb-session-handler.rst
+++ b/docs/service/dynamodb-session-handler.rst
@@ -244,6 +244,13 @@ Best Practices
 Required IAM Permissions
 ------------------------
 
+To use the DynamoDB session handler, your `configured credentials <https://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/credentials.html>`_
+must have permission to use the DynamoDB table that `you created in a previous step <https://docs.aws.amazon.com/aws-sdk-php/v3/guide/service/dynamodb-session-handler.html#create-a-table-for-storing-your-sessions>`_.
+The following IAM policy contains the minimum permissions that you need. To use this policy, replace the Resource value
+with the Amazon Resource Name (ARN) of the table that you created previously. For more information about creating and
+attaching IAM policies, see `Managing IAM Policies <https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_manage.html>`_
+in the *AWS Identity and Access Management User Guide*.
+
 .. code-block:: js
 
     {

--- a/docs/service/dynamodb-session-handler.rst
+++ b/docs/service/dynamodb-session-handler.rst
@@ -258,7 +258,7 @@ Required IAM Permissions
             "dynamodb:BatchWriteItem"
           ],
           "Effect": "Allow",
-          "Resource": "arn:aws:dynamodb:ap-southeast-2:<account-id>:table/<table-name>"
+          "Resource": "arn:aws:dynamodb:<region>:<account-id>:table/<table-name>"
         }
       ]
     }


### PR DESCRIPTION
While setting up a DDB table for Session persistence, I felt a lack of guidance around which IAM permissions developers/resources should have access to.

It's somehow written between the lines in the [guide](http://docs.aws.amazon.com/aws-sdk-php/v3/guide/service/dynamodb-session-handler.html) about this matter, but a developer won't be sure until he/she start reading the [StandardSessionConnection.php](https://github.com/aws/aws-sdk-php/blob/master/src/DynamoDb/StandardSessionConnection.php) which may take some time. 

So I decided to append to the guide the required permissions to make DynamoDB Session Handler feature work. Then again, there is always room for enhancement, isn't there?

If you think this will be beneficial for aws-sdk-php, please accept this PR.

I confirm I'm releasing this change under the Apache License (to make things faster)

Best regards,

Paulo Almeida