### PR TITLE
CURLE_RECV_ERROR  error retry fixed

### DIFF
--- a/.changes/nextrelease/fix_curl_retry.json
+++ b/.changes/nextrelease/fix_curl_retry.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "RetryMiddleware",
+    "description": "Retry the CURLE_RECV_ERROR error."
+  }
+]

--- a/.changes/nextrelease/fix_curl_retry.json
+++ b/.changes/nextrelease/fix_curl_retry.json
@@ -2,6 +2,6 @@
   {
     "type": "bugfix",
     "category": "RetryMiddleware",
-    "description": "Retry the CURLE_RECV_ERROR error."
+    "description": "Retries CURLE_RECV_ERROR on all RequestException, not just ConnectException."
   }
 ]

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -4,7 +4,6 @@ namespace Aws;
 use Aws\Exception\AwsException;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise;
 

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -2,7 +2,7 @@
 namespace Aws;
 
 use Aws\Exception\AwsException;
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -101,7 +101,7 @@ class RetryMiddleware
 
             if (count($retryCurlErrors)
                 && ($previous = $error->getPrevious())
-                && $previous instanceof ConnectException
+                && $previous instanceof RequestException
             ) {
                 if (method_exists($previous, 'getHandlerContext')) {
                     return isset($retryCurlErrors[$previous->getHandlerContext()['errno']]);

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -8,7 +8,7 @@ use Aws\MockHandler;
 use Aws\Result;
 use Aws\RetryMiddleware;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -93,14 +93,15 @@ class RetryMiddlewareTest extends TestCase
         $request = new Request('GET', 'http://www.example.com');
         $version = (string) ClientInterface::VERSION;
         if ($version[0] === '6') {
-            $previous = new ConnectException(
+            $previous = new RequestException(
                 'test',
                 $request,
+                null,
                 null,
                 ['errno' => CURLE_RECV_ERROR]
             );
         } elseif ($version[0] === '5') {
-            $previous = new ConnectException(
+            $previous = new RequestException(
                 'cURL error ' . CURLE_RECV_ERROR . ': test',
                 new \GuzzleHttp\Message\Request('GET', 'http://www.example.com')
             );


### PR DESCRIPTION
Hello,
we have upgraded to the latest AWS SDK because the retry of `CURLE_RECV_ERROR` was fixed in https://github.com/aws/aws-sdk-php/releases/tag/3.52.0

Unfortunately after deploy of the new application version with updated AWS SDK we are still receiving occasional `CURLE_RECV_ERROR` errors.

I've tried to debug a code and I've noticed that `GuzzleHttp\Exception\ConnectException` exception is expected in AWS SDK https://github.com/aws/aws-sdk-php/blob/299ac47ff5171d6a25f788dc333c0a3c8db40f69/src/RetryMiddleware.php#L104 but `GuzzleHttp\Exception\RequestException` is  thrown in Guzzle https://github.com/guzzle/guzzle/blob/748d67e23a984e7a2562847994fd133fd4e629a6/src/Handler/CurlFactory.php#L154 . 
So I think that `CURLE_RECV_ERROR` is never retried. 
This PR should fix it.

thanks

