### PR TITLE
Avoid repeatedly include same files for variables

### DIFF
--- a/.changes/nextrelease/redundant_includes.json
+++ b/.changes/nextrelease/redundant_includes.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "enhancement",
+      "category": "Functions",
+      "description": "Avoid repeatedly loading compiled JSON."
+    }
+] 

--- a/src/functions.php
+++ b/src/functions.php
@@ -141,9 +141,18 @@ function or_chain()
  */
 function load_compiled_json($path)
 {
+    static $compiledList = [];
+
     $compiledFilepath = "{$path}.php";
-    if (is_readable($compiledFilepath)) {
-        return include($compiledFilepath);
+
+    if(!isset($compiledList[$compiledFilepath])) {
+        if (is_readable($compiledFilepath)) {
+            $compiledList[$compiledFilepath] = include($compiledFilepath);
+        }
+    }
+
+    if (isset($compiledList[$compiledFilepath])) {
+        return $compiledList[$compiledFilepath];
     }
 
     if (!file_exists($path)) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -145,7 +145,7 @@ function load_compiled_json($path)
 
     $compiledFilepath = "{$path}.php";
 
-    if(!isset($compiledList[$compiledFilepath])) {
+    if (!isset($compiledList[$compiledFilepath])) {
         if (is_readable($compiledFilepath)) {
             $compiledList[$compiledFilepath] = include($compiledFilepath);
         }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -83,7 +83,13 @@ class FunctionsTest extends TestCase
     {
         $soughtData = ['foo' => 'bar'];
         $jsonPath = sys_get_temp_dir() . '/some-file-name-' . time() . '.json';
+
+        file_put_contents($jsonPath, json_encode($soughtData), LOCK_EX);
+
+        $this->assertSame($soughtData, Aws\load_compiled_json($jsonPath));
+
         file_put_contents($jsonPath, 'INVALID JSON', LOCK_EX);
+
         file_put_contents(
             "$jsonPath.php",
             '<?php return ' . var_export($soughtData, true) . ';',

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -100,6 +100,38 @@ class FunctionsTest extends TestCase
     }
 
     /**
+     * @covers Aws\load_compiled_json()
+     */
+    public function testOnlyLoadsCompiledJsonOnce()
+    {
+        $soughtData = ['foo' => 'bar'];
+        $jsonPath = sys_get_temp_dir() . '/some-file-name-' . time() . '.json';
+
+        file_put_contents($jsonPath, json_encode($soughtData), LOCK_EX);
+
+        $this->assertSame($soughtData, Aws\load_compiled_json($jsonPath));
+        $jsonAtime = fileatime($jsonPath);
+
+        file_put_contents($jsonPath, 'INVALID JSON', LOCK_EX);
+
+        $compiledPath = "{$jsonPath}.php";
+        file_put_contents(
+            $compiledPath,
+            '<?php return ' . var_export($soughtData, true) . ';',
+            LOCK_EX
+        );
+
+        $this->assertSame($soughtData, Aws\load_compiled_json($jsonPath));
+        $compiledAtime = fileatime($compiledPath);
+
+        sleep(1);
+        clearstatcache();
+        $this->assertSame($soughtData, Aws\load_compiled_json($jsonPath));
+        $this->assertEquals($jsonAtime, fileatime($jsonPath));
+        $this->assertEquals($compiledAtime, fileatime($compiledPath));
+    }
+
+    /**
      * @covers Aws\filter()
      */
     public function testFilter()


### PR DESCRIPTION
PHP include (require) only release file handles after script stop, use include for variables, may cause "failed to open stream too many open files" error.
I found this problem when I run coverage test, also happen to long running tasks (such as use loop to load sqs without quit script 24/7).