### PR TITLE
CloudFront Signer: parse private key once

### DIFF
--- a/.changes/nextrelease/cloudfront-signer-optimization
+++ b/.changes/nextrelease/cloudfront-signer-optimization
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "CloudFront",
+        "description": "Parse the private key used to sign Cloudfront Urls once during construction instead of on every call to ->sign(). For a 2048bit key, this dropped the signing time from 1.3ms to 0.7ms. For a 1024bit key, the time went from 0.40ms to 0.16ms."
+    }
+]

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -26,6 +26,21 @@ class SignerTest extends TestCase
     }
 
     /**
+     * Assert that the key is parsed during construction
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /PEM .*no start line/
+     */
+    public function testBadPrivateKey() {
+        $filename = tempnam(sys_get_temp_dir(), 'cloudfront-fake-key');
+        file_put_contents($filename, "Not a real private key");
+        $s = new Signer(
+            "not a real keypair id",
+            $filename
+        );
+    }
+
+    /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage PK file not found
      */

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -34,10 +34,14 @@ class SignerTest extends TestCase
     public function testBadPrivateKey() {
         $filename = tempnam(sys_get_temp_dir(), 'cloudfront-fake-key');
         file_put_contents($filename, "Not a real private key");
-        $s = new Signer(
-            "not a real keypair id",
-            $filename
-        );
+        try {
+           $s = new Signer(
+               "not a real keypair id",
+               $filename
+           );
+        } finally {
+           unlink($filename);
+        }
     }
 
     /**


### PR DESCRIPTION
openss_sign() is abysmally slow. On a fast CPU with a small amount of
data it takes 1.5ms of CPU time.

Turns out, half of that was parsing the private key. If we have
openssl parse the key ahead of time, `openssl_sign()` takes half the
time.

This change brought it from 1.5ms to 0.7ms per call, still really
slow but much better.

Note: We started running into performance issues with *lots* of image
urls being rendered on long pages.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
