### PR TITLE
Fixes double annontation invokeAsync

### DIFF
--- a/src/Lambda/LambdaClient.php
+++ b/src/Lambda/LambdaClient.php
@@ -48,8 +48,6 @@ use Aws\Middleware;
  * @method \GuzzleHttp\Promise\Promise getPolicyAsync(array $args = [])
  * @method \Aws\Result invoke(array $args = [])
  * @method \GuzzleHttp\Promise\Promise invokeAsync(array $args = [])
- * @method \Aws\Result invokeAsync(array $args = [])
- * @method \GuzzleHttp\Promise\Promise invokeAsyncAsync(array $args = [])
  * @method \Aws\Result listAliases(array $args = [])
  * @method \GuzzleHttp\Promise\Promise listAliasesAsync(array $args = [])
  * @method \Aws\Result listEventSourceMappings(array $args = [])


### PR DESCRIPTION
*Issue #, if available:*
There are 2 annotations for function `invokeAsync`. It makes phpstan to fail.
*Description of changes:*
Removed wrong annotation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
