### PR TITLE
DynamoDB SessionHandler - Configurable data & session lifetime attr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ docs/_themes/flask/flask_theme_support.pyc
 docs/_ext/aws/__init__.pyc
 src/package.xml
 clover.xml
+/.project
+/.buildpath
+/.settings

--- a/src/DynamoDb/LockingSessionConnection.php
+++ b/src/DynamoDb/LockingSessionConnection.php
@@ -10,11 +10,7 @@ class LockingSessionConnection extends StandardSessionConnection
 {
     public function __construct(DynamoDbClient $client, array $config = [])
     {
-        parent::__construct($client, $config + [
-            'max_lock_wait_time'       => 10,
-            'min_lock_retry_microtime' => 10000,
-            'max_lock_retry_microtime' => 50000,
-        ]);
+        parent::__construct($client, $config);
     }
 
     /**
@@ -26,7 +22,7 @@ class LockingSessionConnection extends StandardSessionConnection
         // Create the params for the UpdateItem operation so that a lock can be
         // set and item returned (via ReturnValues) in a one, atomic operation.
         $params = [
-            'TableName'        => $this->config['table_name'],
+            'TableName'        => $this->getTableName(),
             'Key'              => $this->formatKey($id),
             'Expected'         => ['lock' => ['Exists' => false]],
             'AttributeUpdates' => ['lock' => ['Value' => ['N' => '1']]],
@@ -34,7 +30,7 @@ class LockingSessionConnection extends StandardSessionConnection
         ];
 
         // Acquire the lock and fetch the item data.
-        $timeout  = time() + $this->config['max_lock_wait_time'];
+        $timeout  = time() + $this->getMaxLockWaitTime();
         while (true) {
             try {
                 $item = [];
@@ -50,8 +46,8 @@ class LockingSessionConnection extends StandardSessionConnection
                     && time() < $timeout
                 ) {
                     usleep(rand(
-                        $this->config['min_lock_retry_microtime'],
-                        $this->config['max_lock_retry_microtime']
+                        $this->getMinLockRetryMicrotime(),
+                        $this->getMaxLockRetryMicrotime()
                     ));
                 } else {
                     break;

--- a/src/DynamoDb/SessionConnectionConfigTrait.php
+++ b/src/DynamoDb/SessionConnectionConfigTrait.php
@@ -1,0 +1,243 @@
+<?php
+namespace Aws\DynamoDb;
+
+trait SessionConnectionConfigTrait
+{
+    /** @var string Name of table to store the sessions */
+    protected $tableName = 'sessions';
+
+    /** @var string Name of hash key in table. Default: "id" */
+    protected $hashKey = 'id';
+
+    /** @var string Name of the data attribute in table. Default: "data" */
+    protected $dataAttribute = 'data';
+
+    /** @var integer Lifetime of inactive sessions expiration */
+    protected $sessionLifetime;
+
+    /** @var string Name of the session life time attribute in table. Default: "expires" */
+    protected $sessionLifetimeAttribute = 'expires';
+
+    /** @var string Whether or not to use consistent reads */
+    protected $consistentRead = true;
+
+    /** @var string Batch options used for garbage collection */
+    protected $batchConfig = [];
+
+    /** @var boolean Whether or not to use session locking */
+    protected $locking = false;
+
+    /** @var integer Max time (s) to wait for lock acquisition */
+    protected $maxLockWaitTime = 10;
+
+    /** @var integer Min time (µs) to wait between lock attempts */
+    protected $minLockRetryMicrotime = 10000;
+
+    /** @var integer Max time (µs) to wait between lock attempts */
+    protected $maxLockRetryMicrotime = 50000;
+
+    /**
+     * It initialize the Config class and
+     * it sets values in case of valid configurations.
+     * 
+     * It transforms parameters underscore separated in camelcase "this_is_a_test" => ThisIsATest
+     * and it uses it in order to set the values.
+     * 
+     * @param array $config
+     */
+    public function initConfig( array $config = [] )
+    {
+        if (!empty($config))
+        {
+            foreach ($config as $key => $value)
+            {
+                $method = 'set' . str_replace('_', '', ucwords($key, '_'));
+                if(method_exists($this,$method))
+                {
+                    call_user_func_array(array($this, $method), array($value));
+                }
+            }
+        }
+
+        // It applies the default PHP session lifetime, if no session lifetime config is provided
+        if(!isset($config['session_lifetime']))
+        {
+            $this->setSessionLifetime((int) ini_get('session.gc_maxlifetime'));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getTableName()
+    {
+        return $this->tableName;
+    }
+
+    /**
+     * @param string $tableName
+     */
+    public function setTableName($tableName)
+    {
+        $this->tableName = $tableName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHashKey()
+    {
+        return $this->hashKey;
+    }
+
+    /**
+     * @param string $hashKey
+     */
+    public function setHashKey($hashKey)
+    {
+        $this->hashKey = $hashKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDataAttribute()
+    {
+        return $this->dataAttribute;
+    }
+
+    /**
+     * @param string $dataAttribute
+     */
+    public function setDataAttribute($dataAttribute)
+    {
+        $this->dataAttribute = $dataAttribute;
+    }
+
+    /**
+     * @return number
+     */
+    public function getSessionLifetime()
+    {
+        return $this->sessionLifetime;
+    }
+
+    /**
+     * @param number $sessionLifetime
+     */
+    public function setSessionLifetime($sessionLifetime)
+    {
+        $this->sessionLifetime = $sessionLifetime;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSessionLifetimeAttribute()
+    {
+        return $this->sessionLifetimeAttribute;
+    }
+
+    /**
+     * @param string $sessionLifetimeAttribute
+     */
+    public function setSessionLifetimeAttribute($sessionLifetimeAttribute)
+    {
+        $this->sessionLifetimeAttribute = $sessionLifetimeAttribute;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isConsistentRead()
+    {
+        return $this->consistentRead;
+    }
+
+    /**
+     * @param boolean $consistentRead
+     */
+    public function setConsistentRead($consistentRead)
+    {
+        $this->consistentRead = $consistentRead;
+    }
+
+    /**
+     * @return multitype:
+     */
+    public function getBatchConfig()
+    {
+        return $this->batchConfig;
+    }
+
+    /**
+     * @param multitype: $batchConfig
+     */
+    public function setBatchConfig($batchConfig)
+    {
+        $this->batchConfig = $batchConfig;
+    }
+    /**
+     * @return boolean
+     */
+    public function isLocking()
+    {
+        return $this->locking;
+    }
+
+    /**
+     * @param boolean $locking
+     */
+    public function setLocking($locking)
+    {
+        $this->locking = $locking;
+    }
+
+    /**
+     * @return number
+     */
+    public function getMaxLockWaitTime()
+    {
+        return $this->maxLockWaitTime;
+    }
+
+    /**
+     * @param number $maxLockWaitTime
+     */
+    public function setMaxLockWaitTime($maxLockWaitTime)
+    {
+        $this->maxLockWaitTime = $maxLockWaitTime;
+    }
+
+    /**
+     * @return number
+     */
+    public function getMinLockRetryMicrotime()
+    {
+        return $this->minLockRetryMicrotime;
+    }
+
+    /**
+     * @param number $minLockRetryMicrotime
+     */
+    public function setMinLockRetryMicrotime($minLockRetryMicrotime)
+    {
+        $this->minLockRetryMicrotime = $minLockRetryMicrotime;
+    }
+
+    /**
+     * @return number
+     */
+    public function getMaxLockRetryMicrotime()
+    {
+        return $this->maxLockRetryMicrotime;
+    }
+
+    /**
+     * @param number $maxLockRetryMicrotime
+     */
+    public function setMaxLockRetryMicrotime($maxLockRetryMicrotime)
+    {
+        $this->maxLockRetryMicrotime = $maxLockRetryMicrotime;
+    }
+}

--- a/tests/DynamoDb/SessionConnectionConfigTraitTest.php
+++ b/tests/DynamoDb/SessionConnectionConfigTraitTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace Aws\Test\DynamoDb;
+
+use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Aws\DynamoDb\SessionConnectionConfigTrait
+ */
+class SessionConnectionConfigTraitTest extends TestCase
+{
+    use UsesServiceTrait;
+
+    public function testStandardConfig()
+    {
+        $scc = $this->getMockForTrait('Aws\DynamoDb\SessionConnectionConfigTrait');
+        $scc->setSessionLifetime((int) ini_get('session.gc_maxlifetime'));
+        $this->assertEquals('sessions', $scc->getTableName());
+        $this->assertEquals('id', $scc->getHashKey());
+        $this->assertEquals('data', $scc->getDataAttribute());
+        $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
+        $this->assertEquals('expires', $scc->getSessionLifetimeAttribute());
+        $this->assertTrue($scc->isConsistentRead());
+        $this->assertFalse($scc->isLocking());
+        $this->assertEmpty($scc->getBatchConfig());
+        $this->assertEquals(10, $scc->getMaxLockWaitTime());
+        $this->assertEquals(10000, $scc->getMinLockRetryMicrotime());
+        $this->assertEquals(50000, $scc->getMaxLockRetryMicrotime());
+    }
+
+    public function testCustomConfig()
+    {
+        $config = [
+            'table_name'                    => 'sessions_custom',
+            'hash_key'                      => 'id_custom',
+            'data_attribute'                => 'data_custom',
+            'session_lifetime'              => 2019,
+            'session_lifetime_attribute'    => 'expires_custom',
+            'consistent_read'               => false,
+            'batch_config'                  => ['hello' => 'hello'],
+            'locking'                       => true,
+            'max_lock_wait_time'            => 2019,
+            'min_lock_retry_microtime'      => 2019,
+            'max_lock_retry_microtime'      => 2019
+        ];
+        $scc = $this->getMockForTrait('Aws\DynamoDb\SessionConnectionConfigTrait');
+        $scc->initConfig($config);
+        $this->assertEquals('sessions_custom', $scc->getTableName());
+        $this->assertEquals('id_custom', $scc->getHashKey());
+        $this->assertEquals('data_custom', $scc->getDataAttribute());
+        $this->assertEquals(2019, $scc->getSessionLifetime());
+        $this->assertEquals('expires_custom', $scc->getSessionLifetimeAttribute());
+        $this->assertFalse($scc->isConsistentRead());
+        $this->assertTrue($scc->isLocking());
+        $this->assertEquals($scc->getBatchConfig(), ['hello' => 'hello']);
+        $this->assertEquals(2019, $scc->getMaxLockWaitTime());
+        $this->assertEquals(2019, $scc->getMinLockRetryMicrotime());
+        $this->assertEquals(2019, $scc->getMaxLockRetryMicrotime());
+
+        // Test Custom Config Without Session Lifetime
+        unset($config['session_lifetime']);
+        $scc = $this->getMockForTrait('Aws\DynamoDb\SessionConnectionConfigTrait');
+        $scc->initConfig($config);
+        $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
+    }
+}

--- a/tests/DynamoDb/SessionHandlerTest.php
+++ b/tests/DynamoDb/SessionHandlerTest.php
@@ -33,13 +33,25 @@ class SessionHandlerTest extends TestCase
     {
         $data = ['fizz' => 'buzz'];
         $connection = $this->getMockForAbstractClass(
-            'Aws\DynamoDb\SessionConnectionInterface'
+            'Aws\DynamoDb\SessionConnectionInterface',
+            array(),
+            '',
+            true,
+            true,
+            true,
+            array('getDataAttribute', 'getSessionLifetimeAttribute')
         );
+        $connection->expects($this->any())
+            ->method('getDataAttribute')
+            ->willReturn('data');
+        $connection->expects($this->any())
+            ->method('getSessionLifetimeAttribute')
+            ->willReturn('expires');
         $connection->expects($this->any())
             ->method('read')
             ->willReturn([
                 'expires' => time() - 1000,
-                'data' => ['fizz' => 'buzz'],
+                'data' => ['fizz' => 'buzz']
             ]);
         $connection->expects($this->any())
             ->method('write')
@@ -76,8 +88,20 @@ class SessionHandlerTest extends TestCase
     {
         $data = 'serializedData';
         $connection = $this->getMockForAbstractClass(
-            'Aws\DynamoDb\SessionConnectionInterface'
+            'Aws\DynamoDb\SessionConnectionInterface',
+            array(),
+            '',
+            true,
+            true,
+            true,
+            array('getDataAttribute', 'getSessionLifetimeAttribute')
         );
+        $connection->expects($this->any())
+            ->method('getDataAttribute')
+            ->willReturn('data');
+        $connection->expects($this->any())
+            ->method('getSessionLifetimeAttribute')
+            ->willReturn('expires');
         $connection->expects($this->once())
             ->method('read')
             ->with('name_test1')

--- a/tests/DynamoDb/StandardSessionConnectionTest.php
+++ b/tests/DynamoDb/StandardSessionConnectionTest.php
@@ -15,21 +15,68 @@ class StandardSessionConnectionTest extends TestCase
 {
     use UsesServiceTrait;
 
+    public function testStandardConfig()
+    {
+        $client = $this->getTestSdk()->createDynamoDb();
+        $scc = new StandardSessionConnection($client);
+        $this->assertEquals('sessions', $scc->getTableName());
+        $this->assertEquals('id', $scc->getHashKey());
+        $this->assertEquals('data', $scc->getDataAttribute());
+        $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
+        $this->assertEquals('expires', $scc->getSessionLifetimeAttribute());
+        $this->assertTrue($scc->isConsistentRead());
+        $this->assertFalse($scc->isLocking());
+        $this->assertEquals(10, $scc->getMaxLockWaitTime());
+        $this->assertEquals(10000, $scc->getMinLockRetryMicrotime());
+        $this->assertEquals(50000, $scc->getMaxLockRetryMicrotime());
+    }
+
+    public function testCustomConfig()
+    {
+        $client = $this->getTestSdk()->createDynamoDb();
+        $config = [
+            'table_name'                    => 'sessions_custom',
+            'hash_key'                      => 'id_custom',
+            'data_attribute'                => 'data_custom',
+            'session_lifetime'              => 2019,
+            'session_lifetime_attribute'    => 'expires_custom',
+            'consistent_read'               => false,
+            'batch_config'                  => ['hello' => 'hello'],
+            'locking'                       => true,
+            'max_lock_wait_time'            => 2019,
+            'min_lock_retry_microtime'      => 2019,
+            'max_lock_retry_microtime'      => 2019
+        ];
+        $scc = new StandardSessionConnection($client, $config);
+        $this->assertEquals('sessions_custom', $scc->getTableName());
+        $this->assertEquals('id_custom', $scc->getHashKey());
+        $this->assertEquals('data_custom', $scc->getDataAttribute());
+        $this->assertEquals(2019, $scc->getSessionLifetime());
+        $this->assertEquals('expires_custom', $scc->getSessionLifetimeAttribute());
+        $this->assertFalse($scc->isConsistentRead());
+        $this->assertTrue($scc->isLocking());
+        $this->assertEquals(2019, $scc->getMaxLockWaitTime());
+        $this->assertEquals(2019, $scc->getMinLockRetryMicrotime());
+        $this->assertEquals(2019, $scc->getMaxLockRetryMicrotime());
+    }
+
     public function testReadRetrievesItemData()
     {
         $client = $this->getTestSdk()->createDynamoDb();
         $this->addMockResults($client, [
             new Result(['Item' => [
                 'sessionid' => ['S' => 'session1'],
-                'otherkey'  => ['S' => 'foo'],
+                'otherkey'  => ['S' => 'foo']
             ]]),
         ]);
+        
         $client->getHandlerList()->appendBuild(Middleware::tap(function ($command) {
             $this->assertEquals(
                 ['sessionid' => ['S' => 'session1']],
                 $command['Key']
             );
         }));
+        
         $connection = new StandardSessionConnection($client, [
             'hash_key' => 'sessionid',
         ]);


### PR DESCRIPTION
We needed to configure the DynamoDB Session data and session lifetime attributes as we share the session across different micro-services built upon different languages and frameworks and saving session data in different attributes than the ones supported by this default. Hence the PR:

- Added SessionConnectionConfigTrait with standard configurations defined both for Standard and Locking Session connections.
- Added tests for Standard and Custom configurations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@srchase opening a new one so that we have a full rebase and just one commit :) hope it's ok
