### PR TITLE
use Behat --suite for smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,10 +64,10 @@ integ:
 	vendor/bin/behat --format=progress --tags=integ
 
 smoke:
-	vendor/bin/behat --format=progress --tags=smoke
+	vendor/bin/behat --format=progress --suite=smoke
 
 smoke-noassumerole:
-	vendor/bin/behat --format=progress --tags='~@noassumerole&&@smoke'
+	vendor/bin/behat --format=progress --suite=smoke --tags='~@noassumerole'
 
 # Packages the phar and zip
 package:


### PR DESCRIPTION
Use --suite instead of --tags to identify smoke tests to keep Behat from loading all integ contexts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
