### PR TITLE
`'X-Amz-Security-Token'` Presign Fix

### DIFF
--- a/.changes/nextrelease/security_token_header_fix.json
+++ b/.changes/nextrelease/security_token_header_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Signature\\SignatureV4",
+    "description": "Updates the SignatureV4 presigning process to not sign, and subsequently require on use, the X-Amz-Security-Token header when it's already signed in the query string."
+  }
+]

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -153,6 +153,9 @@ class SignatureV4 implements SignatureInterface
         $shortDate = substr($httpDate, 0, 8);
         $scope = $this->createScope($shortDate, $this->region, $this->service);
         $credential = $credentials->getAccessKeyId() . '/' . $scope;
+        if ($credentials->getSecurityToken()) {
+            unset($parsed['headers']['X-Amz-Security-Token']);
+        }
         $parsed['query']['X-Amz-Algorithm'] = 'AWS4-HMAC-SHA256';
         $parsed['query']['X-Amz-Credential'] = $credential;
         $parsed['query']['X-Amz-Date'] = gmdate('Ymd\THis\Z', $startTimestamp);

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -156,7 +156,9 @@ class SignatureV4Test extends TestCase
         $_SERVER['override_v4_time'] = true;
         list($request, $credentials, $signature) = $this->getFixtures();
         $credentials = new Credentials('foo', 'bar', '123');
-        $url = (string) $signature->presign($request, $credentials, 1386720000)->getUri();
+        $request = $signature->presign($request, $credentials, 1386720000);
+        $this->assertEmpty($request->getHeader('X-Amz-Security-Token'));
+        $url = (string) $request->getUri();
         $this->assertContains('X-Amz-Security-Token=123', $url);
         $this->assertContains('X-Amz-Expires=518400', $url);
     }


### PR DESCRIPTION
Updates the `SignatureV4` presigning process to not sign, and subsequently require on use, the `'X-Amz-Security-Token'` header when it's already signed in the query string.

Fixes #1609 