### PR TITLE
whitelist cert http option on GuzzleV5

### DIFF
--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -28,6 +28,7 @@ class GuzzleHandler
     private static $validOptions = [
         'proxy'             => true,
         'expect'            => true,
+        'cert'              => true,
         'verify'            => true,
         'timeout'           => true,
         'debug'             => true,


### PR DESCRIPTION
Enables 'cert' http config option to be passed through to GuzzleV5

Adds 'cert' to whitelisted http config options.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
