### PR TITLE
Fixes validation on assoc arrays having a 0 index

### DIFF
--- a/.changes/nextrelease/api_validate_assoc_array
+++ b/.changes/nextrelease/api_validate_assoc_array
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Api",
+        "description": "Fixes validation on assoc arrays having a 0 index."
+    }
+]

--- a/src/Api/Validator.php
+++ b/src/Api/Validator.php
@@ -249,20 +249,20 @@ class Validator
 
     private function checkAssociativeArray($value)
     {
-        $assoc = false;
+        $isAssociative = false;
 
         if (is_array($value)) {
-            $i   = 0;
+            $expectedIndex = 0;
             $key = key($value);
 
             do {
-                $assoc = $key !== $i++;
+                $isAssociative = $key !== $expectedIndex++;
                 next($value);
                 $key = key($value);
-            } while (!$assoc && null !== $key);
+            } while (!$isAssociative && null !== $key);
         }
 
-        if (!$assoc) {
+        if (!$isAssociative) {
             $this->addError('must be an associative array. Found '
                 . Aws\describe_type($value));
             return false;

--- a/src/Api/Validator.php
+++ b/src/Api/Validator.php
@@ -249,7 +249,20 @@ class Validator
 
     private function checkAssociativeArray($value)
     {
-        if (!is_array($value) || isset($value[0])) {
+        $assoc = false;
+
+        if (is_array($value)) {
+            $i   = 0;
+            $key = key($value);
+
+            do {
+                $assoc = $key !== $i++;
+                next($value);
+                $key = key($value);
+            } while (!$assoc && null !== $key);
+        }
+
+        if (!$assoc) {
             $this->addError('must be an associative array. Found '
                 . Aws\describe_type($value));
             return false;

--- a/tests/Api/ValidatorTest.php
+++ b/tests/Api/ValidatorTest.php
@@ -160,6 +160,33 @@ class ValidatorTest extends TestCase
                 ['foo' => [1, 3]],
                 "Found 1 error while validating the input provided for the Foo operation:\n[foo] must be an associative array. Found array(2)"
             ],
+            // empty array must validate as an assoc array
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => []],
+                true
+            ],
+            // non-sequential numeric keys must validate as assoc
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => [1, 3, 5 => 5]],
+                true
+            ],
+            // mixed numeric and string keys must validate as assoc
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => [1, 3, 'abc' => '123']],
+                true
+            ],
             [
                 [
                     'type' => 'structure',

--- a/tests/Api/ValidatorTest.php
+++ b/tests/Api/ValidatorTest.php
@@ -169,13 +169,22 @@ class ValidatorTest extends TestCase
                 ['foo' => []],
                 true
             ],
-            // non-sequential numeric keys must validate as assoc
+            // non-contiguous numeric keys must validate as assoc
             [
                 [
                     'type' => 'structure',
                     'members' => ['foo' => ['type' => 'structure']]
                 ],
-                ['foo' => [1, 3, 5 => 5]],
+                ['foo' => [0 => 'foo', 1 => 'bar', 5 => 'baz']],
+                true
+            ],
+            // contiguous, but non-sequential numeric keys must validate as assoc
+            [
+                [
+                    'type' => 'structure',
+                    'members' => ['foo' => ['type' => 'structure']]
+                ],
+                ['foo' => [2 => 'foo', 0 => 'bar', 1 => 'baz']],
                 true
             ],
             // mixed numeric and string keys must validate as assoc


### PR DESCRIPTION
https://github.com/aws/aws-sdk-php/issues/1722


The existing heuristic for determining an assoc array looks only
for the presence of a `0` index.  However to correctly determine
whether a php array will be serialized (json) or marshaled (DynamoDB)
into a list (array) or map (assoc), the hueristic must be to check
for sequential integer keys starting at 0.

This change will walk the array checking the key against an incrementing
integer.  at any point where the key does not meet the expected integer
value, the iteration will stop and the array will be considered
associative. (this implementation is similar to the DynamoDB marshaler)

For any array not having a 0 index, this method will return after
the first iteration, so for the shape of the assoc arrays that this
method successfully validated before this change, there will be little
to no performance impact.

the only difference will be for arrays that have a 0 index, which this
method did NOT properly validate previously so there is no baseline
for a performance comparison.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
