### PR TITLE
Remove requirement of always available extension

### DIFF
--- a/.changes/nextrelease/spl-extension
+++ b/.changes/nextrelease/spl-extension
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Aws",
+        "description": "Remove requirement of the always available SPL extension in composer.json."
+    }
+]

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "mtdowling/jmespath.php": "~2.2",
         "ext-pcre": "*",
         "ext-json": "*",
-        "ext-simplexml": "*",
-        "ext-spl": "*"
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "ext-openssl": "*",


### PR DESCRIPTION
Since PHP 5.3.0, the SPL extension is always available and it can not be disabled.

Ref: https://php.net/manual/en/spl.installation.php