### PR TITLE
Fix Missing CURLE_RECV_ERROR

### DIFF
--- a/.changes/nextrelease/verify_curl_extension.json
+++ b/.changes/nextrelease/verify_curl_extension.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "RetryMiddleware",
+    "description": "Verify we have the curl extension before retrying on the CURLE_RECV_ERROR curl const."
+  }
+]

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ The GitHub issues are intended for bug reports and feature requests. For help an
 1. **Sign up for AWS** – Before you begin, you need to
    sign up for an AWS account and retrieve your [AWS credentials][docs-signup].
 1. **Minimum requirements** – To run the SDK, your system will need to meet the
-   [minimum requirements][docs-requirements], including having **PHP >= 5.5**
-   compiled with the cURL extension and cURL 7.16.2+ compiled with a TLS
-   backend (e.g., NSS or OpenSSL).
+   [minimum requirements][docs-requirements], including having **PHP >= 5.5**.
+   We highly recommend having it compiled with the cURL extension and cURL
+   7.16.2+ compiled with a TLS backend (e.g., NSS or OpenSSL).
 1. **Install the SDK** – Using [Composer] is the recommended way to install the
    AWS SDK for PHP. The SDK is available via [Packagist] under the
    [`aws/aws-sdk-php`][install-packagist] package. Please see the

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -85,6 +85,9 @@ class RetryMiddlewareTest extends TestCase
 
     public function testDeciderRetriesWhenCurlErrorCodeMatches()
     {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('Test skipped on no cURL extension');
+        }
         $decider = RetryMiddleware::createDefaultDecider();
         $command = new Command('foo');
         $request = new Request('GET', 'http://www.example.com');


### PR DESCRIPTION
Verify we have the `'curl'` extension before retrying on the `CURLE_RECV_ERROR` curl const. Updates README.md language to match `composer.json` and documentation language.

Fixes #1480