### PR TITLE
S3 stream wrapper write empty files

### DIFF
--- a/.changes/nextrelease/stream_wrapper_fixes.json
+++ b/.changes/nextrelease/stream_wrapper_fixes.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "feature",
+        "category": "S3",
+        "description": "Updates the S3 stream wrapper to be able to write empty files for PHP 7+."
+    }
+]

--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -94,6 +94,8 @@ class StreamWrapper
     /** @var string The opened protocol (e.g., "s3") */
     private $protocol = 's3';
 
+    private $isFlushed = false;
+
     /**
      * Register the 's3://' stream wrapper
      *
@@ -127,12 +129,16 @@ class StreamWrapper
 
     public function stream_close()
     {
+        if ($this->body->getSize() === 0 && !($this->isFlushed)) {
+            $this->stream_flush();
+        }
         $this->body = $this->cache = null;
     }
 
     public function stream_open($path, $mode, $options, &$opened_path)
     {
         $this->initProtocol($path);
+        $this->isFlushed = false;
         $this->params = $this->getBucketKey($path);
         $this->mode = rtrim($mode, 'bt');
 
@@ -156,6 +162,7 @@ class StreamWrapper
 
     public function stream_flush()
     {
+        $this->isFlushed = true;
         if ($this->mode == 'r') {
             return false;
         }

--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -94,6 +94,7 @@ class StreamWrapper
     /** @var string The opened protocol (e.g., "s3") */
     private $protocol = 's3';
 
+    /** @var bool Keeps track of whether stream has been flushed since opening */
     private $isFlushed = false;
 
     /**


### PR DESCRIPTION
* Updates the S3 stream wrapper to be able to write empty files for PHP 7+

Fixes #1724 