### PR TITLE
fix endpoint path removal

### DIFF
--- a/.changes/nextrelease/changelog_endpoint_path.json
+++ b/.changes/nextrelease/changelog_endpoint_path.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Api",
+        "description": "Preserve path on custom endpoints"
+    }
+]

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -212,6 +212,12 @@ abstract class RestSerializer
             $relative .= strpos($relative, '?') ? "&{$append}" : "?$append";
         }
 
+        // If endpoint has path, remove leading '/' to preserve URI resolution.
+        $path = $this->endpoint->getPath();
+        if ($path && $relative[0] === '/') {
+            $relative = substr($relative, 1);
+        }
+
         // Expand path place holders using Amazon's slightly different URI
         // template syntax.
         return UriResolver::resolve($this->endpoint, new Uri($relative));

--- a/tests/Api/Serializer/RestJsonSerializerTest.php
+++ b/tests/Api/Serializer/RestJsonSerializerTest.php
@@ -113,7 +113,7 @@ class RestJsonSerializerTest extends TestCase
         $this->assertEquals('http://foo.com/bar', (string) $request->getUri());
         $this->assertEquals('{"baz":"bar"}', (string) $request->getBody());
         $this->assertEquals(
-            'application/x-amz-json-1.1',
+            'application/json',
             $request->getHeaderLine('Content-Type')
         );
     }

--- a/tests/Api/Serializer/RestJsonSerializerTest.php
+++ b/tests/Api/Serializer/RestJsonSerializerTest.php
@@ -86,11 +86,31 @@ class RestJsonSerializerTest extends TestCase
         return $j($command);
     }
 
+    private function getPathEndpointRequest($commandName, $input)
+    {
+        $service = $this->getTestService();
+        $command = new Command($commandName, $input);
+        $j = new RestJsonSerializer($service, 'http://foo.com/bar');
+        return $j($command);
+    }
+
     public function testPreparesRequestsWithContentType()
     {
         $request = $this->getRequest('foo', ['baz' => 'bar']);
         $this->assertEquals('POST', $request->getMethod());
         $this->assertEquals('http://foo.com/', (string) $request->getUri());
+        $this->assertEquals('{"baz":"bar"}', (string) $request->getBody());
+        $this->assertEquals(
+            'application/x-amz-json-1.1',
+            $request->getHeaderLine('Content-Type')
+        );
+    }
+
+    public function testPreparesRequestsWithEndpointWithPath()
+    {
+        $request = $this->getPathEndpointRequest('foo', ['baz' => 'bar']);
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertEquals('http://foo.com/bar', (string) $request->getUri());
         $this->assertEquals('{"baz":"bar"}', (string) $request->getBody());
         $this->assertEquals(
             'application/x-amz-json-1.1',


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-php/issues/1730

Removes leading slash of relative path when resolving URIs.  This preserves the path when a custom endpoint with a path is specified for a client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
