### PR TITLE
fix content-type on rest-json serializer

### DIFF
--- a/.changes/nextrelease/changelog_rest_json_content_type.json
+++ b/.changes/nextrelease/changelog_rest_json_content_type.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Api",
+        "description": "Use application/json content-type on rest-json requests"
+    }
+]

--- a/src/Api/Serializer/RestJsonSerializer.php
+++ b/src/Api/Serializer/RestJsonSerializer.php
@@ -27,7 +27,7 @@ class RestJsonSerializer extends RestSerializer
         JsonBody $jsonFormatter = null
     ) {
         parent::__construct($api, $endpoint);
-        $this->contentType = JsonBody::getContentType($api);
+        $this->contentType = 'application/json';
         $this->jsonFormatter = $jsonFormatter ?: new JsonBody($api);
     }
 

--- a/tests/Api/Serializer/RestJsonSerializerTest.php
+++ b/tests/Api/Serializer/RestJsonSerializerTest.php
@@ -93,7 +93,7 @@ class RestJsonSerializerTest extends TestCase
         $this->assertEquals('http://foo.com/', (string) $request->getUri());
         $this->assertEquals('{"baz":"bar"}', (string) $request->getBody());
         $this->assertEquals(
-            'application/x-amz-json-1.1',
+            'application/json',
             $request->getHeaderLine('Content-Type')
         );
     }
@@ -156,7 +156,7 @@ class RestJsonSerializerTest extends TestCase
         $this->assertEquals('http://foo.com/', (string) $request->getUri());
         $this->assertEquals('{"baz":"1234"}', (string) $request->getBody());
         $this->assertEquals(
-            'application/x-amz-json-1.1',
+            'application/json',
             $request->getHeaderLine('Content-Type')
         );
     }


### PR DESCRIPTION
Fix for https://github.com/aws/aws-sdk-php-laravel/issues/161

Use ```application/json``` on rest-json requests, instead of using ```x-amz-json-...``` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
