### PR TITLE
Add support for presigning additional headers

### DIFF
--- a/.changes/nextrelease/presign_additional_headers.json
+++ b/.changes/nextrelease/presign_additional_headers.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "SignatureV4",
+    "description": "Add support for pre-signing additional headers"
+  }
+]

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -15,6 +15,7 @@ class SignatureV4 implements SignatureInterface
     use SignatureTrait;
     const ISO8601_BASIC = 'Ymd\THis\Z';
     const UNSIGNED_PAYLOAD = 'UNSIGNED-PAYLOAD';
+    const AMZ_CONTENT_SHA256_HEADER = 'X-Amz-Content-Sha256';
 
     /** @var string */
     private $service;
@@ -24,6 +25,41 @@ class SignatureV4 implements SignatureInterface
 
     /** @var bool */
     private $unsigned;
+
+    /**
+     * The following headers are not signed because signing these headers
+     * would potentially cause a signature mismatch when sending a request
+     * through a proxy or if modified at the HTTP client level.
+     *
+     * @return array
+     */
+    private function getHeaderBlacklist()
+    {
+        return [
+            'cache-control'         => true,
+            'content-type'          => true,
+            'content-length'        => true,
+            'expect'                => true,
+            'max-forwards'          => true,
+            'pragma'                => true,
+            'range'                 => true,
+            'te'                    => true,
+            'if-match'              => true,
+            'if-none-match'         => true,
+            'if-modified-since'     => true,
+            'if-unmodified-since'   => true,
+            'if-range'              => true,
+            'accept'                => true,
+            'authorization'         => true,
+            'proxy-authorization'   => true,
+            'from'                  => true,
+            'referer'               => true,
+            'user-agent'            => true,
+            'x-amzn-trace-id'       => true,
+            'aws-sdk-invocation-id' => true,
+            'aws-sdk-retry'         => true,
+        ];
+    }
 
     /**
      * @param string $service Service name to use when signing
@@ -55,7 +91,7 @@ class SignatureV4 implements SignatureInterface
         $payload = $this->getPayload($request);
 
         if ($payload == self::UNSIGNED_PAYLOAD) {
-            $parsed['headers']['X-Amz-Content-Sha256'] = [$payload];
+            $parsed['headers'][self::AMZ_CONTENT_SHA256_HEADER] = [$payload];
         }
 
         $context = $this->createContext($parsed, $payload);
@@ -76,6 +112,26 @@ class SignatureV4 implements SignatureInterface
         return $this->buildRequest($parsed);
     }
 
+    /**
+     * Get the headers that were used to pre-sign the request.
+     * Used for the X-Amz-SignedHeaders header.
+     *
+     * @param array $headers
+     * @return array
+     */
+    private function getPresignHeaders(array $headers)
+    {
+        $presignHeaders = [];
+        $blacklist = $this->getHeaderBlacklist();
+        foreach ($headers as $name => $value) {
+            $lName = strtolower($name);
+            if (!isset($blacklist[$lName]) && $name !== self::AMZ_CONTENT_SHA256_HEADER) {
+                $presignHeaders[] = $lName;
+            }
+        }
+        return $presignHeaders;
+    }
+
     public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
@@ -86,7 +142,7 @@ class SignatureV4 implements SignatureInterface
         $startTimestamp = isset($options['start_time'])
                             ? $this->convertToTimestamp($options['start_time'], null)
                             : time();
-        
+
         $expiresTimestamp = $this->convertToTimestamp($expires, $startTimestamp);
 
         $parsed = $this->createPresignedRequest($request, $credentials);
@@ -98,7 +154,7 @@ class SignatureV4 implements SignatureInterface
         $parsed['query']['X-Amz-Algorithm'] = 'AWS4-HMAC-SHA256';
         $parsed['query']['X-Amz-Credential'] = $credential;
         $parsed['query']['X-Amz-Date'] = gmdate('Ymd\THis\Z', $startTimestamp);
-        $parsed['query']['X-Amz-SignedHeaders'] = 'host';
+        $parsed['query']['X-Amz-SignedHeaders'] = join(';', $this->getPresignHeaders($parsed['headers']));
         $parsed['query']['X-Amz-Expires'] = $this->convertExpires($expiresTimestamp, $startTimestamp);
         $context = $this->createContext($parsed, $payload);
         $stringToSign = $this->createStringToSign($httpDate, $scope, $context['creq']);
@@ -151,9 +207,9 @@ class SignatureV4 implements SignatureInterface
             return self::UNSIGNED_PAYLOAD;
         }
         // Calculate the request signature payload
-        if ($request->hasHeader('X-Amz-Content-Sha256')) {
+        if ($request->hasHeader(self::AMZ_CONTENT_SHA256_HEADER)) {
             // Handle streaming operations (e.g. Glacier.UploadArchive)
-            return $request->getHeaderLine('X-Amz-Content-Sha256');
+            return $request->getHeaderLine(self::AMZ_CONTENT_SHA256_HEADER);
         }
 
         if (!$request->getBody()->isSeekable()) {
@@ -207,31 +263,7 @@ class SignatureV4 implements SignatureInterface
      */
     private function createContext(array $parsedRequest, $payload)
     {
-        // The following headers are not signed because signing these headers
-        // would potentially cause a signature mismatch when sending a request
-        // through a proxy or if modified at the HTTP client level.
-        static $blacklist = [
-            'cache-control'       => true,
-            'content-type'        => true,
-            'content-length'      => true,
-            'expect'              => true,
-            'max-forwards'        => true,
-            'pragma'              => true,
-            'range'               => true,
-            'te'                  => true,
-            'if-match'            => true,
-            'if-none-match'       => true,
-            'if-modified-since'   => true,
-            'if-unmodified-since' => true,
-            'if-range'            => true,
-            'accept'              => true,
-            'authorization'       => true,
-            'proxy-authorization' => true,
-            'from'                => true,
-            'referer'             => true,
-            'user-agent'          => true,
-            'x-amzn-trace-id'     => true
-        ];
+        $blacklist = $this->getHeaderBlacklist();
 
         // Normalize the path as required by SigV4
         $canon = $parsedRequest['method'] . "\n"
@@ -326,7 +358,8 @@ class SignatureV4 implements SignatureInterface
             if (substr($lname, 0, 5) == 'x-amz') {
                 $parsedRequest['query'][$name] = $header;
             }
-            if ($lname !== 'host') {
+            $blacklist = $this->getHeaderBlacklist();
+            if (isset($blacklist[$lname]) || $lname === strtolower(self::AMZ_CONTENT_SHA256_HEADER)) {
                 unset($parsedRequest['headers'][$name]);
             }
         }


### PR DESCRIPTION
**At the moment, when pre-signing a request to S3, only the "Host" header is signed and included in the `X-Amz-SignedHeaders` header. This change proposes updating the method for which headers are included into the signature process so that more than the "Host" header is included.**

Headers are excluded using the existing blacklist.

Signing of additional headers is already supported by other AWS SDKs, such as the Go SDK - https://github.com/aws/aws-sdk-go

See below example using aws-sdk-go:

```go
req, _ := s3Client.PutObjectRequest(&s3.PutObjectInput{
        Bucket: aws.String("mybucket"),
        Key: aws.String("mykey"),
        ACL: aws.String("public-read"),
        Metadata: map[string]*string {
                "foo": aws.String("bar"),
        },
})
 
url, err := req.Presign(5 * time.Minute)
if err != nil {
        panic(err)
}

fmt.Println(url)
```

**Output:**

`https://mybucket.s3.ap-southeast-2.amazonaws.com/mykey?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIDEXAMPLE%2F20180403%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=20180403T131258Z&X-Amz-Expires=300&X-Amz-SignedHeaders=host%3Bx-amz-acl%3Bx-amz-meta-foo&X-Amz-Signature=c31d01fedf4d53acfcc9ef154740cba775eeed31639296ea9ca7776c20524c86`

Note the `X-Amz-SignedHeaders=host%3Bx-amz-acl%3Bx-amz-meta-foo` header which includes the ACL and metadata we specified.

**The following is the equivalent for aws-sdk-php output:**

 `https://mybucket.s3.ap-southeast-2.amazonaws.com/mykey?x-amz-meta-foo=bar&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a%2F13862016%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=1386201600&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Signature=8f473c349ef9c38ba157e583720c47de965e390db314da581434bfc206ac1fd6`

Note the `X-Amz-SignedHeaders=host` header which only signed the host header.

**The proposed changes will return the following URL for the equivalent input:**

`https://mybucket.s3.ap-southeast-2.amazonaws.com/mykey?x-amz-meta-foo=bar&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a%2F13862016%2Fap-southeast-2%2Fs3%2Faws4_request&X-Amz-Date=1386201600&X-Amz-SignedHeaders=host%3Bx-amz-meta-foo%3Bx-amz-acl&X-Amz-Expires=300&X-Amz-Signature=af7a21e2bf40ef47827d39a3f9224616d22bd0eb938ddbead9ca9e76b2a333c4`