### PR TITLE
Retry Specific cURL Error Codes

### DIFF
--- a/.changes/nextrelease/retry_curl56.json
+++ b/.changes/nextrelease/retry_curl56.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "",
+    "description": "Retry on a set of CURLE_*_ERROR based failures. Currently, only CURLE_RECV_ERROR (errno 56) is retried."
+  }
+]

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -62,14 +62,14 @@ class RetryMiddleware
      */
     public static function createDefaultDecider($maxRetries = 3)
     {
-        $guzzleMajorVersion = (string) ClientInterface::VERSION[0];
+        $version = (string) ClientInterface::VERSION;
         return function (
             $retries,
             CommandInterface $command,
             RequestInterface $request,
             ResultInterface $result = null,
             $error = null
-        ) use ($maxRetries, $guzzleMajorVersion) {
+        ) use ($maxRetries, $version) {
             // Allow command-level options to override this value
             $maxRetries = null !== $command['@retries'] ?
                 $command['@retries']
@@ -89,9 +89,9 @@ class RetryMiddleware
                 return true;
             } elseif (($previous = $error->getPrevious())
                 && $previous instanceof ConnectException) {
-                if ($guzzleMajorVersion === '6') {
+                if ($version[0] === '6') {
                     return isset(self::$retryCurlErrors[$previous->getHandlerContext()['errno']]);
-                } elseif ($guzzleMajorVersion === '5') {
+                } elseif ($version[0] === '5') {
                     $message = $previous->getMessage();
                     foreach (array_keys(self::$retryCurlErrors) as $curlError) {
                         if (strpos($message, 'cURL error ' . $curlError . ':') === 0) {

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -88,14 +88,15 @@ class RetryMiddlewareTest extends TestCase
         $decider = RetryMiddleware::createDefaultDecider();
         $command = new Command('foo');
         $request = new Request('GET', 'http://www.example.com');
-        if ((string) ClientInterface::VERSION[0] === '6') {
+        $version = (string) ClientInterface::VERSION;
+        if ($version[0] === '6') {
             $previous = new ConnectException(
                 'test',
                 $request,
                 null,
                 ['errno' => CURLE_RECV_ERROR]
             );
-        } elseif ((string) ClientInterface::VERSION[0] === '5') {
+        } elseif ($version[0] === '5') {
             $previous = new ConnectException(
                 'cURL error ' . CURLE_RECV_ERROR . ': test',
                 new \GuzzleHttp\Message\Request('GET', 'http://www.example.com')


### PR DESCRIPTION
Implements a method to retry `CURLE_*_ERROR` based failures for `AwsExceptions` preceeded by `ConnectExceptions` that do not return true from `->isConnectionError()`.

Resolves #924 

/cc @jeskew 