### PR TITLE
S3Context Validation Fix

### DIFF
--- a/tests/Integ/S3Context.php
+++ b/tests/Integ/S3Context.php
@@ -128,7 +128,11 @@ class S3Context implements Context, SnippetAcceptingContext
      */
     public function theContentsAtThePresignedUrlShouldBe($body)
     {
-        Assert::assertStringEqualsFile($this->presignedRequest->getUri(), $body);
+        // Not using assertStringFileEquals here due to issues with remote files
+        Assert::assertEquals(
+            $body,
+            file_get_contents($this->presignedRequest->getUri())
+        );
     }
 
     /**


### PR DESCRIPTION
Move an `assertStringFileEquals` to an `assertEquals` due to underlying changes that broke the validation.