### PR TITLE
pass through expect on http config

### DIFF
--- a/.changes/nextrelease/expect-http-config
+++ b/.changes/nextrelease/expect-http-config
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Enables Expect http config to be passed through GuzzleV5 Handler."
+    }
+]

--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -26,14 +26,15 @@ use Psr\Http\Message\StreamInterface as Psr7StreamInterface;
 class GuzzleHandler
 {
     private static $validOptions = [
-        'proxy'           => true,
-        'verify'          => true,
-        'timeout'         => true,
-        'debug'           => true,
-        'connect_timeout' => true,
-        'stream'          => true,
-        'delay'           => true,
-        'sink'            => true,
+        'proxy'             => true,
+        'expect'            => true,
+        'verify'            => true,
+        'timeout'           => true,
+        'debug'             => true,
+        'connect_timeout'   => true,
+        'stream'            => true,
+        'delay'             => true,
+        'sink'              => true,
     ];
 
     /** @var ClientInterface */


### PR DESCRIPTION
Change for #1733 

Allows Expect config option to be passed through to Guzzle: http://docs.guzzlephp.org/en/stable/request-options.html#expect


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
