### PR TITLE
Signatures to be generated from any \DateTimeInterface

### DIFF
--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -292,7 +292,7 @@ class SignatureV4 implements SignatureInterface
 
     private function convertToTimestamp($dateValue, $relativeTimeBase = null)
     {
-        if ($dateValue instanceof \DateTime) {
+        if ($dateValue instanceof \DateTimeInterface) {
             $timestamp = $dateValue->getTimestamp();
         } elseif (!is_numeric($dateValue)) {
             $timestamp = strtotime($dateValue,


### PR DESCRIPTION
Added the ability for signatures to be generated off of `\DateTimeInterface` objects that are not based on `\DateTime`.

Resolves #1513 