### PR TITLE
fix XML body escaping

### DIFF
--- a/.changes/nextrelease/changelog_fix_xml_body_escaping.json
+++ b/.changes/nextrelease/changelog_fix_xml_body_escaping.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Api",
+        "description": "Fix XML body escaping"
+    }
+]

--- a/src/Api/Serializer/XmlBody.php
+++ b/src/Api/Serializer/XmlBody.php
@@ -80,7 +80,7 @@ class XmlBody
     private function defaultShape(Shape $shape, $name, $value, XMLWriter $xml)
     {
         $this->startElement($shape, $name, $xml);
-        $xml->writeRaw($value);
+        $xml->text($value);
         $xml->endElement();
     }
 

--- a/tests/Api/test_cases/protocols/input/rest-xml.json
+++ b/tests/Api/test_cases/protocols/input/rest-xml.json
@@ -49,6 +49,30 @@
       {
         "given": {
           "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/hostedzone"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "OperationRequest",
+            "xmlNamespace": {"uri": "https://foo/"}
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Name": "f>o<o",
+          "Description": "escaped"
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "<OperationRequest xmlns=\"https://foo/\"><Name>f&gt;o&lt;o</Name><Description>escaped</Description></OperationRequest>",
+          "uri": "/2014-01-01/hostedzone",
+          "headers": {}
+        }
+      },
+      {
+        "given": {
+          "http": {
             "method": "PUT",
             "requestUri": "/2014-01-01/hostedzone"
           },


### PR DESCRIPTION
Escape strings in XML body requests

Resolves https://github.com/aws/aws-sdk-php/issues/1790


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
