### PR TITLE
Changed type hints from Stream to StreamInterface in DecryptionTrait

### DIFF
--- a/.changes/nextrelease/changelog_decryption_trait.json
+++ b/.changes/nextrelease/changelog_decryption_trait.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Crypto",
+        "description": "Changed type hint to StreamInterface"
+    }
+]

--- a/src/Crypto/DecryptionTrait.php
+++ b/src/Crypto/DecryptionTrait.php
@@ -3,6 +3,7 @@ namespace Aws\Crypto;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\LimitStream;
+use Psr\Http\Message\StreamInterface;
 
 trait DecryptionTrait
 {
@@ -90,7 +91,7 @@ trait DecryptionTrait
     }
 
     private function getTagFromCiphertextStream(
-        Psr7\Stream $cipherText,
+        StreamInterface $cipherText,
         $tagLength
     ) {
         $cipherTextSize = $cipherText->getSize();
@@ -106,7 +107,7 @@ trait DecryptionTrait
     }
 
     private function getStrippedCiphertextStream(
-        Psr7\Stream $cipherText,
+        StreamInterface $cipherText,
         $tagLength
     ) {
         $cipherTextSize = $cipherText->getSize();


### PR DESCRIPTION
*Issue #1787 *

When using the _S3EncryptionClient::getObject()_ to fetch previously client side encrypted document, as described [here](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-encryption-client.html), errors like this was encountered.

`
Argument 1 passed to Aws\S3\Crypto\S3EncryptionClient::getTagFromCiphertextStream() must be an instance of GuzzleHttp\Psr7\Stream, instance of GuzzleHttp\Psr7\LazyOpenStream given, called in .../vendor/aws/aws-sdk-php/src/Crypto/DecryptionTrait.php on line 149

Argument 1 passed to Aws\S3\Crypto\S3EncryptionClient::getStrippedCiphertextStream() must be an instance of GuzzleHttp\Psr7\Stream, instance of GuzzleHttp\Psr7\LazyOpenStream given, called in .../vendor/aws/aws-sdk-php/src/Crypto/DecryptionTrait.php on line 156
`

I fixed this by changing the type hint to Psr\Http\Message\StreamInterfacem which is implemented by the different stream types like LazyOpenStream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
