### PR TITLE
Bugfix php input stream s3 multipart upload

### DIFF
--- a/.changes/nextrelease/bugfix_php_input_stream_s3_multipart_upload.json
+++ b/.changes/nextrelease/bugfix_php_input_stream_s3_multipart_upload.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "S3",
+        "description": "Updates ObjectLoader's requiresMultipart() to handle php://input streams without data loss."
+    }
+]

--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -123,7 +123,7 @@ class ObjectUploader implements PromisorInterface
         }
 
         // If body >= 5 MB, then use multipart. [YES]
-        if ($body->isSeekable()) {
+        if ($body->isSeekable() && $body->getMetadata('uri') !== 'php://input') {
             // If the body is seekable, just rewind the body.
             $body->seek(0);
         } else {


### PR DESCRIPTION
**#1767 S3 Multipart Upload php://input stream bug**

Updates ObjectLoader's requiresMultipart() to handle php://input streams without data loss.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
