### PR TITLE
added pagination support for cognito-idp/ListUsers

### DIFF
--- a/src/data/cognito-idp/2016-04-18/paginators-1.json
+++ b/src/data/cognito-idp/2016-04-18/paginators-1.json
@@ -30,6 +30,12 @@
       "output_token": "NextToken",
       "result_key": "ResourceServers"
     },
+    "ListUsers": {
+      "input_token": "PaginationToken",
+      "limit_key": "Limit",
+      "output_token": "PaginationToken",
+      "result_key": "Users"
+    },
     "ListUserPoolClients": {
       "input_token": "NextToken",
       "limit_key": "MaxResults",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There is missing pagination support for method ListUsers in cognito-idp service. 

In this PR there is no change to paginators-1.json.php (because it should be autogenerated from the source).

Result changes to paginators-1.json.php:
```
'ListUsers' => [ 'input_token' => 'PaginationToken', 
'limit_key' => 'Limit', 'output_token' => 'PaginationToken', 'result_key' => 'Users', ], 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
