### PR TITLE
Add ini parse directive

### DIFF
--- a/.changes/nextrelease/ini_scanner_raw_update.json
+++ b/.changes/nextrelease/ini_scanner_raw_update.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "Credentials",
+    "description": "Update ini parsing to handle unquoted components that contain equals signs."
+  }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -289,7 +289,7 @@ class CredentialProvider
             if (!is_readable($filename)) {
                 return self::reject("Cannot read credentials from $filename");
             }
-            $data = parse_ini_file($filename, true);
+            $data = parse_ini_file($filename, true, INI_SCANNER_RAW);
             if ($data === false) {
                 return self::reject("Invalid credentials file: $filename");
             }

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -170,6 +170,7 @@ class CredentialProviderTest extends TestCase
     public function iniFileProvider()
     {
         $credentials = new Credentials('foo', 'bar', 'baz');
+        $credentialsWithEquals = new Credentials('foo', 'bar', 'baz=');
         $standardIni = <<<EOT
 [default]
 aws_access_key_id = foo
@@ -189,11 +190,25 @@ aws_secret_access_key = bar
 aws_session_token = baz
 aws_security_token = fizz
 EOT;
+        $standardWithEqualsIni = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = bar
+aws_session_token = baz=
+EOT;
+        $standardWithEqualsQuotedIni = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = bar
+aws_session_token = "baz="
+EOT;
 
         return [
             [$standardIni, $credentials],
             [$oldIni, $credentials],
             [$mixedIni, $credentials],
+            [$standardWithEqualsIni, $credentialsWithEquals],
+            [$standardWithEqualsQuotedIni, $credentialsWithEquals],
         ];
     }
 


### PR DESCRIPTION
Update`::ini` parsing to handle unquoted components that contain equals signs.

Fixes #1526
Closes #1563