### PR TITLE
Sort 'Service APIs' by namespace

### DIFF
--- a/build/docs/classes/DocsBuilder.php
+++ b/build/docs/classes/DocsBuilder.php
@@ -119,7 +119,11 @@ class DocsBuilder
             }
         }
 
-        ksort($services, SORT_NATURAL | SORT_FLAG_CASE);
+        uasort($services, function($a, $b) {
+            $serviceA = current($a);
+            $serviceB = current($b);
+            return strcasecmp($serviceA->namespace, $serviceB->namespace);
+        });
         $this->updateHomepage($services);
         $this->updateClients($services);
         $this->updateAliases($services, $aliases);


### PR DESCRIPTION
Update sorting for Service APIs to be sorted by namespace, like the sidebar.

Resolves #1539 

No changelog document because it doesn't affect the SDK itself.