### PR TITLE
fixes default chain failing on missing profile

### DIFF
--- a/.changes/nextrelease/fix_empty_credential_profile.json
+++ b/.changes/nextrelease/fix_empty_credential_profile.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "bugfix",
+      "category": "Credentials",
+      "description": "Fixes empty or unknown profile name causing error in default chain."
+    }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -355,22 +355,26 @@ class CredentialProvider
             } else {
                 $profiles = self::loadDefaultProfiles();
             }
-            $profile = $profiles[$profileName];
 
-            if (isset($profile['web_identity_token_file'])
-                && isset($profile['role_arn'])
-            ) {
-                $sessionName = isset($profile['role_session_name'])
-                    ? $profile['role_session_name']
-                    : null;
-                $provider = new AssumeRoleWithWebIdentityCredentialProvider([
-                    'RoleArn' => $profile['role_arn'],
-                    'WebIdentityTokenFile' => $profile['web_identity_token_file'],
-                    'SessionName' => $sessionName,
-                    'client' => $stsClient
-                ]);
+            if (isset($profiles[$profileName])) {
+                $profile = $profiles[$profileName];
+                if (isset($profile['web_identity_token_file'])
+                    && isset($profile['role_arn'])
+                ) {
+                    $sessionName = isset($profile['role_session_name'])
+                        ? $profile['role_session_name']
+                        : null;
+                    $provider = new AssumeRoleWithWebIdentityCredentialProvider([
+                        'RoleArn' => $profile['role_arn'],
+                        'WebIdentityTokenFile' => $profile['web_identity_token_file'],
+                        'SessionName' => $sessionName,
+                        'client' => $stsClient
+                    ]);
 
-                return $provider();
+                    return $provider();
+                }
+            } else {
+                return self::reject("Unknown profile: $profileName");
             }
             return self::reject("No RoleArn or WebIdentityTokenFile specified");
         };

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1031,6 +1031,52 @@ EOT;
         }
     }
 
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Unknown profile: fooProfile
+     */
+    public function testEnsuresAssumeRoleWebIdentityProfileIsPresent()
+    {
+        $dir = $this->clearEnv();
+        putenv('AWS_PROFILE=fooProfile');
+
+        $ini = <<<EOT
+[barProfile]
+web_identity_token_file = /token/path
+role_arn = arn:aws:iam::012345678910:role/role_name
+EOT;
+        file_put_contents($dir . '/credentials', $ini);
+
+        try {
+            $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider())->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+        }
+    }
+
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Unknown profile: fooProfile
+     */
+    public function testEnsuresAssumeRoleWebIdentityProfileInDefaultFiles()
+    {
+        $dir = $this->clearEnv();
+        putenv('AWS_PROFILE=fooProfile');
+        touch($dir . '/credentials');
+        touch($dir . '/config');
+
+        try {
+            $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider())->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($dir . '/credentials');
+            unlink($dir . '/config');
+        }
+    }
+
     public function testGetsHomeDirectoryForWindowsUsers()
     {
         putenv('HOME=');

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1048,7 +1048,9 @@ EOT;
         file_put_contents($dir . '/credentials', $ini);
 
         try {
-            $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider())->wait();
+            $creds = call_user_func(
+                CredentialProvider::assumeRoleWithWebIdentityCredentialProvider()
+            )->wait();
         } catch (\Exception $e) {
             throw $e;
         } finally {
@@ -1068,7 +1070,9 @@ EOT;
         touch($dir . '/config');
 
         try {
-            $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider())->wait();
+            $creds = call_user_func(
+                CredentialProvider::assumeRoleWithWebIdentityCredentialProvider()
+            )->wait();
         } catch (\Exception $e) {
             throw $e;
         } finally {


### PR DESCRIPTION
Resolves https://github.com/aws/aws-sdk-php/issues/1843

Checks that profile exists for ```assumeRoleWithWebIdentityCredentialProvider``` on default chain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
