### PR TITLE
Added simple cache (PSR-16) adapter.

### DIFF
--- a/.changes/nextrelease/psr16-adapter
+++ b/.changes/nextrelease/psr16-adapter
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Added simple cache (PSR-16) adapter."
+    }
+]

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "aws/aws-php-sns-message-validator": "~1.0",
         "nette/neon": "^2.3",
         "andrewsville/php-token-reflection": "^1.4",
-        "psr/cache": "^1.0"
+        "psr/cache": "^1.0",
+        "psr/simple-cache": "^1.0"
     },
     "suggest": {
         "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",

--- a/src/Psr16CacheAdapter.php
+++ b/src/Psr16CacheAdapter.php
@@ -1,0 +1,30 @@
+<?php
+namespace Aws;
+
+use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
+
+class Psr16CacheAdapter implements CacheInterface
+{
+    /** @var SimpleCacheInterface */
+    private $cache;
+
+    public function __construct(SimpleCacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function get($key)
+    {
+        return $this->cache->get($key);
+    }
+
+    public function set($key, $value, $ttl = 0)
+    {
+        $this->cache->set($key, $value, $ttl);
+    }
+
+    public function remove($key)
+    {
+        $this->cache->delete($key);
+    }
+}

--- a/tests/Psr16CacheAdapterTest.php
+++ b/tests/Psr16CacheAdapterTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace Aws\Test;
+
+use Aws\Psr16CacheAdapter;
+use Psr\SimpleCache\CacheInterface;
+use PHPUnit\Framework\TestCase;
+
+class Psr16CacheAdapterTest extends TestCase
+{
+    /** @var CacheInterface|\PHPUnit_Framework_MockObject_MockObject $wrappedCache */
+    private $wrapped;
+    /** @var Psr16CacheAdapter */
+    private $instance;
+
+    public function setUp()
+    {
+        $this->wrapped = $this->getMockBuilder(CacheInterface::class)->getMock();
+        $this->instance = new Psr16CacheAdapter($this->wrapped);
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    public function testProxiesGetCallsToPsrCache($key, $value)
+    {
+        $this->wrapped->expects($this->once())
+            ->method('get')
+            ->with($key)
+            ->willReturn($value);
+
+        $this->assertSame($value, $this->instance->get($key));
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param int|\DateInterval $ttl
+     */
+    public function testProxiesSetCallsToPsrCache($key, $value, $ttl)
+    {
+        $this->wrapped->expects($this->once())
+            ->method('set')
+            ->with($key, $value, $ttl)
+            ->willReturn(true);
+
+        $this->instance->set($key, $value, $ttl);
+    }
+
+    /**
+     * @dataProvider cacheDataProvider
+     *
+     * @param string $key
+     */
+    public function testProxiesRemoveCallsToPsrCache($key)
+    {
+        $this->wrapped->expects($this->once())
+            ->method('delete')
+            ->with($key)
+            ->willReturn(true);
+
+        $this->instance->remove($key);
+    }
+
+    public function cacheDataProvider()
+    {
+        return [
+            ['foo', 'bar', 300],
+        ];
+    }
+}


### PR DESCRIPTION
This change adds implementation of [PSR-16](https://www.php-fig.org/psr/psr-16/) compatible cache adapter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
