### PR TITLE
Json serialisation bugfix

### DIFF
--- a/.changes/nextrelease/jsonSerialisationBugfix.json
+++ b/.changes/nextrelease/jsonSerialisationBugfix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Api/Serializer",
+    "description": "Fix to correctly format 'structure' options into JSON, when they have no valid values."
+  }
+]

--- a/src/Api/Serializer/JsonBody.php
+++ b/src/Api/Serializer/JsonBody.php
@@ -50,9 +50,6 @@ class JsonBody
     {
         switch ($shape['type']) {
             case 'structure':
-                if (empty($value)) {
-                    return new \stdClass;
-                }
                 $data = [];
                 foreach ($value as $k => $v) {
                     if ($v !== null && $shape->hasMember($k)) {
@@ -60,6 +57,9 @@ class JsonBody
                         $data[$valueShape['locationName'] ?: $k]
                             = $this->format($valueShape, $v);
                     }
+                }
+                if (empty($data)) {
+                    return new \stdClass;
                 }
                 return $data;
 

--- a/src/Api/Serializer/JsonBody.php
+++ b/src/Api/Serializer/JsonBody.php
@@ -50,6 +50,9 @@ class JsonBody
     {
         switch ($shape['type']) {
             case 'structure':
+                if (empty($value)) {
+                    return new \stdClass;
+                }
                 $data = [];
                 foreach ($value as $k => $v) {
                     if ($v !== null && $shape->hasMember($k)) {

--- a/tests/Api/Serializer/JsonBodyTest.php
+++ b/tests/Api/Serializer/JsonBodyTest.php
@@ -117,6 +117,32 @@ class JsonBodyTest extends TestCase
                 ['foo' => 1397259637],
                 '{"foo":1397259637}'
             ],
+            // Formats nested structures, maps and lists which have no elements
+            [
+                [
+                    'type' => 'structure',
+                    'members' => [
+                        'foo' => [
+                            'type' => 'structure',
+                            'members' => [
+                                'bar' => [
+                                    'type' => 'String'
+                                ]
+                            ]
+                        ],
+                        'baz' => [
+                            'type' => 'map',
+                            'value' => ['type' => 'String']
+                        ],
+                        'foz' => [
+                            'type' => 'list',
+                            'member' => ['type' => 'string']
+                        ]
+                    ]
+                ],
+                ['foo' => [], 'baz' => [], 'foz' => []],
+                '{"foo":{},"baz":{},"foz":[]}'
+            ]
         ];
     }
 

--- a/tests/Api/Serializer/JsonBodyTest.php
+++ b/tests/Api/Serializer/JsonBodyTest.php
@@ -126,13 +126,13 @@ class JsonBodyTest extends TestCase
                             'type' => 'structure',
                             'members' => [
                                 'bar' => [
-                                    'type' => 'String'
+                                    'type' => 'string'
                                 ]
                             ]
                         ],
                         'baz' => [
                             'type' => 'map',
-                            'value' => ['type' => 'String']
+                            'value' => ['type' => 'string']
                         ],
                         'foz' => [
                             'type' => 'list',
@@ -142,7 +142,25 @@ class JsonBodyTest extends TestCase
                 ],
                 ['foo' => [], 'baz' => [], 'foz' => []],
                 '{"foo":{},"baz":{},"foz":[]}'
-            ]
+            ],
+            // Formats nested structures which have invalid elements
+            [
+                [
+                    'type' => 'structure',
+                    'members' => [
+                        'foo' => [
+                            'type' => 'structure',
+                            'members' => [
+                                'bar' => [
+                                    'type' => 'string'
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                ['foo' => ['baz' => 'is not a valid member']],
+                '{"foo":{}}'
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix to correctly format 'structure' options into JSON, when they have no valid values.

Fixes #1638 