### PR TITLE
[CS] Remove unused imports

### DIFF
--- a/.changes/nextrelease/remove-unused-imports
+++ b/.changes/nextrelease/remove-unused-imports
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Removed or adjusted unused imports."
+    }
+]

--- a/build/docs/classes/DocsBuilder.php
+++ b/build/docs/classes/DocsBuilder.php
@@ -11,7 +11,6 @@ use Aws\Api\StructureShape;
 use Aws\Api\DocModel;
 use TokenReflection\Broker;
 use TokenReflection\ReflectionBase;
-use TokenReflection\ReflectionClass;
 use TokenReflection\ReflectionFunction;
 use TokenReflection\ReflectionMethod;
 

--- a/build/gh-release.php
+++ b/build/gh-release.php
@@ -10,7 +10,6 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7;
 

--- a/src/AwsClientTrait.php
+++ b/src/AwsClientTrait.php
@@ -2,7 +2,6 @@
 namespace Aws;
 
 use Aws\Api\Service;
-use GuzzleHttp\Promise\Promise;
 
 /**
  * A trait providing generic functionality for interacting with Amazon Web

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -6,13 +6,10 @@ use Aws\Api\ApiProvider;
 use Aws\Api\Service;
 use Aws\Credentials\Credentials;
 use Aws\Credentials\CredentialsInterface;
-use Aws\Endpoint\Partition;
 use Aws\Endpoint\PartitionEndpointProvider;
-use Aws\Endpoint\PartitionProviderInterface;
 use Aws\Signature\SignatureProvider;
 use Aws\Endpoint\EndpointProvider;
 use Aws\Credentials\CredentialProvider;
-use GuzzleHttp\Promise;
 use InvalidArgumentException as IAE;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Credentials/AssumeRoleCredentialProvider.php
+++ b/src/Credentials/AssumeRoleCredentialProvider.php
@@ -14,7 +14,7 @@ class AssumeRoleCredentialProvider
 {
     const ERROR_MSG = "Missing required 'AssumeRoleCredentialProvider' configuration option: ";
 
-    /** @var callable */
+    /** @var StsClient */
     private $client;
 
     /** @var array */

--- a/src/Credentials/AssumeRoleCredentialProvider.php
+++ b/src/Credentials/AssumeRoleCredentialProvider.php
@@ -1,15 +1,10 @@
 <?php
 namespace Aws\Credentials;
 
-use Aws\Exception\AwsException;
 use Aws\Exception\CredentialsException;
 use Aws\Result;
 use Aws\Sts\StsClient;
-use GuzzleHttp\Promise;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\ResponseInterface;
 
 /**
  * Credential provider that provides credentials via assuming a role

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -2,7 +2,6 @@
 namespace Aws\Credentials;
 
 use Aws\Exception\CredentialsException;
-use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Crypto/AesGcmDecryptingStream.php
+++ b/src/Crypto/AesGcmDecryptingStream.php
@@ -4,7 +4,6 @@ namespace Aws\Crypto;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use Psr\Http\Message\StreamInterface;
-use GuzzleHttp\Psr7\LimitStream;
 use \RuntimeException;
 
 /**

--- a/src/DynamoDb/WriteRequestBatch.php
+++ b/src/DynamoDb/WriteRequestBatch.php
@@ -1,7 +1,6 @@
 <?php
 namespace Aws\DynamoDb;
 
-use Aws\AwsClientInterface;
 use Aws\CommandInterface;
 use Aws\CommandPool;
 use Aws\Exception\AwsException;

--- a/src/ElasticLoadBalancingV2/ElasticLoadBalancingV2Client.php
+++ b/src/ElasticLoadBalancingV2/ElasticLoadBalancingV2Client.php
@@ -2,9 +2,6 @@
 namespace Aws\ElasticLoadBalancingV2;
 
 use Aws\AwsClient;
-use Aws\Command;
-use Aws\CommandInterface;
-use Psr\Http\Message\RequestInterface;
 
 /**
  * This client is used to interact with the **Elastic Load Balancing** service.

--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -1,7 +1,6 @@
 <?php
 namespace Aws\Handler\GuzzleV5;
 
-use Aws\Sdk;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;

--- a/src/Handler/GuzzleV6/GuzzleHandler.php
+++ b/src/Handler/GuzzleV6/GuzzleHandler.php
@@ -1,7 +1,6 @@
 <?php
 namespace Aws\Handler\GuzzleV6;
 
-use Aws\Sdk;
 use Exception;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -9,7 +9,6 @@ use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class Middleware
 {

--- a/src/MultiRegionClient.php
+++ b/src/MultiRegionClient.php
@@ -3,8 +3,6 @@ namespace Aws;
 
 use Aws\Endpoint\PartitionEndpointProvider;
 use Aws\Endpoint\PartitionInterface;
-use GuzzleHttp\Promise\FulfilledPromise;
-use Psr\Http\Message\RequestInterface;
 
 class MultiRegionClient implements AwsClientInterface
 {

--- a/src/Multipart/AbstractUploadManager.php
+++ b/src/Multipart/AbstractUploadManager.php
@@ -10,7 +10,6 @@ use Aws\Result;
 use Aws\ResultInterface;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
 use InvalidArgumentException as IAE;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/PresignUrlMiddleware.php
+++ b/src/PresignUrlMiddleware.php
@@ -1,10 +1,8 @@
 <?php
 namespace Aws;
 
-use Aws\AwsClientInterface;
 use Aws\Signature\SignatureV4;
 use Aws\Endpoint\EndpointProvider;
-use Aws\CommandInterface;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -4,6 +4,7 @@ namespace Aws;
 use Aws\Exception\AwsException;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise;
 
 /**
  * @internal Middleware that retries failures.
@@ -131,7 +132,7 @@ class RetryMiddleware
 
             if ($value instanceof \Exception || $value instanceof \Throwable) {
                 if (!$decider($retries, $command, $request, null, $value)) {
-                    return \GuzzleHttp\Promise\rejection_for(
+                    return Promise\rejection_for(
                         $this->bindStatsToReturn($value, $requestStats)
                     );
                 }

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -2,11 +2,8 @@
 namespace Aws;
 
 use Aws\Exception\AwsException;
-use Exception;
 use Psr\Http\Message\RequestInterface;
-use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7;
 
 /**
  * @internal Middleware that retries failures.

--- a/src/S3/BatchDelete.php
+++ b/src/S3/BatchDelete.php
@@ -100,7 +100,7 @@ class BatchDelete implements PromisorInterface
         array $options = []
     ) {
         $fn = function (BatchDelete $that) use ($iter) {
-            return \GuzzleHttp\Promise\coroutine(function () use ($that, $iter) {
+            return Promise\coroutine(function () use ($that, $iter) {
                 foreach ($iter as $obj) {
                     if ($promise = $that->enqueue($obj)) {
                         yield $promise;

--- a/src/S3/Crypto/S3EncryptionClient.php
+++ b/src/S3/Crypto/S3EncryptionClient.php
@@ -8,7 +8,6 @@ use Aws\Crypto\EncryptionTrait;
 use Aws\Crypto\DecryptionTrait;
 use Aws\Crypto\MetadataEnvelope;
 use Aws\Crypto\MaterialsProvider;
-use Aws\Crypto\MetadataStrategyInterface;
 use Aws\Crypto\Cipher\CipherBuilderTrait;
 use Aws\S3\S3Client;
 use GuzzleHttp\Promise;

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -14,8 +14,6 @@ use Aws\RetryMiddleware;
 use Aws\ResultInterface;
 use Aws\CommandInterface;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Promise;
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/src/S3/S3EndpointMiddleware.php
+++ b/src/S3/S3EndpointMiddleware.php
@@ -2,7 +2,6 @@
 namespace Aws\S3;
 
 use Aws\CommandInterface;
-use Aws\S3\Exception\S3Exception;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/src/S3/S3MultiRegionClient.php
+++ b/src/S3/S3MultiRegionClient.php
@@ -1,7 +1,6 @@
 <?php
 namespace Aws\S3;
 
-use Aws\Api\Parser\PayloadParserTrait;
 use Aws\CacheInterface;
 use Aws\CommandInterface;
 use Aws\LruArrayCache;

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -5,7 +5,6 @@ use Aws;
 use Aws\CommandInterface;
 use Aws\Exception\AwsException;
 use GuzzleHttp\Promise;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Promise\PromisorInterface;
 use Iterator;
 

--- a/src/WrappedHttpHandler.php
+++ b/src/WrappedHttpHandler.php
@@ -3,7 +3,6 @@ namespace Aws;
 
 use Aws\Api\Parser\Exception\ParserException;
 use GuzzleHttp\Promise;
-use GuzzleHttp\Promise\FulfilledPromise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -13,8 +13,6 @@ use Aws\S3\S3Client;
 use Aws\HandlerList;
 use Aws\Sdk;
 use Aws\Result;
-use Aws\WrappedHttpHandler;
-use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/CloudSearchDomain/CloudSearchDomainTest.php
+++ b/tests/CloudSearchDomain/CloudSearchDomainTest.php
@@ -3,7 +3,6 @@ namespace Aws\Test\CloudSearchDomain;
 
 use Aws\CloudSearchDomain\CloudSearchDomainClient;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/CognitoIdentity/CognitoIdentityProviderTest.php
+++ b/tests/CognitoIdentity/CognitoIdentityProviderTest.php
@@ -5,7 +5,6 @@ use Aws\Api\DateTimeResult;
 use Aws\CognitoIdentity\CognitoIdentityProvider;
 use Aws\MockHandler;
 use Aws\Result;
-use Aws\Test\UsesServiceTrait;
 use PHPUnit\Framework\TestCase;
 
 class CognitoIdentityProviderTest extends TestCase

--- a/tests/Credentials/AssumeRoleCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleCredentialProviderTest.php
@@ -2,19 +2,13 @@
 namespace Aws\Test\Credentials;
 
 use Aws\Credentials\AssumeRoleCredentialProvider;
-use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\Exception\AwsException;
-use Aws\Exception\CredentialsException;
 use Aws\Result;
 use Aws\Sts\StsClient;
 use Aws\Api\DateTimeResult;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Promise;
-use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\RejectedPromise;
-use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\RequestInterface;
 use Aws\Test\UsesServiceTrait;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -5,7 +5,8 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\LruArrayCache;
 use Aws\Sts\StsClient;
-use GuzzleHttp\Promise;use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Promise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Aws\Credentials\CredentialProvider
@@ -300,7 +301,7 @@ EOT;
         $creds = new Credentials('foo', 'bar');
         $f = function () use (&$called, $creds) {
             $called++;
-            return \GuzzleHttp\Promise\promise_for($creds);
+            return Promise\promise_for($creds);
         };
         $p = CredentialProvider::memoize($f);
         $this->assertSame($creds, $p()->wait());

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -5,7 +5,6 @@ use Aws\Credentials\InstanceProfileProvider;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Crypto/AesEncryptionStreamTestTrait.php
+++ b/tests/Crypto/AesEncryptionStreamTestTrait.php
@@ -2,8 +2,6 @@
 namespace Aws\Test\Crypto;
 
 use Aws\Crypto\Cipher\Cbc;
-use Aws\Crypto\Cipher\Ctr;
-use Aws\Crypto\Cipher\Ecb;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\CachingStream;
 

--- a/tests/Crypto/KmsMaterialsProviderTest.php
+++ b/tests/Crypto/KmsMaterialsProviderTest.php
@@ -2,7 +2,6 @@
 namespace Aws\Test\Crypto;
 
 use Aws\Crypto\KmsMaterialsProvider;
-use Aws\Crypto\MetadataEnvelope;
 use Aws\Kms\KmsClient;
 use Aws\Result;
 use Aws\Test\UsesServiceTrait;

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -4,7 +4,6 @@ namespace Aws\Test\DynamoDb;
 use Aws\Command;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Exception\DynamoDbException;
-use Aws\HandlerList;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;

--- a/tests/ElasticLoadBalancingV2/ElasticLoadBalancingV2ClientTest.php
+++ b/tests/ElasticLoadBalancingV2/ElasticLoadBalancingV2ClientTest.php
@@ -1,13 +1,7 @@
 <?php
 namespace Aws\Test\ElasticLoadBalancingV2;
 
-use Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client;
-use Aws\MockHandler;
-use Aws\Result;
 use Aws\Test\UsesServiceTrait;
-use Psr\Http\Message\RequestInterface;
-use GuzzleHttp\Promise;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Glacier/GlacierClientTest.php
+++ b/tests/Glacier/GlacierClientTest.php
@@ -5,7 +5,6 @@ use Aws\Exception\CouldNotCreateChecksumException;
 use Aws\Glacier\GlacierClient;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7\NoSeekStream;
-use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Handler/GuzzleV5/HandlerTest.php
+++ b/tests/Handler/GuzzleV5/HandlerTest.php
@@ -16,7 +16,6 @@ use GuzzleHttp\Psr7\Request as PsrRequest;
 use GuzzleHttp\Psr7\Response as PsrResponse;
 use GuzzleHttp\Ring\Client\MockHandler;
 use GuzzleHttp\Stream\Stream;
-use GuzzleHttp\Tests\Ring\Client\MockHandlerTest;
 use React\Promise\Deferred;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Handler/GuzzleV6/HandlerTest.php
+++ b/tests/Handler/GuzzleV6/HandlerTest.php
@@ -5,7 +5,6 @@ use Aws\Handler\GuzzleV6\GuzzleHandler;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\RejectionException;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;

--- a/tests/IdempotencyTokenMiddlewareTest.php
+++ b/tests/IdempotencyTokenMiddlewareTest.php
@@ -3,6 +3,7 @@ namespace Aws\Test;
 
 use Aws\IdempotencyTokenMiddleware;
 use Aws\Result;
+use GuzzleHttp\Promise;
 use Aws\HandlerList;
 use Aws\Api\ApiProvider;
 use Aws\Api\Service;
@@ -23,7 +24,7 @@ class IdempotencyTokenMiddlewareTest extends TestCase
             $this->assertNotNull($command['ClientToken']);
             $regex = '/([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/';
             $this->assertRegExp($regex, $command['ClientToken']);
-            return \GuzzleHttp\Promise\promise_for(new Result([]));
+            return Promise\promise_for(new Result([]));
         });
 
         $provider = ApiProvider::defaultProvider();
@@ -55,7 +56,7 @@ class IdempotencyTokenMiddlewareTest extends TestCase
                 '00000000-0000-4000-8000-000000000000',
                 $command['ClientToken']
             );
-            return \GuzzleHttp\Promise\promise_for(new Result([]));
+            return Promise\promise_for(new Result([]));
         });
 
         $provider = ApiProvider::defaultProvider();

--- a/tests/IdempotencyTokenMiddlewareTest.php
+++ b/tests/IdempotencyTokenMiddlewareTest.php
@@ -3,7 +3,6 @@ namespace Aws\Test;
 
 use Aws\IdempotencyTokenMiddleware;
 use Aws\Result;
-use GuzzleHttp\Promise;
 use Aws\HandlerList;
 use Aws\Api\ApiProvider;
 use Aws\Api\Service;

--- a/tests/MachineLearning/MachineLearningClientTest.php
+++ b/tests/MachineLearning/MachineLearningClientTest.php
@@ -4,7 +4,6 @@ namespace Aws\Test\MachineLearning;
 use Aws\Middleware;
 use Aws\MachineLearning\MachineLearningClient;
 use Aws\Test\UsesServiceTrait;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -79,7 +79,7 @@ class MiddlewareTest extends TestCase
         $list = new HandlerList();
         $mock = function ($command, $request) {
             $this->assertTrue($request->hasHeader('aws-sdk-invocation-id'));
-            return \GuzzleHttp\Promise\promise_for(
+            return Promise\promise_for(
                 new Result(['@metadata' => ['statusCode' => 200]])
             );
         };
@@ -94,7 +94,7 @@ class MiddlewareTest extends TestCase
         $list = new HandlerList();
         $mock = function ($command, $request) use (&$req) {
             $req = $request;
-            return \GuzzleHttp\Promise\promise_for(
+            return Promise\promise_for(
                 new Result(['@metadata' => ['statusCode' => 200]])
             );
         };

--- a/tests/Multipart/TestUploader.php
+++ b/tests/Multipart/TestUploader.php
@@ -2,10 +2,8 @@
 namespace Aws\Test\Multipart;
 
 use Aws\CommandInterface;
-use Aws\Multipart\UploadState;
 use Aws\Multipart\AbstractUploader;
 use Aws\ResultInterface;
-use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use Aws\S3\Exception\S3MultipartUploadException;
 

--- a/tests/PresignUrlMiddlewareTest.php
+++ b/tests/PresignUrlMiddlewareTest.php
@@ -5,7 +5,6 @@ use Aws\CommandInterface;
 use Aws\Ec2\Ec2Client;
 use Aws\Rds\RdsClient;
 use Aws\Result;
-use Aws\Test\UsesServiceTrait;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/ResultPaginatorTest.php
+++ b/tests/ResultPaginatorTest.php
@@ -5,6 +5,7 @@ use Aws\Api\ApiProvider;
 use Aws\CommandInterface;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Result;
+use GuzzleHttp\Promise;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -259,7 +260,7 @@ class ResultPaginatorTest extends TestCase
 
         $handler = function (CommandInterface $cmd, RequestInterface $request) use (&$results, &$cmds) {
             $cmds[] = $cmd;
-            return \GuzzleHttp\Promise\promise_for(
+            return Promise\promise_for(
                 new Result(array_shift($results))
             );
         };
@@ -312,7 +313,7 @@ class ResultPaginatorTest extends TestCase
                 }
             }
 
-            return \GuzzleHttp\Promise\promise_for(new Result($result));
+            return Promise\promise_for(new Result($result));
         };
 
         $client->getHandlerList()->setHandler($handler);
@@ -399,7 +400,7 @@ class ResultPaginatorTest extends TestCase
                 $this->assertArrayHasKey($expectedKey, $cmd);
                 $this->assertSame($expectedValue, $cmd[$expectedKey]);
             }
-            return \GuzzleHttp\Promise\promise_for(
+            return Promise\promise_for(
                 new Result($currentWindow['response'])
             );
         };

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -7,7 +7,6 @@ use Aws\Exception\AwsException;
 use Aws\MockHandler;
 use Aws\Result;
 use Aws\RetryMiddleware;
-use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;

--- a/tests/S3/ApplyChecksumMiddlewareTest.php
+++ b/tests/S3/ApplyChecksumMiddlewareTest.php
@@ -3,7 +3,6 @@ namespace Aws\Test\S3;
 
 use Aws\Middleware;
 use Aws\Test\UsesServiceTrait;
-use GuzzleHttp\Psr7;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -16,7 +16,6 @@ use Aws\Test\Crypto\UsesCryptoParamsTrait;
 use Aws\Test\UsesServiceTrait;
 use Aws\Test\Crypto\UsesMetadataEnvelopeTrait;
 use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -5,7 +5,6 @@ use Aws\Command;
 use Aws\Exception\AwsException;
 use Aws\Result;
 use Aws\S3\Exception\S3Exception;
-use Aws\S3\MultipartUploader;
 use Aws\S3\S3Client;
 use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Exception\ConnectException;
@@ -14,10 +13,8 @@ use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\StreamInterface;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/S3/S3MultiRegionClientTest.php
+++ b/tests/S3/S3MultiRegionClientTest.php
@@ -4,7 +4,6 @@ namespace Aws\Test\S3;
 use Aws\CacheInterface;
 use Aws\CommandInterface;
 use Aws\Endpoint\Partition;
-use Aws\Exception\AwsException;
 use Aws\LruArrayCache;
 use Aws\ResultInterface;
 use Aws\S3\S3ClientInterface;

--- a/tests/Signature/S3SignatureV4Test.php
+++ b/tests/Signature/S3SignatureV4Test.php
@@ -3,7 +3,6 @@ namespace Aws\Test\Signature;
 
 use Aws\Credentials\Credentials;
 use Aws\Signature\S3SignatureV4;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 
 require_once __DIR__ . '/sig_hack.php';

--- a/tests/TraceMiddlewareTest.php
+++ b/tests/TraceMiddlewareTest.php
@@ -23,7 +23,7 @@ class TraceMiddlewareTest extends TestCase
         $logfn = function ($value) use (&$str) { $str .= $value; };
         $list = new HandlerList();
         $list->setHandler(function ($cmd, $req) {
-            return \GuzzleHttp\Promise\promise_for(new Result([
+            return Promise\promise_for(new Result([
                 'baz' => 'bar',
                 'bam' => 'qux'
             ]));
@@ -63,7 +63,7 @@ class TraceMiddlewareTest extends TestCase
         $logfn = function ($value) use (&$str) { $str .= $value; };
         $list = new HandlerList();
         $list->setHandler(function ($cmd, $req) {
-            return \GuzzleHttp\Promise\promise_for(new Result());
+            return Promise\promise_for(new Result());
         });
         $list->appendInit(function ($handler) {
             return function ($cmd, $req = null) use ($handler) {
@@ -95,7 +95,7 @@ class TraceMiddlewareTest extends TestCase
         $logfn = function ($value) use (&$str) { $str .= $value; };
         $list = new HandlerList();
         $list->setHandler(function ($cmd, $req) {
-            return \GuzzleHttp\Promise\promise_for(new Result());
+            return Promise\promise_for(new Result());
         });
         $list->appendInit(function ($handler) {
             return function ($cmd, $req = null) use ($handler) {
@@ -140,7 +140,7 @@ class TraceMiddlewareTest extends TestCase
         $list->setHandler(function ($cmd, $req) use ($key) {
             // ensure that http level debug information is filtered as well.
             fwrite($cmd['@http']['debug'], "Credential=$key/...\n");
-            return \GuzzleHttp\Promise\promise_for(new Result());
+            return Promise\promise_for(new Result());
         });
 
         $list->appendInit(function ($handler) {
@@ -202,7 +202,7 @@ class TraceMiddlewareTest extends TestCase
         $list = new HandlerList();
 
         $list->setHandler(function ($cmd, $req) {
-            return \GuzzleHttp\Promise\promise_for(new Result());
+            return Promise\promise_for(new Result());
         });
 
         $list->appendInit(function ($handler) {

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -6,7 +6,6 @@ use Aws\CommandInterface;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Exception\AwsException;
 use Aws\Result;
-use Aws\S3\S3Client;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\FulfilledPromise;


### PR DESCRIPTION
I've cleaned up some unused imports. This save us some lines :put_litter_in_its_place: 

[`PHP-CS-Fixer`](https://github.com/FriendsOfPHP/PHP-CS-Fixer) helped me find them.