### PR TITLE
Status Code Checking in Smoke/Integ Tests

### DIFF
--- a/.changes/nextrelease/update_ecs_smoke_test.json
+++ b/.changes/nextrelease/update_ecs_smoke_test.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "Test\\Integ",
+    "description": "Adds the ability for Integ/Smoke tests to check status codes. Updates ECS Handling errors to use a status code check."
+  }
+]

--- a/features/smoke/ecs.feature
+++ b/features/smoke/ecs.feature
@@ -11,4 +11,4 @@ Feature: Amazon ECS
   Scenario: Handling errors
     When I attempt to call the "StopTask" API with:
     | task  | xxxxxxxxxxx-xxxxxxxxxxxx-xxxxxxxxxxx  |
-    Then the error code should be "ClientException"
+    Then the status code should be "400"

--- a/tests/Integ/SmokeContext.php
+++ b/tests/Integ/SmokeContext.php
@@ -416,4 +416,14 @@ class SmokeContext extends PHPUnit_Framework_Assert implements
     {
         $this->assertContains($string->getRaw(), $this->error->getMessage());
     }
+
+    /**
+     * @Then the status code should be :statusCode
+     *
+     * @param string $statusCode
+     */
+    public function theStatusCodeShouldBe($statusCode)
+    {
+        $this->assertEquals($statusCode, $this->error->getStatusCode());
+    }
 }


### PR DESCRIPTION
Adds the ability for Integ/Smoke tests to check status codes. Updates ECS Handling errors to use a status code check.