### PR TITLE
assume role using profile(s) in ~/.aws/config

### DIFF
--- a/.changes/nextrelease/changelog_assume_role_from_config.json
+++ b/.changes/nextrelease/changelog_assume_role_from_config.json
@@ -1,0 +1,8 @@
+[
+    {
+        "type": "feature",
+        "category": "",
+        "description": "Auto assume credential role using profile in `~/.aws/config`"
+    }
+] 
+

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -591,12 +591,10 @@ class CredentialProvider
         // If loading .aws/credentials, also load .aws/config when AWS_SDK_LOAD_NONDEFAULT_CONFIG is set
         if ($filename === self::getHomeDir() . '/.aws/credentials'
             && getenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG')
-        )
-        {
+        ) {
             $configFilename = self::getHomeDir() . '/.aws/config';
             $configProfileData = \Aws\parse_ini_file($configFilename, true, INI_SCANNER_RAW);
-            foreach ($configProfileData as $name => $profile)
-            {
+            foreach ($configProfileData as $name => $profile) {
                 // standardize config profile names
                 $name = str_replace('profile ', '', $name);
                 if (!isset($profileData[$name])) {

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -313,7 +313,7 @@ class CredentialProvider
             if (!is_readable($filename)) {
                 return self::reject("Cannot read credentials from $filename");
             }
-            $data = \Aws\parse_ini_file($filename, true, INI_SCANNER_RAW);
+            $data = self::loadProfiles($filename);
             if ($data === false) {
                 return self::reject("Invalid credentials file: $filename");
             }
@@ -579,6 +579,33 @@ class CredentialProvider
         $homePath = getenv('HOMEPATH');
 
         return ($homeDrive && $homePath) ? $homeDrive . $homePath : null;
+    }
+
+    /**
+     * Gets profiles from specified $filename, or default ini files.
+     */
+    private static function loadProfiles($filename)
+    {
+        $profileData = \Aws\parse_ini_file($filename, true, INI_SCANNER_RAW);
+
+        // If loading .aws/credentials, also load .aws/config when AWS_SDK_LOAD_NONDEFAULT_CONFIG is set
+        if ($filename === self::getHomeDir() . '/.aws/credentials'
+            && getenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG')
+        )
+        {
+            $configFilename = self::getHomeDir() . '/.aws/config';
+            $configProfileData = \Aws\parse_ini_file($configFilename, true, INI_SCANNER_RAW);
+            foreach ($configProfileData as $name => $profile)
+            {
+                // standardize config profile names
+                $name = str_replace('profile ', '', $name);
+                if (!isset($profileData[$name])) {
+                    $profileData[$name] = $profile;
+                }
+            }
+        }
+
+        return $profileData;
     }
 
     private static function reject($msg)


### PR DESCRIPTION
Enables profiles in ~/.aws/config to be used in auto-assuming role.

When environment variable ```AWS_SDK_LOAD_NONDEFAULT_CONFIG``` is set, profiles will be read from ```~/.aws/config```.  Any profiles returned from ```~/.aws/config``` can be used as a ```source_profile``` or the profile of the role to be assume.

Given this credential file at ~/.aws/credentials:
```
[profile1]
output = json
region = us-east-1
aws_access_key_id = A**************
aws_secret_access_key = *****************
```

And this config file at ~/.aws/config:
```
[profile profile2]
output = json
region = us-east-1
role_arn = arn:aws:iam::123456789012:role/Developer
source_profile = profile1
```

profile2 will be assumed using the credentials from profile1.  The reverse also works, as well as using one profile in ```~/.aws/config``` to load another profile also in ```~/.aws/config```.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
