### PR TITLE
Configuration for StandardSessionConnection data type

### DIFF
--- a/.changes/nextrelease/standard_connection_session_data_type.json
+++ b/.changes/nextrelease/standard_connection_session_data_type.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "enhancement",
+      "category": "DynamoDb",
+      "description": "Added support configuring data attribute type as 'binary', defaults to 'string'."
+    }
+  ]

--- a/src/DynamoDb/SessionConnectionConfigTrait.php
+++ b/src/DynamoDb/SessionConnectionConfigTrait.php
@@ -12,6 +12,9 @@ trait SessionConnectionConfigTrait
     /** @var string Name of the data attribute in table. Default: "data" */
     protected $dataAttribute = 'data';
 
+    /** @var string Type of the data attribute in table. Default: "string" */
+    protected $dataAttributeType = 'string';
+
     /** @var integer Lifetime of inactive sessions expiration */
     protected $sessionLifetime;
 
@@ -112,6 +115,22 @@ trait SessionConnectionConfigTrait
     public function setDataAttribute($dataAttribute)
     {
         $this->dataAttribute = $dataAttribute;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDataAttributeType()
+    {
+        return $this->dataAttributeType;
+    }
+
+    /**
+     * @param string $dataAttributeType
+     */
+    public function setDataAttributeType($dataAttributeType)
+    {
+        $this->dataAttributeType = $dataAttributeType;
     }
 
     /**

--- a/src/DynamoDb/StandardSessionConnection.php
+++ b/src/DynamoDb/StandardSessionConnection.php
@@ -56,7 +56,13 @@ class StandardSessionConnection implements SessionConnectionInterface
         ];
         if ($isChanged) {
             if ($data != '') {
-                $attributes[$this->getDataAttribute()] = ['Value' => ['S' => $data]];
+                $type = $this->getDataAttributeType();
+                if ($type == 'binary') {
+                    $attributes[$this->getDataAttribute()] = ['Value' => ['B' => $data]];
+                } else {
+                    $attributes[$this->getDataAttribute()] = ['Value' => ['S' => $data]];
+                }
+
             } else {
                 $attributes[$this->getDataAttribute()] = ['Action' => 'DELETE'];
             }

--- a/tests/DynamoDb/SessionConnectionConfigTraitTest.php
+++ b/tests/DynamoDb/SessionConnectionConfigTraitTest.php
@@ -18,6 +18,7 @@ class SessionConnectionConfigTraitTest extends TestCase
         $this->assertEquals('sessions', $scc->getTableName());
         $this->assertEquals('id', $scc->getHashKey());
         $this->assertEquals('data', $scc->getDataAttribute());
+        $this->assertEquals('string', $scc->getDataAttributeType());
         $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
         $this->assertEquals('expires', $scc->getSessionLifetimeAttribute());
         $this->assertTrue($scc->isConsistentRead());
@@ -34,6 +35,7 @@ class SessionConnectionConfigTraitTest extends TestCase
             'table_name'                    => 'sessions_custom',
             'hash_key'                      => 'id_custom',
             'data_attribute'                => 'data_custom',
+            'data_attribute_type'           => 'binary',
             'session_lifetime'              => 2019,
             'session_lifetime_attribute'    => 'expires_custom',
             'consistent_read'               => false,
@@ -48,6 +50,7 @@ class SessionConnectionConfigTraitTest extends TestCase
         $this->assertEquals('sessions_custom', $scc->getTableName());
         $this->assertEquals('id_custom', $scc->getHashKey());
         $this->assertEquals('data_custom', $scc->getDataAttribute());
+        $this->assertEquals('binary', $scc->getDataAttributeType());
         $this->assertEquals(2019, $scc->getSessionLifetime());
         $this->assertEquals('expires_custom', $scc->getSessionLifetimeAttribute());
         $this->assertFalse($scc->isConsistentRead());

--- a/tests/DynamoDb/StandardSessionConnectionTest.php
+++ b/tests/DynamoDb/StandardSessionConnectionTest.php
@@ -22,6 +22,7 @@ class StandardSessionConnectionTest extends TestCase
         $this->assertEquals('sessions', $scc->getTableName());
         $this->assertEquals('id', $scc->getHashKey());
         $this->assertEquals('data', $scc->getDataAttribute());
+        $this->assertEquals('string', $scc->getDataAttributeType());
         $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
         $this->assertEquals('expires', $scc->getSessionLifetimeAttribute());
         $this->assertTrue($scc->isConsistentRead());
@@ -38,6 +39,7 @@ class StandardSessionConnectionTest extends TestCase
             'table_name'                    => 'sessions_custom',
             'hash_key'                      => 'id_custom',
             'data_attribute'                => 'data_custom',
+            'data_attribute_type'           => 'binary',
             'session_lifetime'              => 2019,
             'session_lifetime_attribute'    => 'expires_custom',
             'consistent_read'               => false,
@@ -51,6 +53,7 @@ class StandardSessionConnectionTest extends TestCase
         $this->assertEquals('sessions_custom', $scc->getTableName());
         $this->assertEquals('id_custom', $scc->getHashKey());
         $this->assertEquals('data_custom', $scc->getDataAttribute());
+        $this->assertEquals('binary', $scc->getDataAttributeType());
         $this->assertEquals(2019, $scc->getSessionLifetime());
         $this->assertEquals('expires_custom', $scc->getSessionLifetimeAttribute());
         $this->assertFalse($scc->isConsistentRead());
@@ -66,7 +69,8 @@ class StandardSessionConnectionTest extends TestCase
         $this->addMockResults($client, [
             new Result(['Item' => [
                 'sessionid' => ['S' => 'session1'],
-                'otherkey'  => ['S' => 'foo']
+                'otherkey'  => ['S' => 'foo'],
+                'binarykey' => ['B' => 'bar']k
             ]]),
         ]);
         
@@ -83,7 +87,7 @@ class StandardSessionConnectionTest extends TestCase
         $data = $connection->read('session1');
 
         $this->assertEquals(
-            ['sessionid' => 'session1', 'otherkey' => 'foo'],
+            ['sessionid' => 'session1', 'otherkey' => 'foo', 'binarykey' => 'bar'],
             $data
         );
     }
@@ -109,8 +113,25 @@ class StandardSessionConnectionTest extends TestCase
             $this->assertArrayHasKey('expires', $updates);
             $this->assertArrayHasKey('lock', $updates);
             $this->assertArrayHasKey('data', $updates);
+            $this->assertArrayHasKey('S', $updates['data']['Value']);
         }));
         $connection = new StandardSessionConnection($client);
+        $return = $connection->write('s1', serialize(['foo' => 'bar']), true);
+        $this->assertTrue($return);
+    }
+
+    public function testWriteUpdatesItemDataAsBinary()
+    {
+        $client = $this->getTestSdk()->createDynamoDb();
+        $this->addMockResults($client, [new Result([])]);
+        $client->getHandlerList()->appendBuild(Middleware::tap(function ($command) {
+            $updates = $command['AttributeUpdates'];
+            $this->assertArrayHasKey('data', $updates);
+            $this->assertArrayHasKey('B', $updates['data']['Value']);
+        }));
+        $connection = new StandardSessionConnection($client, [
+            'data_attribute_type' => 'binary',
+        ]);
         $return = $connection->write('s1', serialize(['foo' => 'bar']), true);
         $this->assertTrue($return);
     }

--- a/tests/DynamoDb/StandardSessionConnectionTest.php
+++ b/tests/DynamoDb/StandardSessionConnectionTest.php
@@ -70,7 +70,7 @@ class StandardSessionConnectionTest extends TestCase
             new Result(['Item' => [
                 'sessionid' => ['S' => 'session1'],
                 'otherkey'  => ['S' => 'foo'],
-                'binarykey' => ['B' => 'bar']k
+                'binarykey' => ['B' => 'bar']
             ]]),
         ]);
         


### PR DESCRIPTION
Allows configuration of dataAttributeType on StandardSessionConnection.  Defaults to ```string``` (```S```) to preserve backward compatibility, but can be set to ```binary``` (```B```) to make session data binary safe.

```
$sessionHandler = SessionHandler::fromClient($dynamoDbClient, [
  'data_attribute_type' => 'binary',
]);
```

Resolves https://github.com/aws/aws-sdk-php/issues/1831

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
