### PR TITLE
Fix failing integ tests

### DIFF
--- a/tests/Integ/CredentialsContext.php
+++ b/tests/Integ/CredentialsContext.php
@@ -20,7 +20,7 @@ class CredentialsContext extends \PHPUnit_Framework_Assert implements
     private static $roleName;
 
     /**
-     * @BeforeSuite
+     * @BeforeFeature
      */
     public static function createCredentialsFile()
     {
@@ -29,7 +29,7 @@ class CredentialsContext extends \PHPUnit_Framework_Assert implements
     }
 
     /**
-     * @AfterSuite
+     * @AfterFeature
      */
     public static function deleteCredentialsFile()
     {
@@ -37,7 +37,7 @@ class CredentialsContext extends \PHPUnit_Framework_Assert implements
     }
 
     /**
-     * @BeforeSuite
+     * @BeforeFeature
      */
     public static function setRoleName()
     {
@@ -45,7 +45,7 @@ class CredentialsContext extends \PHPUnit_Framework_Assert implements
     }
 
     /**
-     * @AfterSuite
+     * @AfterFeature
      */
     public static function deleteRole()
     {


### PR DESCRIPTION
Fixes integration tests failing when using --tags, due to BeforeSuite and AfterSuite steps getting invoked.

Use BeforeFeature and AfterFeature instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
