### PR TITLE
Preceding Slash Signing Fix

### DIFF
--- a/.changes/nextrelease/preceding_slash_signing_fix.json
+++ b/.changes/nextrelease/preceding_slash_signing_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3/S3SignatureV4",
+    "description": "Fixes an issue that would strip a preceding slash from a key during the signing process on virtual host style pathing, resulting in an invalid signature."
+  }
+]

--- a/src/Signature/S3SignatureV4.php
+++ b/src/Signature/S3SignatureV4.php
@@ -59,6 +59,10 @@ class S3SignatureV4 extends SignatureV4
      */
     protected function createCanonicalizedPath($path)
     {
-        return '/' . ltrim($path, '/');
+        // Only remove one slash in case of keys that have a preceding slash
+        if (substr($path, 0, 1) === '/') {
+            $path = substr($path, 1);
+        }
+        return '/' . $path;
     }
 }

--- a/tests/Signature/S3SignatureV4Test.php
+++ b/tests/Signature/S3SignatureV4Test.php
@@ -65,6 +65,23 @@ class S3SignatureV4Test extends TestCase
         );
     }
 
+    public function testDoesNotRemoveMultiplePrecedingSlashes()
+    {
+        list($request, $credentials, $signature) = $this->getFixtures();
+        $uri = $request->getUri()->withPath('//foo');
+        $request = $request->withUri($uri);
+        $p = new \ReflectionMethod($signature, 'parseRequest');
+        $p->setAccessible(true);
+        $parsed = $p->invoke($signature, $request);
+        $meth = new \ReflectionMethod($signature, 'createContext');
+        $meth->setAccessible(true);
+        $ctx = $meth->invoke($signature, $parsed, 'foo');
+        $this->assertStringStartsWith(
+            "GET\n//foo",
+            $ctx['creq']
+        );
+    }
+
     public function testCreatesPresignedDatesFromDateTime()
     {
         list($request, $credentials, $signature) = $this->getFixtures();


### PR DESCRIPTION
Fixes an issue that would strip a preceding slash from a key during the signing process on virtual host style pathing, resulting in an invalid signature.

Fixes #1507 

/cc @jeskew 