### PR TITLE
Make Multipart\AbstractUploadManager accept PHP 7+ Throwable as a failure type

### DIFF
--- a/.changes/nextrelease/1755_php_7_throwable_support_abstract_upload_manager.json
+++ b/.changes/nextrelease/1755_php_7_throwable_support_abstract_upload_manager.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Aws\\Multipart",
+        "description": "Updated the coroutine promise catch to type-hint against `Throwable` for PHP 7+ while keeping `Exception` for backwards-compatibility."
+    }
+]

--- a/src/Multipart/AbstractUploadManager.php
+++ b/src/Multipart/AbstractUploadManager.php
@@ -137,13 +137,29 @@ abstract class AbstractUploadManager implements Promise\PromisorInterface
             // Complete the multipart upload.
             yield $this->execCommand('complete', $this->getCompleteParams());
             $this->state->setStatus(UploadState::COMPLETED);
-        })->otherwise(function (\Exception $e) {
-            // Throw errors from the operations as a specific Multipart error.
-            if ($e instanceof AwsException) {
-                $e = new $this->config['exception_class']($this->state, $e);
-            }
-            throw $e;
-        });
+        })->otherwise($this->buildFailureCatch());
+    }
+
+    private function transformException($e)
+    {
+        // Throw errors from the operations as a specific Multipart error.
+        if ($e instanceof AwsException) {
+            $e = new $this->config['exception_class']($this->state, $e);
+        }
+        throw $e;
+    }
+
+    private function buildFailureCatch()
+    {
+        if (interface_exists("Throwable")) {
+            return function (\Throwable $e) {
+                return $this->transformException($e);
+            };
+        } else {
+            return function (\Exception $e) {
+                return $this->transformException($e);
+            };
+        }
     }
 
     protected function getConfig()


### PR DESCRIPTION
Closes #1755
#  ------------------------ >8 ------------------------
# Do not modify or remove the line above.
# Everything below it will be ignored.

Requesting a pull to aws:master from bradynpoulsen:bug/1755_php_7_throwable_support_by_multipart_abstractuploadmanager

Write a message for this pull request. The first block
of text is the title and the rest is the description.