### PR TITLE
Iterator test refactor

### DIFF
--- a/.changes/nextrelease/iterator_test_refactor.json
+++ b/.changes/nextrelease/iterator_test_refactor.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Test",
+        "description": "Refactor client iterator tests to use mocked model data."
+    }
+]

--- a/tests/AwsClientTest.php
+++ b/tests/AwsClientTest.php
@@ -152,12 +152,12 @@ class AwsClientTest extends TestCase
         $client = $this->getTestClient('ec2', ['api_provider' => $provider]);
         $data = ['foo', 'bar', 'baz'];
         $this->addMockResults($client, [new Result([
-            'Examples' => $data,
+            'Examples' => [$data, $data],
         ])]);
         $iterator = $client->getIterator('DescribeExamples');
         $this->assertInstanceOf('Traversable', $iterator);
         foreach ($iterator as $iterated) {
-            $this->assertContains($iterated, $data);
+            $this->assertSame($iterated, $data);
         }
     }
 

--- a/tests/AwsClientTest.php
+++ b/tests/AwsClientTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Test;
 
+use Aws\Api\ApiProvider;
 use Aws\Api\ErrorParser\JsonRpcErrorParser;
 use Aws\AwsClient;
 use Aws\CommandInterface;
@@ -137,24 +138,26 @@ class AwsClientTest extends TestCase
 
     public function testCanGetIterator()
     {
-        $client = $this->getTestClient('s3');
+        $provider = ApiProvider::filesystem(__DIR__ . '/fixtures/aws_client_test');
+        $client = $this->getTestClient('ec2', ['api_provider' => $provider]);
         $this->assertInstanceOf(
             'Generator',
-            $client->getIterator('ListObjects', ['Bucket' => 'foobar'])
+            $client->getIterator('DescribePaginatedExamples')
         );
     }
 
-    public function testCanGetIteratorWithoutDefinedPaginator()
+    public function testCanGetIteratorWithoutFullyDefinedPaginator()
     {
-        $client = $this->getTestClient('ec2');
+        $provider = ApiProvider::filesystem(__DIR__ . '/fixtures/aws_client_test');
+        $client = $this->getTestClient('ec2', ['api_provider' => $provider]);
         $data = ['foo', 'bar', 'baz'];
         $this->addMockResults($client, [new Result([
-            'Subnets' => [$data],
+            'Examples' => $data,
         ])]);
-        $iterator = $client->getIterator('DescribeSubnets');
+        $iterator = $client->getIterator('DescribeExamples');
         $this->assertInstanceOf('Traversable', $iterator);
         foreach ($iterator as $iterated) {
-            $this->assertSame($data, $iterated);
+            $this->assertContains($iterated, $data);
         }
     }
 

--- a/tests/fixtures/aws_client_test/ec2/2019-03-04/api-2.json
+++ b/tests/fixtures/aws_client_test/ec2/2019-03-04/api-2.json
@@ -1,0 +1,71 @@
+{
+    "version": "2.0",
+    "metadata": {
+        "apiVersion": "2019-03-04",
+        "endpointPrefix": "ec2",
+        "protocol": "ec2",
+        "serviceAbbreviation": "Test EC2 Service",
+        "serviceFullName": "Test EC2 Service",
+        "serviceId": "EC2",
+        "signatureVersion": "v4",
+        "uid": "ec2-2016-11-15",
+        "xmlNamespace": "http://ec2.amazonaws.com/doc/2016-11-15"
+    },
+    "operations": {
+        "DescribeExamples":{
+            "name":"DescribeExamples",
+            "http":{
+                "method":"POST",
+                "requestUri":"/"
+            },
+            "input":{"shape":"DescribeExamplesRequest"},
+            "output":{"shape":"DescribeExamplesResult"}
+        },
+        "DescribePaginatedExamples":{
+            "name":"DescribePaginatedExamples",
+            "http":{
+                "method":"POST",
+                "requestUri":"/"
+            },
+            "input":{"shape":"DescribePaginatedExamplesRequest"},
+            "output":{"shape":"DescribePaginatedExamplesResult"}
+        }
+    },
+    "shapes": {
+        "DescribeExamplesRequest":{
+            "type":"structure",
+            "members":{}
+        },
+        "DescribeExamplesResult":{
+            "type":"structure",
+            "members":{
+                "Examples":{
+                    "shape":"ExamplesList"
+                }
+            }
+        },
+        "DescribePaginatedExamplesRequest":{
+            "type":"structure",
+            "members":{
+                "MaxResults":{"shape":"MaxResults"},
+                "NextToken":{"shape":"NextToken"}
+            }
+        },
+        "DescribePaginatedExamplesResult":{
+            "type":"structure",
+            "members":{
+                "Examples":{
+                    "shape":"ExamplesList"
+                }
+            }
+        },
+        "ExamplesList":{
+            "type":"list",
+            "member":{
+                "shape":"Example"
+            }
+        },
+        "MaxResults":{"type":"integer"},
+        "NextToken":{"type":"string"}
+    }
+}

--- a/tests/fixtures/aws_client_test/ec2/2019-03-04/paginators-1.json
+++ b/tests/fixtures/aws_client_test/ec2/2019-03-04/paginators-1.json
@@ -1,0 +1,13 @@
+{
+    "pagination": {
+        "DescribeExamples": {
+            "result_key": "Examples"
+        },
+        "DescribePaginatedExamples": {
+            "input_token": "NextToken",
+            "limit_key": "MaxResults",
+            "output_token": "NextToken",
+            "result_key": "Examples"
+        }
+    }
+}


### PR DESCRIPTION
Refactors client iterator tests to use mocked model data instead of actual model data, which is subject to change by the service.