### PR TITLE
Instance profile provider retries

### DIFF
--- a/.changes/nextrelease/instance_profile_provider_retries.json
+++ b/.changes/nextrelease/instance_profile_provider_retries.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "enhancement",
+      "category": "Credentials",
+      "description": "Adds retry option for invalid json returned to instance profile credential provider."
+    }
+]

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -44,7 +44,7 @@ class InstanceProfileProvider
     {
         $this->timeout = isset($config['timeout']) ? $config['timeout'] : 1.0;
         $this->profile = isset($config['profile']) ? $config['profile'] : null;
-        $this->retries = isset($config['retries']) ? $config['retries'] : 0;
+        $this->retries = isset($config['retries']) ? $config['retries'] : 3;
         $this->attempts = 0;
         $this->client = isset($config['client'])
             ? $config['client'] // internal use only

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -69,7 +69,7 @@ class InstanceProfileProvider
                     $result = $this->decodeResult($json);
                 } catch (InvalidJsonException $e) {
                     if ($this->attempts < $this->retries) {
-                        sleep(1.2 ** $this->attempts);
+                        sleep(pow(1.2, $this->attempts));
                     } else {
                         throw new CredentialsException(
                             'Invalid JSON Response, retries exhausted.'

--- a/src/Exception/InvalidJsonException.php
+++ b/src/Exception/InvalidJsonException.php
@@ -1,0 +1,11 @@
+<?php
+namespace Aws\Exception;
+
+use Aws\HasMonitoringEventsTrait;
+use Aws\MonitoringEventsInterface;
+
+class InvalidJsonException extends \RuntimeException implements
+    MonitoringEventsInterface
+{
+    use HasMonitoringEventsTrait;
+}

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -179,8 +179,7 @@ class InstanceProfileProviderTest extends TestCase
         $c = $this->getTestCreds(
             '{\n "Code":"Success"}', //invalid json
             'foo',
-            new Response(200, [], Psr7\stream_for($result)),
-            ['retries' => 1]
+            new Response(200, [], Psr7\stream_for($result))
         )->wait();
         $this->assertEquals('foo', $c->getAccessKeyId());
         $this->assertEquals('baz', $c->getSecretKey());
@@ -196,7 +195,9 @@ class InstanceProfileProviderTest extends TestCase
     {
         $c = $this->getTestCreds(
             '{\n "Code":"Success"}', //invalid json
-            'foo'
+            'foo',
+            null,
+            ['retries' => 0]
         )->wait();
     }
 }

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -255,7 +255,7 @@ class InstanceProfileProviderTest extends TestCase
         $error = $this->getRequestException();
 
         $client = function () use (&$retries, $responses, $error) {
-            if (0 === --$retries) {
+            if (0 === $retries--) {
                 return Promise\promise_for(array_shift($responses));
             }
 

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -177,7 +177,7 @@ class InstanceProfileProviderTest extends TestCase
         $t = time() + 1000;
         $result = json_encode($this->getCredentialArray('foo', 'baz', null, "@{$t}"));
         $c = $this->getTestCreds(
-            '{\n "Code":"Success"}', //initial json
+            '{\n "Code":"Success"}', //invalid json
             'foo',
             new Response(200, [], Psr7\stream_for($result)),
             ['retries' => 1]
@@ -190,7 +190,7 @@ class InstanceProfileProviderTest extends TestCase
 
     /**
      * @expectedException \Aws\Exception\CredentialsException
-     * @expectedExceptionMessage Invalid Instance JSON Response
+     * @expectedExceptionMessage Invalid JSON Response
      */
     public function testThrowsExceptionOnInvalidJsonResponse()
     {


### PR DESCRIPTION
resolves https://github.com/aws/aws-sdk-php/issues/1664

Implements exponential backoff when invalid JSON is returned to InstanceProfileProvider.

By default, the provider will retry three times.

Retries can be adjusted on the provider with the ```retries``` config option:
```
$provider = new InstanceProfileProvider([
    'retries' => 5
]);
```
And can be disabled by setting to ```0```:
```
$provider = new InstanceProfileProvider([
    'retries' => 0
]);
```





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
