### PR TITLE
Switch DynamoDb session data type to binary (B)

### DIFF
--- a/src/DynamoDb/StandardSessionConnection.php
+++ b/src/DynamoDb/StandardSessionConnection.php
@@ -9,10 +9,10 @@ use Aws\DynamoDb\Exception\DynamoDbException;
 class StandardSessionConnection implements SessionConnectionInterface
 {
     use SessionConnectionConfigTrait;
-    
+
     /** @var DynamoDbClient The DynamoDB client */
     protected $client;
-    
+
     /**
      * @param DynamoDbClient    $client DynamoDB client
      * @param array             $config Session handler config
@@ -56,7 +56,7 @@ class StandardSessionConnection implements SessionConnectionInterface
         ];
         if ($isChanged) {
             if ($data != '') {
-                $attributes[$this->getDataAttribute()] = ['Value' => ['S' => $data]];
+                $attributes[$this->getDataAttribute()] = ['Value' => ['B' => $data]];
             } else {
                 $attributes[$this->getDataAttribute()] = ['Action' => 'DELETE'];
             }


### PR DESCRIPTION
Fixes #1831

 - change DynamoDb session data type from S to B so PHP strings are handled in a binary safe manner

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.