### PR TITLE
Adding SQS FIFO Support

### DIFF
--- a/src/Aws/Sqs/Resources/sqs-2012-11-05.php
+++ b/src/Aws/Sqs/Resources/sqs-2012-11-05.php
@@ -694,6 +694,14 @@ return array (
                     'type' => 'numeric',
                     'location' => 'aws.query',
                 ),
+                'MessageGroupId' => array(
+                    'type' => 'string',
+                    'location' => 'aws.query',
+                ),
+                'MessageDeduplicationId' => array(
+                    'type' => 'string',
+                    'location' => 'aws.query',
+                ),
                 'MessageAttributes' => array(
                     'type' => 'object',
                     'location' => 'aws.query',


### PR DESCRIPTION
The fields MessageGroupId and MessageDeduplicationId are required fields for FIFO SQS queues.