### PR TITLE
fix json parse error on empty headers

### DIFF
--- a/.changes/nextrelease/changelog_fix_json_parse_header.json
+++ b/.changes/nextrelease/changelog_fix_json_parse_header.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "enhancement",
+      "category": "Api",
+      "description": "Fix json parse error when extracting header"
+    }
+  ] 

--- a/src/Api/Parser/AbstractRestParser.php
+++ b/src/Api/Parser/AbstractRestParser.php
@@ -129,14 +129,19 @@ abstract class AbstractRestParser extends AbstractParser
                 }
             case 'string':
                 try {
-                     if ($shape['jsonvalue']) {
-                         $value = $this->parseJson(base64_decode($value), $response);
-                     }
-                     break;
+                    if ($shape['jsonvalue']) {
+                        $value = $this->parseJson(base64_decode($value), $response);
+                    }
+
+                    // If value is not set, do not add to output structure.
+                    if (!isset($value)) {
+                        return;
+                    }
+                    break;
                 } catch (\Exception $e) {
                     //If the value cannot be parsed, then do not add it to the
                     //output structure.
-                   return;
+                    return;
                 }
         }
 

--- a/src/Api/Parser/AbstractRestParser.php
+++ b/src/Api/Parser/AbstractRestParser.php
@@ -128,10 +128,16 @@ abstract class AbstractRestParser extends AbstractParser
                     return;
                 }
             case 'string':
-                if ($shape['jsonvalue']) {
-                    $value = $this->parseJson(base64_decode($value), $response);
+                try {
+                     if ($shape['jsonvalue']) {
+                         $value = $this->parseJson(base64_decode($value), $response);
+                     }
+                     break;
+                } catch (\Exception $e) {
+                    //If the value cannot be parsed, then do not add it to the
+                    //output structure.
+                   return;
                 }
-                break;
         }
 
         $result[$name] = $value;

--- a/tests/Api/test_cases/protocols/output/rest-json.json
+++ b/tests/Api/test_cases/protocols/output/rest-json.json
@@ -702,6 +702,36 @@
           "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
           "body": ""
         }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "Attr": {}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {"X-Amz-Foo": "e30="},
+          "body": ""
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {},
+        "response": {
+          "status_code": 200,
+          "headers": {"X-Amz-Foo": ""},
+          "body": ""
+        }
       }
     ]
   }


### PR DESCRIPTION
resolves https://github.com/aws/aws-sdk-php/issues/1813

ignore headers that cannot be parsed as JSON

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
