### PR TITLE
add documentation changelog type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ outward impact, or updates to the SDK foundations. This will result in a minor
 version change.
 * `enhancement` - For minor additive features or incremental sized changes.
 This will result in a patch version change.
-* `bugfix` - For updates to guides and documentation files only. This will
+* `bugfix` - For minor changes that resolve an issue. This will result in a
+patch version change.
+* `documentation` - For updates to guides and documentation files only. This will
 result in a patch version change.
 
 #### Changelog Categories

--- a/build/changelog/ChangelogBuilder.php
+++ b/build/changelog/ChangelogBuilder.php
@@ -22,6 +22,7 @@ class ChangelogBuilder
     const CHANGELOG_API_CHANGE = 'api-change';
     const CHANGELOG_ENHANCEMENT = 'enhancement';
     const CHANGELOG_BUGFIX = 'bugfix';
+    const CHANGELOG_DOCUMENTATION = 'documentation';
 
     /**
      *  The constructor requires following configure parameters:


### PR DESCRIPTION
Adds ```documentation``` changelog type.  

Clarifies CONTRIUBUTING.md.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
