### PR TITLE
Parse ini update

### DIFF
--- a/.changes/nextrelease/parse_ini_hash_comment.json
+++ b/.changes/nextrelease/parse_ini_hash_comment.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "feature",
+        "category": "",
+        "description": "Adds helper function to parse full-line hash comments for credentials and config files, which was removed in PHP 7's implemention of parse_ini_file."
+    }
+]

--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -232,7 +232,7 @@ class ConfigurationProvider
             if (!is_readable($filename)) {
                 return self::reject("Cannot read CSM config from $filename");
             }
-            $data = parse_ini_file($filename, true);
+            $data = \Aws\parse_ini_file($filename, true);
             if ($data === false) {
                 return self::reject("Invalid config file: $filename");
             }

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -294,7 +294,7 @@ class CredentialProvider
             if (!is_readable($filename)) {
                 return self::reject("Cannot read credentials from $filename");
             }
-            $data = parse_ini_file($filename, true, INI_SCANNER_RAW);
+            $data = \Aws\parse_ini_file($filename, true, INI_SCANNER_RAW);
             if ($data === false) {
                 return self::reject("Invalid credentials file: $filename");
             }

--- a/src/EndpointDiscovery/ConfigurationProvider.php
+++ b/src/EndpointDiscovery/ConfigurationProvider.php
@@ -229,7 +229,7 @@ class ConfigurationProvider
             if (!is_readable($filename)) {
                 return self::reject("Cannot read configuration from $filename");
             }
-            $data = parse_ini_file($filename, true);
+            $data = \Aws\parse_ini_file($filename, true);
             if ($data === false) {
                 return self::reject("Invalid config file: $filename");
             }

--- a/src/functions.php
+++ b/src/functions.php
@@ -388,3 +388,24 @@ function is_valid_hostname($hostname)
         && preg_match("/^[^\.]{1,63}(\.[^\.]{0,63})*$/", $hostname)
     );
 }
+
+/**
+ * Ignores '#' full line comments, which parse_ini_file no longer does
+ * in PHP 7+.
+ *
+ * @param $filename
+ * @param bool $process_sections
+ * @param int $scanner_mode
+ * @return array|bool
+ */
+function parse_ini_file(
+    $filename,
+    $process_sections = false,
+    $scanner_mode = INI_SCANNER_NORMAL)
+{
+    return parse_ini_string(
+        preg_replace('/^#.*\\n/m', "", file_get_contents($filename)),
+        $process_sections,
+        $scanner_mode
+    );
+}

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -335,4 +335,64 @@ class FunctionsTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @covers Aws\parse_ini_file()
+     * @dataProvider getIniFileTestCases
+     */
+    public function testParsesIniFile($ini, $expected)
+    {
+        $tmpFile = sys_get_temp_dir() . 'test.ini';
+        file_put_contents($tmpFile, $ini);
+        $this->assertEquals(
+            $expected,
+            Aws\parse_ini_file($tmpFile, true, INI_SCANNER_RAW)
+        );
+        unlink($tmpFile);
+    }
+
+    public function getIniFileTestCases()
+    {
+        return [
+            [
+                <<<EOT
+[default]
+foo_key = bar
+baz_key = qux
+[custom]
+foo_key = bar-custom
+baz_key = qux-custom
+EOT
+                ,
+                [
+                    'default' => [
+                        'foo_key' => 'bar',
+                        'baz_key' => 'qux',
+                    ],
+                    'custom' => [
+                        'foo_key' => 'bar-custom',
+                        'baz_key' => 'qux-custom',
+                    ]
+                ]
+            ],
+            [
+                <<<EOT
+[default]
+;Full-line comment = ignored
+#Full-line comment = ignored
+foo_key = bar;Inline comment = ignored
+baz_key = qux
+*star_key = not_ignored
+EOT
+                ,
+                [
+                    'default' => [
+                        'foo_key' => 'bar',
+                        'baz_key' => 'qux',
+                        '*star_key' => 'not_ignored'
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -342,7 +342,7 @@ class FunctionsTest extends TestCase
      */
     public function testParsesIniFile($ini, $expected)
     {
-        $tmpFile = sys_get_temp_dir() . 'test.ini';
+        $tmpFile = sys_get_temp_dir() . '/test.ini';
         file_put_contents($tmpFile, $ini);
         $this->assertEquals(
             $expected,


### PR DESCRIPTION
* Adds helper function to parse full-line hash comments for credentials and config files, which was removed in PHP 7's implemention of parse_ini_file.

Closes #1754 