### PR TITLE
Fix for anchor links in docs issue

### DIFF
--- a/build/docs/theme/js/main.js
+++ b/build/docs/theme/js/main.js
@@ -158,7 +158,6 @@ $(window).load(function() {
 		var height = $(window).height() - navigationHeight;
 		$left.height(height);
 		$splitter.height(height);
-		$right.height(height);
 	}
 	function setContentWidth()
 	{


### PR DESCRIPTION
* Remove unnecessary height adjustment on the API docs pages script, which combined with the CSS overflow settings causes anchor links to jump back to the top of the page.

Fixes #1729 