### PR TITLE
S3\Transfer::construct(): correct docs

### DIFF
--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -46,10 +46,9 @@ class Transfer implements PromisorInterface
      *   iterator. If the $source option is not an array, then this option is
      *   ignored.
      * - before: (callable) A callback to invoke before each transfer. The
-     *   callback accepts the following positional arguments: string $source,
-     *   string $dest, Aws\CommandInterface $command. The provided command will
-     *   be either a GetObject, PutObject, InitiateMultipartUpload, or
-     *   UploadPart command.
+     *   callback accepts a single argument: Aws\CommandInterface $command.
+     *   The provided command will be either a GetObject, PutObject,
+     *   InitiateMultipartUpload, or UploadPart command.
      * - mup_threshold: (int) Size in bytes in which a multipart upload should
      *   be used instead of PutObject. Defaults to 20971520 (20 MB).
      * - concurrency: (int, default=5) Number of files to upload concurrently.


### PR DESCRIPTION
The docs didn't match the implementation, adjust the docs to be
correct.

It's been this way since 2015 -- 74f8c50c0bde2ef8d8ec57b195c4a20857056f9f