### PR TITLE
S3 presigned options

### DIFF
--- a/.changes/nextrelease/presigned_url_options.json
+++ b/.changes/nextrelease/presigned_url_options.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "S3",
+    "description": "Added support for passing options to presign via createPresignedRequest."
+  }
+]

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -337,7 +337,7 @@ class S3Client extends AwsClient implements S3ClientInterface
             preg_match('/^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$/', $bucket);
     }
 
-    public function createPresignedRequest(CommandInterface $command, $expires)
+    public function createPresignedRequest(CommandInterface $command, $expires, array $options = [])
     {
         $command = clone $command;
         $command->getHandlerList()->remove('signer');
@@ -353,7 +353,8 @@ class S3Client extends AwsClient implements S3ClientInterface
         return $signer->presign(
             \Aws\serialize($command),
             $this->getCredentials()->wait(),
-            $expires
+            $expires,
+            $options
         );
     }
 

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -22,7 +22,7 @@ interface S3ClientInterface extends AwsClientInterface
      *
      * @return RequestInterface
      */
-    public function createPresignedRequest(CommandInterface $command, $expires);
+    public function createPresignedRequest(CommandInterface $command, $expires, array $options = []);
 
     /**
      * Returns the URL to an object identified by its bucket and key.
@@ -34,6 +34,7 @@ interface S3ClientInterface extends AwsClientInterface
      *
      * @param string $bucket  The name of the bucket where the object is located
      * @param string $key     The key of the object
+     * @param array  $options Aws\Signature\SignatureInterface::presign options
      *
      * @return string The URL to the object
      */

--- a/src/S3/S3MultiRegionClient.php
+++ b/src/S3/S3MultiRegionClient.php
@@ -285,7 +285,7 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
         };
     }
 
-    public function createPresignedRequest(CommandInterface $command, $expires)
+    public function createPresignedRequest(CommandInterface $command, $expires, array $options = [])
     {
         if (empty($command['Bucket'])) {
             throw new \InvalidArgumentException('The S3\\MultiRegionClient'

--- a/src/Signature/AnonymousSignature.php
+++ b/src/Signature/AnonymousSignature.php
@@ -19,7 +19,8 @@ class AnonymousSignature implements SignatureInterface
     public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
-        $expires
+        $expires,
+        array $options = []
     ) {
         return $request;
     }

--- a/src/Signature/SignatureInterface.php
+++ b/src/Signature/SignatureInterface.php
@@ -39,6 +39,7 @@ interface SignatureInterface
     public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,
-        $expires
+        $expires,
+        array $options = []
     );
 }

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -82,6 +82,25 @@ class S3ClientTest extends TestCase
         $this->assertContains('X-Amz-Signature=', $url);
     }
 
+    public function testCreatesPresignedRequestsWithStartTime()
+    {
+        /** @var S3Client $client */
+        $client = $this->getTestClient('S3', [
+            'region'      => 'us-east-1',
+            'credentials' => ['key' => 'foo', 'secret' => 'bar']
+        ]);
+        $command = $client->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'bar']);
+        $url = (string) $client->createPresignedRequest(
+            $command,
+            '+20 minutes',
+            ['start_time' => 1562349366]
+        )->getUri();
+        $this->assertStringStartsWith('https://foo.s3.amazonaws.com/bar?', $url);
+        $this->assertContains('X-Amz-Expires=1200', $url);
+        $this->assertContains('X-Amz-Credential=', $url);
+        $this->assertContains('X-Amz-Signature=61a9940ecdd901be8e36833f6d47123c0c719fc6aa82042144a6c5cf44a25988', $url);
+    }
+
     public function testCreatesPresignedRequestsWithPathStyleFallback()
     {
         /** @var S3Client $client */


### PR DESCRIPTION
Implements https://github.com/aws/aws-sdk-php/issues/1839

Allows options to be passed through S3Client to presigner, enabling reproducible presigned URLs to be generated via setting the start_time.

```
use Aws\S3\S3Client;

$s3Client = new S3Client([
  'version' => 'latest',
  'region' => 'us-east-1',
  'credentials' => ['key' => 'foo', 'secret' => 'bar']
]);

$cmd = $s3Client->getCommand('GetObject', [
  'Bucket' => 'foo',
  'Key' => 'bar'
]);

$request = $s3Client->createPresignedRequest(
  $cmd,
  '+120 minutes',
  ['start_time' => 1562349099]
);

$presignedUrl = (string)$request->getUri();
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
