### PR TITLE
High memory consumption fix when deleting >1 million files from S3

### DIFF
--- a/src/Aws/S3/Model/ClearBucket.php
+++ b/src/Aws/S3/Model/ClearBucket.php
@@ -162,13 +162,13 @@ class ClearBucket extends AbstractHasDispatcher
 
         $deleted = 0;
         // Original implementation for file deletion first creates array of ALL 
-		// objects in the bucket (that matches defined prefix) and then starts 
-		// sending batch delete reqests with 1000 files per reqest.
-		// Loading array with all files increases memory consumption so
-		// deletion of 1 million files with 2GB RAM instance (t2.small) was impossible.
-		// Fix for that is to flush requests manually after every 10k files 
-		// which will clear array and won't increase memory consumption further.
-		$filesToDelete = 0;
+        // objects in the bucket (that matches defined prefix) and then starts 
+        // sending batch delete reqests with 1000 files per reqest.
+        // Loading array with all files increases memory consumption so
+        // deletion of 1 million files with 2GB RAM instance (t2.small) was impossible.
+        // Fix for that is to flush requests manually after every 10k files 
+        // which will clear array and won't increase memory consumption further.
+        $filesToDelete = 0;
         foreach ($this->getIterator() as $object) {
             if (isset($object['VersionId'])) {
                 $versionId = $object['VersionId'] == 'null' ? null : $object['VersionId'];
@@ -178,10 +178,10 @@ class ClearBucket extends AbstractHasDispatcher
             $batch->addKey($object['Key'], $versionId);
             $deleted++;
             $filesToDelete++;
-			if ($filesToDelete === 10000) {
-				$batch->flush();
-				$filesToDelete = 0;
-			}
+            if ($filesToDelete === 10000) {
+                $batch->flush();
+                $filesToDelete = 0;
+            }
         }
         $batch->flush();
 


### PR DESCRIPTION
Using ClearBucket class to delete over 1 million of files from one part of the S3 bucket (not clearing the whole bucket) was leading into memory exception. 

Going through the original implementation I found out that it creates an array of ALL objects in the bucket (that matches defined prefix) and only after retrieving all objects it starts sending batch delete requests with 1000 files per request. Loading an array with all files was increasing memory consumption and deletion of 1 million files with 2GB RAM instance (t2.small) was impossible.
Fix for that is to flush requests manually after every 10k files which will clear the array and won't increase memory consumption further. After deleting 1.4 million files memory consumption didn't go above 300mb.