### PR TITLE
Add AWS_EC2_METADATA_DISABLED Environment Variable

### DIFF
--- a/.changes/nextrelease/env_disable_ec2_metadata_access.json
+++ b/.changes/nextrelease/env_disable_ec2_metadata_access.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "Credentials",
+    "description": "Add support for an AWS_EC2_METADATA_DISABLED environment variable to short-circuit requests for credentials via the InstanceProfileProvider."
+  }
+]

--- a/docs/guide/credentials.rst
+++ b/docs/guide/credentials.rst
@@ -333,6 +333,11 @@ credentials from Amazon EC2 instance profiles.
         'credentials' => $memoizedProvider
     ]);
 
+.. note::
+
+    This attempt to load from Amazon EC2 instance profiles can be disabled by
+    setting the ``AWS_EC2_METADATA_DISABLED`` environment variable to ``true``.
+
 ecsCredentials provider
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -15,6 +15,8 @@ class InstanceProfileProvider
     const SERVER_URI = 'http://169.254.169.254/latest/';
     const CRED_PATH = 'meta-data/iam/security-credentials/';
 
+    const ENV_DISABLE = 'AWS_EC2_METADATA_DISABLED';
+
     /** @var string */
     private $profile;
 
@@ -67,6 +69,13 @@ class InstanceProfileProvider
      */
     private function request($url)
     {
+        $disabled = getenv(self::ENV_DISABLE) ?: false;
+        if (strcasecmp($disabled, 'true') === 0) {
+            throw new CredentialsException(
+                $this->createErrorMessage('EC2 metadata server access disabled')
+            );
+        }
+
         $fn = $this->client;
         $request = new Request('GET', self::SERVER_URI . $url);
 
@@ -77,7 +86,7 @@ class InstanceProfileProvider
                 $reason = $reason['exception'];
                 $msg = $reason->getMessage();
                 throw new CredentialsException(
-                    $this->createErrorMessage($msg, 0, $reason)
+                    $this->createErrorMessage($msg)
                 );
             });
     }


### PR DESCRIPTION
Add support for an `AWS_EC2_METADATA_DISABLED` environment variable to short-circuit requests for credentials via the InstanceProfileProvider.

/cc @cjyclaire 