### PR TITLE
Assume role with web identity

### DIFF
--- a/.changes/nextrelease/assume_with_web_identity.json
+++ b/.changes/nextrelease/assume_with_web_identity.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "feature",
+      "category": "",
+      "description": "Added support for assuming credential role via web identity token."
+    }
+  ]

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -93,7 +93,7 @@ class AssumeRoleWithWebIdentityCredentialProvider
 
         return $client->assumeRoleWithWebIdentityAsync($assumeParams)
             ->then(function (Result $result) {
-                    return $this->client->createCredentials($result);
+                return $this->client->createCredentials($result);
             })->otherwise(function (\RuntimeException $exception) {
                 throw new CredentialsException(
                     "Error assuming role from web identity credentials",

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -13,9 +13,6 @@ use GuzzleHttp\Promise;
 class AssumeRoleWithWebIdentityCredentialProvider
 {
     const ERROR_MSG = "Missing required 'AssumeRoleWithWebIdentityCredentialProvider' configuration option: ";
-    const ENV_TOKEN_FILE = 'AWS_WEB_IDENTITY_TOKEN_FILE';
-    const ENV_ARN = 'AWS_ROLE_ARN';
-    const ENV_SESSION = 'AWS_ROLE_SESSION';
 
     /** @var string */
     private $tokenFile;
@@ -51,6 +48,10 @@ class AssumeRoleWithWebIdentityCredentialProvider
             throw new \InvalidArgumentException(self::ERROR_MSG . "'WebIdentityTokenFile'.");
         }
         $this->tokenFile = $config['WebIdentityTokenFile'];
+
+        if (!preg_match("/^\w\:|^\/|^\\\/", $this->tokenFile)) {
+            throw new \InvalidArgumentException("'WebIdentityTokenFile' must be absolute path.");
+        }
 
         $this->session = isset($config['SessionName'])
             ? $config['SessionName']

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -50,7 +50,7 @@ class AssumeRoleWithWebIdentityCredentialProvider
         $this->tokenFile = $config['WebIdentityTokenFile'];
 
         if (!preg_match("/^\w\:|^\/|^\\\/", $this->tokenFile)) {
-            throw new \InvalidArgumentException("'WebIdentityTokenFile' must be absolute path.");
+            throw new \InvalidArgumentException("'WebIdentityTokenFile' must be an absolute path.");
         }
 
         $this->session = isset($config['SessionName'])

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -1,0 +1,105 @@
+<?php
+namespace Aws\Credentials;
+
+use Aws\Exception\CredentialsException;
+use Aws\Result;
+use Aws\Sts\StsClient;
+use GuzzleHttp\Promise;
+
+/**
+ * Credential provider that provides credentials via assuming a role with a web identity
+ * More Information, see: https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sts-2011-06-15.html#assumerolewithwebidentity
+ */
+class AssumeRoleWithWebIdentityCredentialProvider
+{
+    const ERROR_MSG = "Missing required 'AssumeRoleWithWebIdentityCredentialProvider' configuration option: ";
+    const ENV_TOKEN_FILE = 'AWS_WEB_IDENTITY_TOKEN_FILE';
+    const ENV_ARN = 'AWS_ROLE_ARN';
+    const ENV_SESSION = 'AWS_ROLE_SESSION';
+
+    /** @var string */
+    private $tokenFile;
+
+    /** @var string */
+    private $arn;
+
+    /** @var string */
+    private $session;
+
+    /** @var StsClient */
+    private $client;
+
+
+    /**
+     * The constructor attempts to load config from environment variables.
+     * If not set, the following config options are used:
+     *  - WebIdentityTokenFile: full path of token filename
+     *  - RoleArn: arn of role to be assumed
+     *  - SessionName: (optional) set by SDK if not provided
+     *
+     * @param array $config Configuration options
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(array $config = [])
+    {
+        if (!isset($config['RoleArn'])) {
+            throw new \InvalidArgumentException(self::ERROR_MSG . "'RoleArn'.");
+        }
+        $this->arn = $config['RoleArn'];
+
+        if (!isset($config['WebIdentityTokenFile'])) {
+            throw new \InvalidArgumentException(self::ERROR_MSG . "'WebIdentityTokenFile'.");
+        }
+        $this->tokenFile = $config['WebIdentityTokenFile'];
+
+        $this->session = isset($config['SessionName'])
+            ? $config['SessionName']
+            : 'aws-sdk-php-' . round(microtime(true) * 1000);
+
+        if (isset($config['client'])) {
+            $this->client = $config['client'];
+        } else {
+            $this->client = new StsClient([
+                'credentials' => false,
+                'region' => 'us-east-1',
+                'version' => 'latest'
+            ]);
+        }
+    }
+
+    /**
+     * Loads assume role with web identity credentials.
+     *
+     * @return PromiseInterface
+     */
+    public function __invoke()
+    {
+        $client = $this->client;
+        try {
+            $token = file_get_contents($this->tokenFile);
+        } catch (\Exception $exception) {
+            throw new CredentialsException(
+                "Error reading WebIdentityTokenFile from " . $this->tokenFile,
+                0,
+                $exception
+            );
+        }
+
+        $assumeParams = [
+            'RoleArn' => $this->arn,
+            'RoleSessionName' => $this->session,
+            'WebIdentityToken' => $token
+        ];
+
+        return $client->assumeRoleWithWebIdentityAsync($assumeParams)
+            ->then(function (Result $result) {
+                    return $this->client->createCredentials($result);
+            })->otherwise(function (\RuntimeException $exception) {
+                throw new CredentialsException(
+                    "Error assuming role from web identity credentials",
+                    0,
+                    $exception
+                );
+            });
+    }
+}

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -72,11 +72,19 @@ class CredentialProvider
      */
     public static function defaultProvider(array $config = [])
     {
+        $cacheable = [
+            'web_identity',
+            'ecs',
+            'process_credentials',
+            'process_config',
+            'instance'
+        ];
+
         $defaultChain = [
-            self::env(),
-            self::assumeRoleWithWebIdentityCredentialProvider(),
-            self::ini(),
-            self::ini('profile default', self::getHomeDir() . '/.aws/config'),
+            'env' => self::env(),
+            'web_identity' => self::assumeRoleWithWebIdentityCredentialProvider(),
+            'ini' => self::ini(),
+            'ini_config' => self::ini('profile default', self::getHomeDir() . '/.aws/config'),
         ];
 
         if (!empty(getenv(EcsCredentialProvider::ENV_URI))) {
@@ -88,13 +96,6 @@ class CredentialProvider
             self::getHomeDir() . '/.aws/config'
         );
         $defaultChain['instance'] = self::instanceProfile($config);
-
-        $cacheable = [
-            'ecs',
-            'process_credentials',
-            'process_config',
-            'instance'
-        ];
 
         if (isset($config['credentials'])
             && $config['credentials'] instanceof CacheInterface

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -30,6 +30,7 @@ class RetryMiddleware
         'BandwidthLimitExceeded'                 => true,
         'RequestThrottledException'              => true,
         'TooManyRequestsException'               => true,
+        'IDPCommunicationError'                  => true,
     ];
 
     private $decider;

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -1,0 +1,153 @@
+<?php
+namespace Aws\Test\Credentials;
+
+use Aws\Credentials\AssumeRoleWithWebIdentityCredentialProvider;
+use Aws\Credentials\Credentials;
+use Aws\Exception\AwsException;
+use Aws\Result;
+use Aws\Sts\StsClient;
+use Aws\Api\DateTimeResult;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\RejectedPromise;
+use Aws\Test\UsesServiceTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Aws\Credentials\AssumeRoleWithWebIdentityCredentialProvider
+ */
+class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
+{
+    const SAMPLE_ROLE_ARN = 'arn:aws:iam::012345678910:role/role_name';
+
+    use UsesServiceTrait;
+
+    private function clearEnv()
+    {
+        $dir = sys_get_temp_dir() . '/.aws';
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        return $dir;
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Missing required 'AssumeRoleWithWebIdentityCredentialProvider' configuration option:
+     */
+    public function testEnsureRoleArnProvidedForAssumeRole()
+    {
+        $config = [
+            'WebIdentityTokenFile' => '/path/to/token/file',
+        ];
+        new AssumeRoleWithWebIdentityCredentialProvider($config);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Missing required 'AssumeRoleWithWebIdentityCredentialProvider' configuration option:
+     */
+    public function testEnsureWebIdentityTokenFileProvidedForAssumeRole()
+    {
+        $config = [
+            'RoleArn' => self::SAMPLE_ROLE_ARN,
+        ];
+        new AssumeRoleWithWebIdentityCredentialProvider($config);
+    }
+
+    /**
+     * @group foo
+     */
+    public function testCanLoadAssumeRoleWithWebIdentityCredentials()
+    {
+        $dir = $this->clearEnv();
+        $result = [
+            'Credentials' => [
+                'AccessKeyId'     => 'foo',
+                'SecretAccessKey' => 'bar',
+                'SessionToken'    => 'baz',
+                'Expiration'      => DateTimeResult::fromEpoch(time() + 10)
+            ],
+        ];
+
+        $tokenPath = $dir . '/my-token.jwt';
+        file_put_contents($tokenPath, 'token');
+
+        $sts = $this->getTestClient('Sts');
+        $sts->getHandlerList()->setHandler(
+            function ($c, $r) use ($result) {
+                return Promise\promise_for(new Result($result));
+            }
+        );
+
+        $args['client'] = $sts;
+        $args['RoleArn'] = self::SAMPLE_ROLE_ARN;
+        $args['WebIdentityTokenFile'] = $tokenPath;
+        $provider = new AssumeRoleWithWebIdentityCredentialProvider($args);
+        $creds = $provider()->wait();
+
+        try {
+            $this->assertEquals('foo', $creds->getAccessKeyId());
+            $this->assertEquals('bar', $creds->getSecretKey());
+            $this->assertEquals('baz', $creds->getSecurityToken());
+            $this->assertInternalType('int', $creds->getExpiration());
+            $this->assertFalse($creds->isExpired());
+        } catch (\Error $e) {
+            throw $e;
+        } finally {
+            unlink($tokenPath);
+        }
+
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Error reading WebIdentityTokenFile
+     */
+    public function testThrowsExceptionWhenReadingTokenFileFails()
+    {
+        $args['RoleArn'] = self::SAMPLE_ROLE_ARN;
+        $args['WebIdentityTokenFile'] = '/foo';
+        $provider = new AssumeRoleWithWebIdentityCredentialProvider($args);
+        $provider()->wait();
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Error assuming role from web identity credentials
+     */
+    public function testThrowsExceptionWhenRetrievingAssumeRoleCredentialFails()
+    {
+        $dir = $this->clearEnv();
+        $sts = new StsClient([
+            'region' => 'us-west-2',
+            'version' => 'latest',
+            'credentials' => false,
+            'http_handler' => function () {
+                return new RejectedPromise([
+                    'connection_error' => false,
+                    'exception' => $this->getMockBuilder(AwsException::class)
+                        ->disableOriginalConstructor()
+                        ->getMock(),
+                    'result' => null,
+                ]);
+            }
+        ]);
+
+        $tokenPath = $dir . '/my-token.jwt';
+        file_put_contents($tokenPath, 'token');
+
+        $args['client'] = $sts;
+        $args['RoleArn'] = self::SAMPLE_ROLE_ARN;
+        $args['WebIdentityTokenFile'] = $tokenPath;
+        $provider = new AssumeRoleWithWebIdentityCredentialProvider($args);
+        try {
+            $provider()->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($tokenPath);
+        }
+    }
+}

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -69,9 +69,6 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         new AssumeRoleWithWebIdentityCredentialProvider($config);
     }
 
-    /**
-     * @group foo
-     */
     public function testCanLoadAssumeRoleWithWebIdentityCredentials()
     {
         $dir = $this->clearEnv();
@@ -90,6 +87,7 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         $sts = $this->getTestClient('Sts', ['credentials' => false]);
         $sts->getHandlerList()->setHandler(
             function ($c, $r) use ($result) {
+                $this->assertEquals('fooSession', $c->toArray()['RoleSessionName']);
                 return Promise\promise_for(new Result($result));
             }
         );
@@ -97,6 +95,7 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         $args['client'] = $sts;
         $args['RoleArn'] = self::SAMPLE_ROLE_ARN;
         $args['WebIdentityTokenFile'] = $tokenPath;
+        $args['SessionName'] = 'fooSession';
         $provider = new AssumeRoleWithWebIdentityCredentialProvider($args);
         $creds = $provider()->wait();
 

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -57,6 +57,19 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
     }
 
     /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage 'WebIdentityTokenFile' must be absolute path.
+     */
+    public function testEnsureWebIdentityTokenFileIsAbsolutePath()
+    {
+        $config = [
+            'RoleArn' => self::SAMPLE_ROLE_ARN,
+            'WebIdentityTokenFile' => '..\foo\path'
+        ];
+        new AssumeRoleWithWebIdentityCredentialProvider($config);
+    }
+
+    /**
      * @group foo
      */
     public function testCanLoadAssumeRoleWithWebIdentityCredentials()

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -74,7 +74,7 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         $tokenPath = $dir . '/my-token.jwt';
         file_put_contents($tokenPath, 'token');
 
-        $sts = $this->getTestClient('Sts');
+        $sts = $this->getTestClient('Sts', ['credentials' => false]);
         $sts->getHandlerList()->setHandler(
             function ($c, $r) use ($result) {
                 return Promise\promise_for(new Result($result));

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -98,7 +98,6 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         } finally {
             unlink($tokenPath);
         }
-
     }
 
     /**

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -58,7 +58,7 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage 'WebIdentityTokenFile' must be absolute path.
+     * @expectedExceptionMessage 'WebIdentityTokenFile' must be an absolute path.
      */
     public function testEnsureWebIdentityTokenFileIsAbsolutePath()
     {

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -923,15 +923,7 @@ EOT;
         $tokenPath = $dir . '/token';
         file_put_contents($tokenPath, 'token');
         putenv('HOME=' . dirname($dir));
-        putenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG=1');
         putenv('AWS_PROFILE=config');
-
-        $ini = <<<EOT
-[default]
-web_identity_token_file = $tokenPath
-role_arn = arn:aws:iam::012345678910:role/role_name
-EOT;
-        file_put_contents($dir . '/credentials', $ini);
 
         $ini = <<<EOT
 [profile config]
@@ -969,7 +961,6 @@ EOT;
             throw $e;
         } finally {
             unlink($dir . '/config');
-            unlink($dir . '/credentials');
             unlink($tokenPath);
         }
     }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -184,7 +184,10 @@ class RetryMiddlewareTest extends TestCase
             [new AwsException('e', $command, ['code' => 'ThrottlingException'])],
             [new AwsException('e', $command, ['code' => 'ProvisionedThroughputExceededException'])],
             [new AwsException('e', $command, ['code' => 'RequestThrottled'])],
-            [new AwsException('e', $command, ['code' => 'BandwidthLimitExceeded'])]
+            [new AwsException('e', $command, ['code' => 'BandwidthLimitExceeded'])],
+            [new AwsException('e', $command, ['code' => 'RequestThrottledException'])],
+            [new AwsException('e', $command, ['code' => 'TooManyRequestsException'])],
+            [new AwsException('e', $command, ['code' => 'IDPCommunicationError'])],
         ];
     }
     /**

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -186,12 +186,8 @@ class RetryMiddlewareTest extends TestCase
             [new AwsException('e', $command, ['code' => 'RequestThrottled'])],
             [new AwsException('e', $command, ['code' => 'BandwidthLimitExceeded'])],
             [new AwsException('e', $command, ['code' => 'RequestThrottledException'])],
-<<<<<<< HEAD
             [new AwsException('e', $command, ['code' => 'TooManyRequestsException'])],
             [new AwsException('e', $command, ['code' => 'IDPCommunicationError'])],
-=======
-            [new AwsException('e', $command, ['code' => 'TooManyRequestsException'])]
->>>>>>> be04607c91573df9fb5364ad8658d25705f82bfe
         ];
     }
     /**


### PR DESCRIPTION
Implements credential provider that allows role to be assumed using web_identity_token_file, specified as an environmental variable, ```AWS_WEB_IDENTITY_TOKEN_FILE``` or as ```web_identity_token_file``` option in shared credentials/config.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
