### PR TITLE
add credential_process provider

### DIFF
--- a/.changes/nextrelease/process_credential_provider.json
+++ b/.changes/nextrelease/process_credential_provider.json
@@ -1,6 +1,6 @@
 [
     {
-        "type": "enhancement",
+        "type": "feature",
         "category": "Credentials",
         "description": "This update adds a process credential provider. Credetentials can be sourced from a command returning json on stdout."
     }

--- a/.changes/nextrelease/process_credential_provider.json
+++ b/.changes/nextrelease/process_credential_provider.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Credentials",
+        "description": "This update adds a process credential provider. Credetentials can be sourced from a command returning json on stdout."
+    }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -360,7 +360,7 @@ class CredentialProvider
             }
 
             $credential_process = $data[$profile]['credential_process'];
-            $json = exec($credential_process);
+            $json = shell_exec($credential_process);
 
             $process_data = json_decode($json, true);
 
@@ -376,9 +376,13 @@ class CredentialProvider
             }
 
             if (isset($process_data['Expiration'])) {
-                $expiration = DateTimeResult::createFromFormat('Y-m-d\TH:i:s+', $process_data['Expiration']);
+                try {
+                    $expiration = new DateTimeResult($process_data['Expiration']);
+                } catch (\Exception $e) {
+                    return self::reject("credential_process returned invalid expiration");
+                }
                 $now = new DateTimeResult();
-                if($expiration < $now) {
+                if ($expiration < $now) {
                     return self::reject("credential_process returned expired credentials");
                 }
             } else {

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -441,8 +441,10 @@ class CredentialProvider
             $providers['ecs'] = self::ecsCredentials($config);
         }
         $providers['process_credentials'] = self::process();
-        $providers['process_config']
-            = self::process('profile default', self::getHomeDir() . '/.aws/config');
+        $providers['process_config'] = self::process(
+            'profile default',
+            self::getHomeDir() . '/.aws/config'
+        );
         $providers['instance'] = self::instanceProfile($config);
 
         if (isset($config['credentials'])

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Test\Credentials;
 
+use Aws\Api\DateTimeResult;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\LruArrayCache;
@@ -280,14 +281,52 @@ EOT;
     public function testCreatesFromProcessCredentialProvider()
     {
         $dir = $this->clearEnv();
-        $ini = "[foo]\ncredential_process = "
-            . "echo '{\"AccessKeyId\":\"foo\",\"SecretAccessKey\":\"bar\", \"Version\":1}'";
+        $ini = <<<EOT
+[foo]
+credential_process = echo '{"AccessKeyId":"foo","SecretAccessKey":"bar", "Version":1}'
+EOT;
         file_put_contents($dir . '/credentials', $ini);
         putenv('HOME=' . dirname($dir));
 
         $creds = call_user_func(CredentialProvider::process('foo'))->wait();
+        unlink($dir . '/credentials');
         $this->assertEquals('foo', $creds->getAccessKeyId());
         $this->assertEquals('bar', $creds->getSecretKey());
+    }
+
+    public function testCreatesFromProcessCredentialWithFilename()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[baz]
+credential_process = echo '{"AccessKeyId":"foo","SecretAccessKey":"bar", "Version":1}'
+EOT;
+        file_put_contents($dir . '/mycreds', $ini);
+        putenv('HOME=' . dirname($dir));
+
+        $creds = call_user_func(CredentialProvider::process('baz', $dir . '/mycreds'))->wait();
+        unlink($dir . '/mycreds');
+        $this->assertEquals('foo', $creds->getAccessKeyId());
+        $this->assertEquals('bar', $creds->getSecretKey());
+    }
+
+    public function testCreatesTemporaryFromProcessCredential()
+    {
+        $dir = $this->clearEnv();
+        $expiration = new DateTimeResult("+1 hour");
+        $ini = <<<EOT
+[foo]
+credential_process = echo '{"AccessKeyId":"foo","SecretAccessKey":"bar", "SessionToken": "baz", "Expiration":"$expiration", "Version":1}'
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+
+        $creds = call_user_func(CredentialProvider::process('foo'))->wait();
+        unlink($dir . '/credentials');
+        $this->assertEquals('foo', $creds->getAccessKeyId());
+        $this->assertEquals('bar', $creds->getSecretKey());
+        $this->assertEquals('baz', $creds->getSecurityToken());
+        $this->assertEquals($expiration, $creds->getExpiration());
     }
 
     /**
@@ -297,16 +336,20 @@ EOT;
     public function testEnsuresProcessCredentialIsPresent()
     {
         $dir = $this->clearEnv();
-        $ini = "[default]\naws_access_key_id = foo\n"
-            . "aws_secret_access_key = baz\n[foo]";
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = baz
+EOT;
         file_put_contents($dir . '/credentials', $ini);
         putenv('HOME=' . dirname($dir));
 
         try {
             $creds = call_user_func(CredentialProvider::process())->wait();
         } catch (\Exception $e) {
-            unlink($dir . '/credentials');
             throw $e;
+        } finally {
+            unlink($dir . '/credentials');
         }
     }
 
@@ -317,16 +360,19 @@ EOT;
     public function testEnsuresProcessCredentialVersion()
     {
         $dir = $this->clearEnv();
-        $ini = "[default]\ncredential_process = "
-            . "echo '{\"AccessKeyId\":\"foo\",\"SecretAccessKey\":\"bar\", \"Version\":2}'";
+        $ini = <<<EOT
+[default]
+credential_process = echo '{"AccessKeyId":"foo","SecretAccessKey":"bar", "Version":2}'
+EOT;
         file_put_contents($dir . '/credentials', $ini);
         putenv('HOME=' . dirname($dir));
 
         try {
             $creds = call_user_func(CredentialProvider::process())->wait();
         } catch (\Exception $e) {
-            unlink($dir . '/credentials');
             throw $e;
+        } finally {
+            unlink($dir . '/credentials');
         }
     }
 
@@ -337,17 +383,42 @@ EOT;
     public function testEnsuresProcessCredentialsAreCurrent()
     {
         $dir = $this->clearEnv();
-        $ini = "[default]\ncredential_process = "
-            . "echo '{\"AccessKeyId\":\"foo\",\"SecretAccessKey\":\"bar\", \"SessionToken\":\"baz\","
-            . "\"Version\":1, \"Expiration\":\"1970-01-01T00:00:00.000Z\"}'";
+        $ini = <<<EOT
+[default]
+credential_process = echo '{"AccessKeyId":"foo","SecretAccessKey":"bar", "SessionToken":"baz","Version":1, "Expiration":"1970-01-01T00:00:00.000Z"}'
+EOT;
         file_put_contents($dir . '/credentials', $ini);
         putenv('HOME=' . dirname($dir));
 
         try {
             $creds = call_user_func(CredentialProvider::process())->wait();
         } catch (\Exception $e) {
-            unlink($dir . '/credentials');
             throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+        /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage credential_process returned invalid expiration
+     */
+    public function testEnsuresProcessCredentialsExpirationIsValid()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+credential_process = echo '{"AccessKeyId":"foo","SecretAccessKey":"bar", "SessionToken":"baz","Version":1, "Expiration":"invalid_date_format"}'
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+
+        try {
+            $creds = call_user_func(CredentialProvider::process())->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
         }
     }
 
@@ -467,5 +538,36 @@ EOT;
         $creds = $provider()->wait();
         $this->assertEquals('foo', $creds->getAccessKeyId());
         $this->assertEquals('baz', $creds->getSecretKey());
+    }
+
+    public function testProcessCredentialDefaultChain()
+    {
+        $dir = $this->clearEnv();
+        $credentialsIni = <<<EOT
+[default]
+credential_process = echo '{"AccessKeyId":"credentialsFoo","SecretAccessKey":"bar", "Version":1}'
+EOT;
+        file_put_contents($dir . '/credentials', $credentialsIni);
+        putenv('HOME=' . dirname($dir));
+        $provider = CredentialProvider::defaultProvider();
+        $creds = $provider()->wait();
+        unlink($dir . '/credentials');
+        $this->assertEquals('credentialsFoo', $creds->getAccessKeyId());
+    }
+
+    public function testProcessCredentialConfigDefaultChain()
+    {
+        $dir = $this->clearEnv();
+        $configIni = <<<EOT
+[profile default]
+credential_process = echo '{"AccessKeyId":"configFoo","SecretAccessKey":"baz", "Version":1}'
+EOT;
+
+        file_put_contents($dir . '/config', $configIni);
+        putenv('HOME=' . dirname($dir));
+        $provider = CredentialProvider::defaultProvider();
+        $creds = $provider()->wait();
+        unlink($dir . '/config');
+        $this->assertEquals('configFoo', $creds->getAccessKeyId());
     }
 }


### PR DESCRIPTION
Adds a credential_process provider.  

The SDK will execute the command specified as a credential_process in the shared INI configuration file (at ~/.aws/credentials by default).  This command should return JSON containing valid credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
