### PR TITLE
Use fluent interface when defining mocks

### DIFF
--- a/.changes/nextrelease/fluent-mock
+++ b/.changes/nextrelease/fluent-mock
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Test",
+        "description": "Use fluent interface when defining mocks."
+    }
+]

--- a/tests/Handler/GuzzleV5/HandlerTest.php
+++ b/tests/Handler/GuzzleV5/HandlerTest.php
@@ -202,7 +202,7 @@ EOXML;
 
     private function getHandler(Deferred $deferred, $output = 'foo')
     {
-        $client = $this->getMock('GuzzleHttp\Client', ['send']);
+        $client = $this->getMockBuilder('GuzzleHttp\Client')->setMethods(['send'])->getMock();
         $future = new FutureResponse($deferred->promise());
         $client->method('send')->willReturn($future);
 


### PR DESCRIPTION
Another `PHPUnit 6` future compatibility: `getMock` was removed, so, we should use fluent interface when defining our mocks. This was the last occurrence.