### PR TITLE
Signer Unquoted Integers Fix

### DIFF
--- a/.changes/nextrelease/signer_int_fix.json
+++ b/.changes/nextrelease/signer_int_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "CloudFront",
+    "description": "Updates the `Signer` to force expire timestamps to match CloudFront required unquoted integers."
+  }
+]

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -66,6 +66,7 @@ class Signer
             $policy = preg_replace('/\s/s', '', $policy);
             $signatureHash['Policy'] = $this->encode($policy);
         } elseif ($resource && $expires) {
+            $expires = (int) $expires; // Handle epoch passed as string
             $policy = $this->createCannedPolicy($resource, $expires);
             $signatureHash['Expires'] = $expires;
         } else {

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -52,11 +52,27 @@ class SignerTest extends TestCase
         $this->assertArrayHasKey('Key-Pair-Id', $signature);
     }
 
-    public function testReturnsExpiresForCannedPolicies()
+    public function getExpiresCases()
     {
-        $signature = $this->instance->getSignature('test.mp4', time() + 1000);
+        return [
+            [
+                time() + 1000
+            ],
+            [
+                (string) (time() + 1000)
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getExpiresCases
+     */
+    public function testReturnsExpiresForCannedPolicies($expires)
+    {
+        $signature = $this->instance->getSignature('test.mp4', $expires);
 
         $this->assertArrayHasKey('Expires', $signature);
+        $this->assertInternalType('int', $signature['Expires']);
     }
 
     public function testReturnsPolicyForCustomPolicies()

--- a/tests/CloudFront/UrlSignerTest.php
+++ b/tests/CloudFront/UrlSignerTest.php
@@ -127,7 +127,7 @@ class UrlSignerTest extends TestCase
     public function testEnsuresUriSchemeIsValid()
     {
         $s = new UrlSigner('a', $_SERVER['CF_PRIVATE_KEY']);
-        $s->getSignedUrl('foo://bar.com', '+10 minutes');
+        $s->getSignedUrl('foo://bar.com', strtotime('+10 minutes'));
     }
 
     /**


### PR DESCRIPTION
Updates the `Signer` to force expire timestamps to match CloudFront required unquoted integers.

Fixes #1499 