### PR TITLE
configurable host for client side monitoring

### DIFF
--- a/.changes/nextrelease/changelog_csm_agent_host_config.json
+++ b/.changes/nextrelease/changelog_csm_agent_host_config.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "enhancement",
+      "category": "ClientSideMonitoring",
+      "description": "Support host configuration for CSM"
+    }
+]

--- a/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
+++ b/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
@@ -151,6 +151,11 @@ abstract class AbstractMonitoringMiddleware
         return $event;
     }
 
+    private function getHost()
+    {
+        return $this->unwrappedOptions()->getHost();
+    }
+
     private function getPort()
     {
         return $this->unwrappedOptions()->getPort();
@@ -236,7 +241,7 @@ abstract class AbstractMonitoringMiddleware
         ) {
             self::$socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
             socket_clear_error(self::$socket);
-            socket_connect(self::$socket, '127.0.0.1', $this->getPort());
+            socket_connect(self::$socket, $this->getHost(), $this->getPort());
         }
 
         return self::$socket;
@@ -274,6 +279,7 @@ abstract class AbstractMonitoringMiddleware
                 // Errors unwrapping CSM config defaults to disabling it
                 $this->options = new Configuration(
                     false,
+                    ConfigurationProvider::DEFAULT_HOST,
                     ConfigurationProvider::DEFAULT_PORT
                 );
             }

--- a/src/ClientSideMonitoring/Configuration.php
+++ b/src/ClientSideMonitoring/Configuration.php
@@ -5,17 +5,20 @@ class Configuration implements ConfigurationInterface
 {
     private $clientId;
     private $enabled;
+    private $host;
     private $port;
 
     /**
      * Constructs a new Configuration object with the specified CSM options set.
      *
      * @param mixed $enabled
+     * @param string $host
      * @param string|int $port
      * @param string $clientId
      */
-    public function __construct($enabled, $port, $clientId = '')
+    public function __construct($enabled, $host, $port, $clientId = '')
     {
+        $this->host = $host;
         $this->port = filter_var($port, FILTER_VALIDATE_INT);
         if ($this->port === false) {
             throw new \InvalidArgumentException(
@@ -44,6 +47,14 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
+     * /{@inheritdoc}
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getPort()
@@ -59,6 +70,7 @@ class Configuration implements ConfigurationInterface
         return [
             'client_id' => $this->getClientId(),
             'enabled' => $this->isEnabled(),
+            'host' => $this->getHost(),
             'port' => $this->getPort()
         ];
     }

--- a/src/ClientSideMonitoring/ConfigurationInterface.php
+++ b/src/ClientSideMonitoring/ConfigurationInterface.php
@@ -3,7 +3,7 @@ namespace Aws\ClientSideMonitoring;
 
 /**
  * Provides access to client-side monitoring configuration options:
- * 'client_id', 'enabled', 'port'
+ * 'client_id', 'enabled', 'host', 'port'
  */
 interface ConfigurationInterface
 {
@@ -20,6 +20,13 @@ interface ConfigurationInterface
      * @return string|null
      */
     public function getClientId();
+
+    /**
+     * Returns the configured host.
+     *
+     * @return string|null
+     */
+    public function getHost();
 
     /**
      * Returns the configured port.

--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -46,9 +46,11 @@ class ConfigurationProvider
     const CACHE_KEY = 'aws_cached_csm_config';
     const DEFAULT_CLIENT_ID = '';
     const DEFAULT_ENABLED = false;
+    const DEFAULT_HOST = '127.0.0.1';
     const DEFAULT_PORT = 31000;
     const ENV_CLIENT_ID = 'AWS_CSM_CLIENT_ID';
     const ENV_ENABLED = 'AWS_CSM_ENABLED';
+    const ENV_HOST = 'AWS_CSM_HOST';
     const ENV_PORT = 'AWS_CSM_PORT';
     const ENV_PROFILE = 'AWS_PROFILE';
 
@@ -163,6 +165,7 @@ class ConfigurationProvider
                 return Promise\promise_for(
                     new Configuration(
                         $enabled,
+                        getenv(self::ENV_HOST) ?: self::DEFAULT_HOST,
                         getenv(self::ENV_PORT) ?: self::DEFAULT_PORT,
                         getenv(self:: ENV_CLIENT_ID) ?: self::DEFAULT_CLIENT_ID
                      )
@@ -170,8 +173,8 @@ class ConfigurationProvider
             }
 
             return self::reject('Could not find environment variable CSM config'
-                . ' in ' . self::ENV_ENABLED. '/' . self::ENV_PORT . '/'
-                . self::ENV_CLIENT_ID);
+                . ' in ' . self::ENV_ENABLED. '/' . self::ENV_HOST . '/'
+                . self::ENV_PORT . '/' . self::ENV_CLIENT_ID);
         };
     }
 
@@ -186,6 +189,7 @@ class ConfigurationProvider
             return Promise\promise_for(
                 new Configuration(
                     self::DEFAULT_ENABLED,
+                    self::DEFAULT_HOST,
                     self::DEFAULT_PORT,
                     self::DEFAULT_CLIENT_ID
                 )
@@ -244,6 +248,11 @@ class ConfigurationProvider
                     INI profile '{$profile}' ({$filename})");
             }
 
+            // host is optional
+            if (empty($data[$profile]['csm_host'])) {
+                $data[$profile]['csm_host'] = self::DEFAULT_HOST;
+            }
+
             // port is optional
             if (empty($data[$profile]['csm_port'])) {
                 $data[$profile]['csm_port'] = self::DEFAULT_PORT;
@@ -257,6 +266,7 @@ class ConfigurationProvider
             return Promise\promise_for(
                 new Configuration(
                     $data[$profile]['csm_enabled'],
+                    $data[$profile]['csm_host'],
                     $data[$profile]['csm_port'],
                     $data[$profile]['csm_client_id']
                 )
@@ -331,9 +341,11 @@ class ConfigurationProvider
         } elseif (is_array($config) && isset($config['enabled'])) {
             $client_id = isset($config['client_id']) ? $config['client_id']
                 : self::DEFAULT_CLIENT_ID;
+            $host = isset($config['host']) ? $config['host']
+                : self::DEFAULT_HOST;
             $port = isset($config['port']) ? $config['port']
                 : self::DEFAULT_PORT;
-            return new Configuration($config['enabled'], $port, $client_id);
+            return new Configuration($config['enabled'], $host, $port, $client_id);
         }
 
         throw new \InvalidArgumentException('Not a valid CSM configuration '

--- a/tests/ClientSideMonitoring/ApiCallAttemptMonitoringMiddlewareTest.php
+++ b/tests/ClientSideMonitoring/ApiCallAttemptMonitoringMiddlewareTest.php
@@ -24,7 +24,7 @@ class ApiCallAttemptMonitoringMiddlewareTest extends TestCase
 
     protected function getConfiguration()
     {
-        return new Configuration(true, 31000, 'AwsPhpSdkTestApp');
+        return new Configuration(true, '127.0.0.1', 31000, 'AwsPhpSdkTestApp');
     }
 
     protected function getCredentialProvider()

--- a/tests/ClientSideMonitoring/ApiCallMonitoringMiddlewareTest.php
+++ b/tests/ClientSideMonitoring/ApiCallMonitoringMiddlewareTest.php
@@ -21,7 +21,7 @@ class ApiCallMonitoringMiddlewareTest extends TestCase
 
     protected function getConfiguration()
     {
-        return new Configuration(true, 31000, 'AwsPhpSdkTestApp');
+        return new Configuration(true, '127.0.0.1', 31000, 'AwsPhpSdkTestApp');
     }
 
     protected function getCredentialProvider()

--- a/tests/ClientSideMonitoring/ConfigurationTest.php
+++ b/tests/ClientSideMonitoring/ConfigurationTest.php
@@ -15,17 +15,19 @@ class ConfigurationTest extends TestCase
 
     public function testGetsCorrectValues()
     {
-        $config = new Configuration(true, 888, 'FooApp');
+        $config = new Configuration(true, 'FooHost', 888, 'FooApp');
         $this->assertTrue($config->isEnabled());
+        $this->assertSame('FooHost', $config->getHost());
         $this->assertSame(888, $config->getPort());
         $this->assertSame('FooApp', $config->getClientId());
     }
 
     public function testToArray()
     {
-        $config = new Configuration(true, 888, 'FooApp');
+        $config = new Configuration(true, 'FooHost', 888, 'FooApp');
         $expected = [
             'enabled' => true,
+            'host' => 'FooHost',
             'port' => 888,
             'client_id' => 'FooApp'
         ];
@@ -42,7 +44,7 @@ class ConfigurationTest extends TestCase
 
     public function testHandlesInvalidEnabled()
     {
-        $config = new Configuration('invalidvalue', 123, 'FooApp');
+        $config = new Configuration('invalidvalue', 'FooHost', 123, 'FooApp');
         $this->assertFalse($config->isEnabled());
     }
 }


### PR DESCRIPTION
host for client side monitoring can be configured via `AWS_CSM_HOST` environment variable or `csm_host` in profile.

Resolves #1659 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
