### PR TITLE
Consistent Result class casing for docblocks

### DIFF
--- a/.changes/nextrelease
+++ b/.changes/nextrelease
@@ -1,0 +1,7 @@
+[
+	{
+		"type": "enhancement",
+		"category": "",
+		"description": "Fixes docblock @param tags to reference Result class with a consistent case"
+	}
+]

--- a/src/Waiter.php
+++ b/src/Waiter.php
@@ -175,7 +175,7 @@ class Waiter implements PromisorInterface
     }
 
     /**
-     * @param result $result   Result or exception.
+     * @param Result $result   Result or exception.
      * @param array  $acceptor Acceptor configuration being checked.
      *
      * @return bool
@@ -188,7 +188,7 @@ class Waiter implements PromisorInterface
     }
 
     /**
-     * @param result $result   Result or exception.
+     * @param Result $result   Result or exception.
      * @param array  $acceptor Acceptor configuration being checked.
      *
      * @return bool
@@ -210,7 +210,7 @@ class Waiter implements PromisorInterface
     }
 
     /**
-     * @param result $result   Result or exception.
+     * @param Result $result   Result or exception.
      * @param array  $acceptor Acceptor configuration being checked.
      *
      * @return bool
@@ -232,7 +232,7 @@ class Waiter implements PromisorInterface
     }
 
     /**
-     * @param result $result   Result or exception.
+     * @param Result $result   Result or exception.
      * @param array  $acceptor Acceptor configuration being checked.
      *
      * @return bool
@@ -251,7 +251,7 @@ class Waiter implements PromisorInterface
     }
 
     /**
-     * @param result $result   Result or exception.
+     * @param Result $result   Result or exception.
      * @param array  $acceptor Acceptor configuration being checked.
      *
      * @return bool


### PR DESCRIPTION
Fixes docblock `@param` tags to reference Result class with a consistent case.
This did not affect any functionality, but confused static analyzers (see vimeo/psalm#673)