### PR TITLE
fix scalars when using symfony/yaml ~4.0

### DIFF
--- a/.changes/nextrelease/changelog_behat_scalars.json
+++ b/.changes/nextrelease/changelog_behat_scalars.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Build",
+        "description": "Fix behat scalars on ~v4.0"
+    }
+] 

--- a/behat.yml
+++ b/behat.yml
@@ -1,32 +1,32 @@
 default:
     suites:
         smoke:
-            paths: [ %paths.base%/features/smoke ]
+            paths: [ "%paths.base%/features/smoke" ]
             contexts: [ Aws\Test\Integ\SmokeContext ]
         performance:
-            paths: [ %paths.base%/features/performance ]
+            paths: [ "%paths.base%/features/performance" ]
             contexts: [ Aws\Test\PerformanceContext ]
         multipart:
-            paths: [ %paths.base%/features/multipart ]
+            paths: [ "%paths.base%/features/multipart" ]
             contexts: [ Aws\Test\Integ\MultipartContext ]
         batching:
-            paths: [ %paths.base%/features/batching ]
+            paths: [ "%paths.base%/features/batching" ]
             contexts: [ Aws\Test\Integ\BatchingContext ]
         blocking:
-            paths: [ %paths.base%/features/blocking ]
+            paths: [ "%paths.base%/features/blocking" ]
             contexts: [ Aws\Test\Integ\BlockingContext ]
         clientSideMonitoring:
-            paths: [ %paths.base%/features/clientSideMonitoring ]
+            paths: [ "%paths.base%/features/clientSideMonitoring" ]
             contexts: [ Aws\Test\Integ\ClientSideMonitoringContext ]
         concurrency:
-            paths: [ %paths.base%/features/concurrency ]
+            paths: [ "%paths.base%/features/concurrency" ]
             contexts: [ Aws\Test\Integ\ConcurrencyContext ]
         streams:
-            paths: [ %paths.base%/features/streams ]
+            paths: [ "%paths.base%/features/streams" ]
             contexts: [ Aws\Test\Integ\NativeStreamContext ]
         s3:
-            paths: [ %paths.base%/features/s3 ]
+            paths: [ "%paths.base%/features/s3" ]
             contexts: [ Aws\Test\Integ\S3Context ]
         s3Encryption:
-            paths: [ %paths.base%/features/s3Encryption ]
+            paths: [ "%paths.base%/features/s3Encryption" ]
             contexts: [ Aws\Test\Integ\S3EncryptionContext ]


### PR DESCRIPTION
Fixes integration test runner when Behat depends on symfony yaml ~4.0

Adds quotes surrounding path scalars.

Tested with symfony/yaml versions 2.8.50, 3.4.27 and 4.2.8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
