### PR TITLE
Update `Aws\PhpHash::$context` docblock with `HashContext` type.

### DIFF
--- a/src/PhpHash.php
+++ b/src/PhpHash.php
@@ -1,14 +1,12 @@
 <?php
 namespace Aws;
 
-use HashContext;
-
 /**
  * Incremental hashing using PHP's hash functions.
  */
 class PhpHash implements HashInterface
 {
-    /** @var HashContext */
+    /** @var resource|\HashContext */
     private $context;
 
     /** @var string */
@@ -65,7 +63,7 @@ class PhpHash implements HashInterface
     /**
      * Get a hash context or create one if needed
      *
-     * @return resource
+     * @return resource|\HashContext 
      */
     private function getContext()
     {

--- a/src/PhpHash.php
+++ b/src/PhpHash.php
@@ -1,12 +1,14 @@
 <?php
 namespace Aws;
 
+use HashContext;
+
 /**
  * Incremental hashing using PHP's hash functions.
  */
 class PhpHash implements HashInterface
 {
-    /** @var resource */
+    /** @var HashContext */
     private $context;
 
     /** @var string */


### PR DESCRIPTION
With PHP 7.2, the `hash` extension was updated to use objects instead of resources. See https://secure.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.hash-ext-to-objects .