### PR TITLE
auto assume role

### DIFF
--- a/.changes/nextrelease/changelog_auto_assume_role.json
+++ b/.changes/nextrelease/changelog_auto_assume_role.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "feature",
+        "category": "",
+        "description": "Auto assume credential role from source_profile"
+    }
+]

--- a/behat.yml
+++ b/behat.yml
@@ -21,6 +21,9 @@ default:
         concurrency:
             paths: [ "%paths.base%/features/concurrency" ]
             contexts: [ Aws\Test\Integ\ConcurrencyContext ]
+        credentials:
+            paths: [ "%paths.base%/features/credentials" ]
+            contexts: [ Aws\Test\Integ\CredentialsContext ]
         streams:
             paths: [ "%paths.base%/features/streams" ]
             contexts: [ Aws\Test\Integ\NativeStreamContext ]

--- a/features/credentials/assumeRole.feature
+++ b/features/credentials/assumeRole.feature
@@ -1,0 +1,8 @@
+Feature: Assume Role Credentials
+
+  Scenario: Assume role from credentials
+    Given I have a credentials file with session name "foo"
+    And I have credentials
+    And I have an sts client
+    When I call GetCallerIdentity
+    Then the value at "Arn" should contain "foo"

--- a/features/credentials/assumeRole.feature
+++ b/features/credentials/assumeRole.feature
@@ -1,3 +1,5 @@
+@credentials @integ
+
 Feature: Assume Role Credentials
 
   Scenario: Assume role from credentials

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -302,14 +302,12 @@ class CredentialProvider
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
         return function () use ($profile, $filename, $config) {
-            $preferStaticCredentials
-                = isset($config['preferStaticCredentials'])
-                    ? $config['preferStaticCredentials']
-                    : false;
-            $disableAssumeRole
-                = isset($config['disableAssumeRole'])
-                    ? $config['disableAssumeRole']
-                    : false;
+            $preferStaticCredentials = isset($config['preferStaticCredentials'])
+                ? $config['preferStaticCredentials']
+                : false;
+            $disableAssumeRole = isset($config['disableAssumeRole'])
+                ? $config['disableAssumeRole']
+                : false;
             $stsClient = isset($config['stsClient']) ? $config['stsClient'] : null;
 
             if (!is_readable($filename)) {
@@ -337,13 +335,11 @@ class CredentialProvider
                 && isset($data[$profile]['aws_access_key_id'])
                 && isset($data[$profile]['aws_secret_access_key']));
 
-            if (
-                isset($data[$profile]['role_arn'])
-                    && !$preferStaticCredentialsToRoleArn
+            if (isset($data[$profile]['role_arn'])
+                && !$preferStaticCredentialsToRoleArn
             )
             {
-                if ($disableAssumeRole)
-                {
+                if ($disableAssumeRole) {
                     return self::reject(
                         "Role assumption profiles are disabled. "
                         . "Failed to load profile " . $profile);
@@ -407,8 +403,7 @@ class CredentialProvider
             if (!isset($data[$profile])) {
                 return self::reject("'$profile' not found in credentials file");
             }
-            if (!isset($data[$profile]['credential_process'])
-            ) {
+            if (!isset($data[$profile]['credential_process'])) {
                 return self::reject("No credential_process present in INI profile "
                     . "'$profile' ($filename)");
             }
@@ -425,7 +420,9 @@ class CredentialProvider
                 }
             }
 
-            if (!isset($processData['AccessKeyId']) || !isset($processData['SecretAccessKey'])) {
+            if (!isset($processData['AccessKeyId'])
+                || !isset($processData['SecretAccessKey']))
+            {
                 return self::reject("credential_process does not return valid credentials");
             }
 
@@ -467,10 +464,9 @@ class CredentialProvider
     {
         $roleProfile = $profiles[$profileName];
         $roleArn = isset($roleProfile['role_arn']) ? $roleProfile['role_arn'] : '';
-        $roleSessionName
-            = isset($roleProfile['role_session_name'])
-                ? $roleProfile['role_session_name']
-                : 'aws-sdk-php-' . round(microtime(true) * 1000);
+        $roleSessionName = isset($roleProfile['role_session_name'])
+            ? $roleProfile['role_session_name']
+            : 'aws-sdk-php-' . round(microtime(true) * 1000);
 
         if (empty($profiles[$profileName]['source_profile'])) {
             return self::reject("source_profile is not set using profile " .
@@ -479,16 +475,14 @@ class CredentialProvider
         }
 
         $sourceProfileName = $roleProfile['source_profile'];
-        if (!isset($profiles[$sourceProfileName]))
-        {
+        if (!isset($profiles[$sourceProfileName])) {
             return self::reject("source_profile " . $sourceProfileName
                 . " using profile " . $profileName . " does not exist"
             );
         }
-        $sourceRegion
-            = isset($profiles[$sourceProfileName]['region'])
-                ? $profiles[$sourceProfileName]['region']
-                : 'us-east-1';
+        $sourceRegion = isset($profiles[$sourceProfileName]['region'])
+            ? $profiles[$sourceProfileName]['region']
+            : 'us-east-1';
 
         if (empty($stsClient)) {
             $config = [
@@ -598,9 +592,8 @@ class CredentialProvider
         $profileData = \Aws\parse_ini_file($filename, true, INI_SCANNER_RAW);
 
         // If loading .aws/credentials, also load .aws/config when AWS_SDK_LOAD_NONDEFAULT_CONFIG is set
-        if (
-            $filename === self::getHomeDir() . '/.aws/credentials'
-                && getenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG')
+        if ($filename === self::getHomeDir() . '/.aws/credentials'
+            && getenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG')
         )
         {
             $configFilename = self::getHomeDir() . '/.aws/config';
@@ -609,8 +602,7 @@ class CredentialProvider
             {
                 // standardize config profile names
                 $name = str_replace('profile ', '', $name);
-                if (!isset($profileData[$name]))
-                {
+                if (!isset($profileData[$name])) {
                     $profileData[$name] = $profile;
                 }
             }

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -5,6 +5,7 @@ use Aws;
 use Aws\Api\DateTimeResult;
 use Aws\CacheInterface;
 use Aws\Exception\CredentialsException;
+use Aws\Sts\StsClient;
 use GuzzleHttp\Promise;
 
 /**
@@ -285,25 +286,76 @@ class CredentialProvider
      *                              the "default" profile in "~/.aws/credentials".
      * @param string|null $filename If provided, uses a custom filename rather
      *                              than looking in the home directory.
+     * @param array|null $config If provided, may contain the following:
+     *                           preferStaticCredentials: If true, prefer static
+     *                           credentials to role_arn if both are present
+     *                           disableAssumeRole: If true, disable support for
+     *                           roles that assume an IAM role. If true and role profile
+     *                           is selected, an error is raised.
+     *                           stsClient: StsClient used to assume role specified in profile
      *
      * @return callable
      */
-    public static function ini($profile = null, $filename = null)
+    public static function ini($profile = null, $filename = null, array $config = [])
     {
         $filename = $filename ?: (self::getHomeDir() . '/.aws/credentials');
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
-        return function () use ($profile, $filename) {
+        return function () use ($profile, $filename, $config) {
+            $preferStaticCredentials
+                = isset($config['preferStaticCredentials'])
+                    ? $config['preferStaticCredentials']
+                    : false;
+            $disableAssumeRole
+                = isset($config['disableAssumeRole'])
+                    ? $config['disableAssumeRole']
+                    : false;
+            $stsClient = isset($config['stsClient']) ? $config['stsClient'] : null;
+
             if (!is_readable($filename)) {
                 return self::reject("Cannot read credentials from $filename");
             }
-            $data = \Aws\parse_ini_file($filename, true, INI_SCANNER_RAW);
+            $data = self::loadProfiles($filename);
             if ($data === false) {
                 return self::reject("Invalid credentials file: $filename");
             }
             if (!isset($data[$profile])) {
                 return self::reject("'$profile' not found in credentials file");
             }
+
+            /*
+            In the CLI, the presence of both a role_arn and static credentials have
+            different meanings depending on how many profiles have been visited. For
+            the first profile processed, role_arn takes precedence over any static
+            credentials, but for all subsequent profiles, static credentials are
+            used if present, and only in their absence will the profile's
+            source_profile and role_arn keys be used to load another set of
+            credentials. This bool is intended to yield compatible behaviour in this
+            sdk.
+            */
+            $preferStaticCredentialsToRoleArn = ($preferStaticCredentials
+                && isset($data[$profile]['aws_access_key_id'])
+                && isset($data[$profile]['aws_secret_access_key']));
+
+            if (
+                isset($data[$profile]['role_arn'])
+                    && !$preferStaticCredentialsToRoleArn
+            )
+            {
+                if ($disableAssumeRole)
+                {
+                    return self::reject(
+                        "Role assumption profiles are disabled. "
+                        . "Failed to load profile " . $profile);
+                }
+                return self::loadRoleProfile(
+                    $data,
+                    $profile,
+                    $filename,
+                    $stsClient
+                );
+            }
+
             if (!isset($data[$profile]['aws_access_key_id'])
                 || !isset($data[$profile]['aws_secret_access_key'])
             ) {
@@ -406,6 +458,63 @@ class CredentialProvider
         };
     }
 
+    /**
+     * Assumes role for profile that includes role_arn
+     *
+     * @return callable
+     */
+    private static function loadRoleProfile($profiles, $profileName, $filename, $stsClient)
+    {
+        $roleProfile = $profiles[$profileName];
+        $roleArn = isset($roleProfile['role_arn']) ? $roleProfile['role_arn'] : '';
+        $roleSessionName
+            = isset($roleProfile['role_session_name'])
+                ? $roleProfile['role_session_name']
+                : 'aws-sdk-php-' . round(microtime(true) * 1000);
+
+        if (empty($profiles[$profileName]['source_profile'])) {
+            return self::reject("source_profile is not set using profile " .
+                $profileName
+            );
+        }
+
+        $sourceProfileName = $roleProfile['source_profile'];
+        if (!isset($profiles[$sourceProfileName]))
+        {
+            return self::reject("source_profile " . $sourceProfileName
+                . " using profile " . $profileName . " does not exist"
+            );
+        }
+        $sourceRegion
+            = isset($profiles[$sourceProfileName]['region'])
+                ? $profiles[$sourceProfileName]['region']
+                : 'us-east-1';
+
+        if (empty($stsClient)) {
+            $config = [
+                'preferStaticCredentials' => true
+            ];
+            $sourceCredentials = call_user_func(
+                CredentialProvider::ini($sourceProfileName, $filename, $config)
+            )->wait();
+            $stsClient = new StsClient([
+                'credentials' => $sourceCredentials,
+                'region' => $sourceRegion,
+                'version' => '2011-06-15',
+            ]);
+        }
+
+        $result = $stsClient->assumeRole([
+            'RoleArn' => $roleArn,
+            'RoleSessionName' => $roleSessionName
+        ]);
+
+        $creds = $stsClient->createCredentials($result);
+        return Promise\promise_for(
+            $creds
+        );
+    }
+
 
     /**
      * Local credential providers returns a list of local credential providers
@@ -479,6 +588,35 @@ class CredentialProvider
         $homePath = getenv('HOMEPATH');
 
         return ($homeDrive && $homePath) ? $homeDrive . $homePath : null;
+    }
+
+    /**
+     * Gets profiles from specified $filename, or default ini files.
+     */
+    private static function loadProfiles($filename)
+    {
+        $profileData = \Aws\parse_ini_file($filename, true, INI_SCANNER_RAW);
+
+        // If loading .aws/credentials, also load .aws/config when AWS_SDK_LOAD_NONDEFAULT_CONFIG is set
+        if (
+            $filename === self::getHomeDir() . '/.aws/credentials'
+                && getenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG')
+        )
+        {
+            $configFilename = self::getHomeDir() . '/.aws/config';
+            $configProfileData = \Aws\parse_ini_file($configFilename, true, INI_SCANNER_RAW);
+            foreach ($configProfileData as $name => $profile)
+            {
+                // standardize config profile names
+                $name = str_replace('profile ', '', $name);
+                if (!isset($profileData[$name]))
+                {
+                    $profileData[$name] = $profile;
+                }
+            }
+        }
+
+        return $profileData;
     }
 
     private static function reject($msg)

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -4,10 +4,15 @@ namespace Aws\Test\Credentials;
 use Aws\Api\DateTimeResult;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
+use Aws\History;
 use Aws\LruArrayCache;
+use Aws\Middleware;
+use Aws\Result;
 use Aws\Sts\StsClient;
 use GuzzleHttp\Promise;
+use Aws\Test\UsesServiceTrait;
 use PHPUnit\Framework\TestCase;
+
 
 /**
  * @covers \Aws\Credentials\CredentialProvider
@@ -16,12 +21,15 @@ class CredentialProviderTest extends TestCase
 {
     private $home, $homedrive, $homepath, $key, $secret, $profile;
 
+    use UsesServiceTrait;
+
     private function clearEnv()
     {
         putenv(CredentialProvider::ENV_KEY . '=');
         putenv(CredentialProvider::ENV_SECRET . '=');
         putenv(CredentialProvider::ENV_PROFILE . '=');
         putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI');
+        putenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG');
 
         $dir = sys_get_temp_dir() . '/.aws';
 
@@ -399,7 +407,7 @@ EOT;
         }
     }
 
-        /**
+    /**
      * @expectedException \Aws\Exception\CredentialsException
      * @expectedExceptionMessage credential_process returned invalid expiration
      */
@@ -432,6 +440,391 @@ EOT;
     {
         $p = CredentialProvider::ecsCredentials();
         $this->assertInstanceOf('Aws\Credentials\EcsCredentialProvider', $p);
+    }
+
+    public function testCreatesFromRoleArn()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = defaultSecret
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = default
+role_session_name = foobar
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+
+        $result = [
+            'Credentials' => [
+                'AccessKeyId'     => 'foo',
+                'SecretAccessKey' => 'assumedSecret',
+                'SessionToken'    => null,
+                'Expiration'      => DateTimeResult::fromEpoch(time() + 10)
+            ],
+        ];
+
+        $sts = $this->getTestClient('Sts');
+        $this->addMockResults($sts, [
+            new Result($result)
+        ]);
+
+        $history = new History();
+        $sts->getHandlerList()->appendSign(\Aws\Middleware::history($history));
+
+        try {
+            $config = [
+                'stsClient' => $sts
+            ];
+            $creds = call_user_func(CredentialProvider::ini(
+                'assume',
+                null,
+                $config
+            ))->wait();
+
+            $body = (string) $history->getLastRequest()->getBody();
+            $this->assertContains('RoleSessionName=foobar', $body);
+            $this->assertEquals('foo', $creds->getAccessKeyId());
+            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertNull($creds->getSecurityToken());
+            $this->assertInternalType('int', $creds->getExpiration());
+            $this->assertFalse($creds->isExpired());
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    public function testSetsRoleSessionNameToDefault()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = defaultSecret
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = default
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+
+        $result = [
+            'Credentials' => [
+                'AccessKeyId'     => 'foo',
+                'SecretAccessKey' => 'assumedSecret',
+                'SessionToken'    => null,
+                'Expiration'      => DateTimeResult::fromEpoch(time() + 10)
+            ],
+        ];
+
+        $sts = $this->getTestClient('Sts');
+        $this->addMockResults($sts, [
+            new Result($result)
+        ]);
+
+        $history = new History();
+        $sts->getHandlerList()->appendSign(\Aws\Middleware::history($history));
+
+        try {
+            $config = [
+                'stsClient' => $sts
+            ];
+            $creds = call_user_func(CredentialProvider::ini(
+                'assume',
+                null,
+                $config
+            ))->wait();
+
+            $last = $history->getLastRequest();
+            $body = (string) $history->getLastRequest()->getBody();
+            $this->assertRegExp('/RoleSessionName=aws-sdk-php-\d{13}/', $body);
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Role assumption profiles are disabled. Failed to load profile assume
+     */
+    public function testEnsuresAssumeRoleCanBeDisabled()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = baz
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = default
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+        putenv('AWS_PROFILE=assume');
+
+        try {
+            $config = [
+                'preferStaticCredentials' => false,
+                'disableAssumeRole' => true
+            ];
+            $creds = call_user_func(CredentialProvider::ini(
+                "assume",
+                null,
+                $config
+            ))->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage source_profile is not set using profile assume
+     */
+    public function testEnsuresSourceProfileIsSpecified()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = baz
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+        putenv('AWS_PROFILE=assume');
+
+        try {
+            $creds = call_user_func(CredentialProvider::ini())->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage source_profile default using profile assume does not exist
+     */
+    public function testEnsuresSourceProfileConfigIsSpecified()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = default
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+        putenv('AWS_PROFILE=assume');
+
+        try {
+            $creds = call_user_func(CredentialProvider::ini())->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage No credentials present in INI profile 'default'
+     */
+    public function testEnsuresSourceProfileHasCredentials()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = default
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+        putenv('AWS_PROFILE=assume');
+
+        try {
+            $creds = call_user_func(CredentialProvider::ini())->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    public function testPreferRoleArnToStaticCredentialsInBaseProfile()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = baz
+[assume]
+aws_access_key_id = foo
+aws_secret_access_key = staticSecret
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = default
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+        putenv('HOME=' . dirname($dir));
+
+        $result = [
+            'Credentials' => [
+                'AccessKeyId'     => 'foo',
+                'SecretAccessKey' => 'assumedSecret',
+                'SessionToken'    => null,
+                'Expiration'      => DateTimeResult::fromEpoch(time() + 10)
+            ],
+        ];
+
+        $sts = $this->getTestClient('Sts');
+        $this->addMockResults($sts, [
+            new Result($result)
+        ]);
+
+        try {
+            $config = [
+                'stsClient' => $sts
+            ];
+            $creds = call_user_func(CredentialProvider::ini(
+                'assume',
+                null,
+                $config
+            ))->wait();
+            $this->assertEquals('foo', $creds->getAccessKeyId());
+            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertNull($creds->getSecurityToken());
+            $this->assertInternalType('int', $creds->getExpiration());
+            $this->assertFalse($creds->isExpired());
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    public function testAssumeRoleInCredentialsFromSourceInConfig()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = credentialSecret
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = configProfile
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+
+        $config = <<<EOT
+[configProfile]
+aws_access_key_id = foo
+aws_secret_access_key = configSecret
+EOT;
+        file_put_contents($dir . '/config', $config);
+        putenv('HOME=' . dirname($dir));
+        putenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG=1');
+
+        $result = [
+            'Credentials' => [
+                'AccessKeyId'     => 'foo',
+                'SecretAccessKey' => 'assumedSecret',
+                'SessionToken'    => null,
+                'Expiration'      => DateTimeResult::fromEpoch(time() + 10)
+            ],
+        ];
+
+        $sts = $this->getTestClient('Sts');
+        $this->addMockResults($sts, [
+            new Result($result)
+        ]);
+
+        try {
+            $config = [
+                'stsClient' => $sts
+            ];
+            $creds = call_user_func(CredentialProvider::ini(
+                'assume',
+                null,
+                $config
+            ))->wait();
+            $this->assertEquals('foo', $creds->getAccessKeyId());
+            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertNull($creds->getSecurityToken());
+            $this->assertInternalType('int', $creds->getExpiration());
+            $this->assertFalse($creds->isExpired());
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+            unlink($dir . '/config');
+        }
+    }
+
+    public function testAssumeRoleInConfigFromSourceInCredentials()
+    {
+        $dir = $this->clearEnv();
+        $ini = <<<EOT
+[default]
+aws_access_key_id = foo
+aws_secret_access_key = credentialSecret
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+
+        $config = <<<EOT
+[assume]
+role_arn = arn:aws:iam::012345678910:role/role_name
+source_profile = default
+EOT;
+        file_put_contents($dir . '/config', $config);
+        putenv('HOME=' . dirname($dir));
+        putenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG=1');
+
+        $result = [
+            'Credentials' => [
+                'AccessKeyId'     => 'foo',
+                'SecretAccessKey' => 'assumedSecret',
+                'SessionToken'    => null,
+                'Expiration'      => DateTimeResult::fromEpoch(time() + 10)
+            ],
+        ];
+
+        $sts = $this->getTestClient('Sts');
+        $this->addMockResults($sts, [
+            new Result($result)
+        ]);
+
+        try {
+            $config = [
+                'stsClient' => $sts
+            ];
+            $creds = call_user_func(CredentialProvider::ini(
+                'assume',
+                null,
+                $config
+            ))->wait();
+            $this->assertEquals('foo', $creds->getAccessKeyId());
+            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertNull($creds->getSecurityToken());
+            $this->assertInternalType('int', $creds->getExpiration());
+            $this->assertFalse($creds->isExpired());
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+            unlink($dir . '/config');
+        }
     }
 
     public function testCreatesFromAssumeRoleCredentialProvider()

--- a/tests/Integ/CredentialsContext.php
+++ b/tests/Integ/CredentialsContext.php
@@ -59,7 +59,6 @@ EOT;
            'RoleName' => self::$roleName,
         ]);
         $iamClient->waitUntil('RoleExists', ['RoleName' => self::$roleName]);
-
         $sourceKeyId = getenv('AWS_ACCESS_KEY_ID');
         $sourceAccessKey = getenv('AWS_SECRET_ACCESS_KEY');
         $sourceToken = getenv('AWS_SESSION_TOKEN');
@@ -95,7 +94,6 @@ EOT;
      */
     public function iHaveAnStsClient()
     {
-        //sleep(10);
         $this->client = self::getSdk()->createSts([
             'credentials' => $this->credentials
         ]);
@@ -106,7 +104,19 @@ EOT;
      */
     public function iCallGetCallerIdentity()
     {
-        $this->result = $this->client->getCallerIdentity();
+        //Assume role should exist, but may not yet be assumable.
+        $maxAttempts = 10;
+        $attempts = 0;
+        do {
+            try {
+                $this->result = $this->client->getCallerIdentity();
+            } catch (\Exception $e) {
+                $attempts++;
+                sleep(2);
+                continue;
+            }
+            break;
+        } while ($attempts < $maxAttempts);
     }
 
     /**

--- a/tests/Integ/CredentialsContext.php
+++ b/tests/Integ/CredentialsContext.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Aws\Test\Integ;
+
+use Aws\Result;
+use Aws\Credentials\CredentialProvider;
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+
+/**
+ * Defines application features from the specific context.
+ */
+class CredentialsContext extends \PHPUnit_Framework_Assert implements
+    Context,
+    SnippetAcceptingContext
+{
+    use IntegUtils;
+
+    private static $credentialsFile;
+    private static $roleName;
+
+    /**
+     * @AfterSuite
+     */
+    public static function deleteCredentialsFile()
+    {
+        unlink(self::$credentialsFile);
+        $client = self::getSdk()->createIam();
+        $client->deleteRole([
+            'RoleName' => self::$roleName
+        ]);
+    }
+
+    /**
+     * @Given I have a credentials file with session name :value
+     */
+    public function iHaveACredentialsFile($sessionName)
+    {
+        $stsClient = self::getSdk()->createSts();
+        $sourceIdentity = $stsClient->getCallerIdentity();
+        $sourceArn = $sourceIdentity['Arn'];
+        $assumeRolePolicy = <<<EOT
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "AWS": "$sourceArn"
+        },
+        "Action": "sts:AssumeRole"
+    }]
+}
+EOT;
+        self::$roleName = 'php-integration-' . round(microtime(true) * 1000);
+        $iamClient = self::getSdk()->createIam();
+        $result = $iamClient->createRole([
+           'AssumeRolePolicyDocument' => $assumeRolePolicy,
+           'RoleName' => self::$roleName,
+        ]);
+        $iamClient->waitUntil('RoleExists', ['RoleName' => self::$roleName]);
+
+        $sourceKeyId = getenv('AWS_ACCESS_KEY_ID');
+        $sourceAccessKey = getenv('AWS_SECRET_ACCESS_KEY');
+        $sourceToken = getenv('AWS_SESSION_TOKEN');
+        $roleArn = $result['Role']['Arn'];
+        $ini = <<<EOT
+[default]
+aws_access_key_id = $sourceKeyId
+aws_secret_access_key = $sourceAccessKey
+aws_session_token = $sourceToken
+[assumeInteg]
+role_arn = $roleArn
+source_profile = default
+role_session_name = $sessionName
+EOT;
+
+        self::$credentialsFile = tempnam(sys_get_temp_dir(), '/.aws/credentials');
+        file_put_contents(self::$credentialsFile, $ini);
+    }
+
+    /**
+     * @Given I have credentials
+     */
+    public function iHaveCredentials()
+    {
+        $this->credentials = CredentialProvider::ini(
+            'assumeInteg',
+            self::$credentialsFile
+        );
+    }
+
+    /**
+     * @Given I have an sts client
+     */
+    public function iHaveAnStsClient()
+    {
+        //sleep(10);
+        $this->client = self::getSdk()->createSts([
+            'credentials' => $this->credentials
+        ]);
+    }
+
+    /**
+     * @When I call GetCallerIdentity
+     */
+    public function iCallGetCallerIdentity()
+    {
+        $this->result = $this->client->getCallerIdentity();
+    }
+
+    /**
+     * @Then the value at :key should contain :value
+     */
+    public function theValueAtShouldBeA($key, $value)
+    {
+        $this->assertInstanceOf(Result::class, $this->result);
+        $this->assertContains($value, $this->result->search($key));
+    }
+}

--- a/tests/Integ/CredentialsContext.php
+++ b/tests/Integ/CredentialsContext.php
@@ -59,9 +59,10 @@ EOT;
            'RoleName' => self::$roleName,
         ]);
         $iamClient->waitUntil('RoleExists', ['RoleName' => self::$roleName]);
-        $sourceKeyId = getenv('AWS_ACCESS_KEY_ID');
-        $sourceAccessKey = getenv('AWS_SECRET_ACCESS_KEY');
-        $sourceToken = getenv('AWS_SESSION_TOKEN');
+        $creds = $iamClient->getCredentials()->wait();
+        $sourceKeyId = $creds->getAccessKeyId();
+        $sourceAccessKey = $creds->getSecretKey();
+        $sourceToken = $creds->getSecurityToken();
         $roleArn = $result['Role']['Arn'];
         $ini = <<<EOT
 [default]

--- a/tests/Integ/CredentialsContext.php
+++ b/tests/Integ/CredentialsContext.php
@@ -20,11 +20,35 @@ class CredentialsContext extends \PHPUnit_Framework_Assert implements
     private static $roleName;
 
     /**
+     * @BeforeSuite
+     */
+    public static function createCredentialsFile()
+    {
+        self::$credentialsFile = tempnam(sys_get_temp_dir(), '/.aws/credentials');
+        touch(self::$credentialsFile);
+    }
+
+    /**
      * @AfterSuite
      */
     public static function deleteCredentialsFile()
     {
         unlink(self::$credentialsFile);
+    }
+
+    /**
+     * @BeforeSuite
+     */
+    public static function setRoleName()
+    {
+        self::$roleName = 'php-integration-' . round(microtime(true) * 1000);
+    }
+
+    /**
+     * @AfterSuite
+     */
+    public static function deleteRole()
+    {
         $client = self::getSdk()->createIam();
         $client->deleteRole([
             'RoleName' => self::$roleName
@@ -52,7 +76,6 @@ class CredentialsContext extends \PHPUnit_Framework_Assert implements
     }]
 }
 EOT;
-        self::$roleName = 'php-integration-' . round(microtime(true) * 1000);
         $iamClient = self::getSdk()->createIam();
         $result = $iamClient->createRole([
            'AssumeRolePolicyDocument' => $assumeRolePolicy,
@@ -74,8 +97,6 @@ role_arn = $roleArn
 source_profile = default
 role_session_name = $sessionName
 EOT;
-
-        self::$credentialsFile = tempnam(sys_get_temp_dir(), '/.aws/credentials');
         file_put_contents(self::$credentialsFile, $ini);
     }
 


### PR DESCRIPTION
Re-opening: Enhancement for #1323

Implements auto-assuming role from another profile.

Given this credential file at ~/.aws/credentials:
```
[profile1]
output = json
region = us-east-1
aws_access_key_id = A**************
aws_secret_access_key = *****************

[profile2]
output = json
region = us-east-1
role_arn = arn:aws:iam::123456789012:role/Developer
source_profile = profile1
```
When profile2 is configured (in AWS_PROFILE enn var, or in 'profile' when constructing a client), the role will automatically be assumed, using profile1 as the source credentials.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
