### PR TITLE
Indirect deprecation notices fixed

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -361,7 +361,7 @@ class S3Client extends AwsClient implements S3ClientInterface
     /**
      * Returns the URL to an object identified by its bucket and key.
      *
-     * The URL returned by this method is not signed nor does it ensure the the
+     * The URL returned by this method is not signed nor does it ensure that the
      * bucket and key given to the method exist. If you need a signed URL, then
      * use the {@see \Aws\S3\S3Client::createPresignedRequest} method and get
      * the URI of the signed request.

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -368,7 +368,6 @@ class S3Client extends AwsClient implements S3ClientInterface
      *
      * @param string $bucket  The name of the bucket where the object is located
      * @param string $key     The key of the object
-     * @param array  $options Aws\Signature\SignatureInterface::presign options
      *
      * @return string The URL to the object
      */

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -358,6 +358,20 @@ class S3Client extends AwsClient implements S3ClientInterface
         );
     }
 
+    /**
+     * Returns the URL to an object identified by its bucket and key.
+     *
+     * The URL returned by this method is not signed nor does it ensure the the
+     * bucket and key given to the method exist. If you need a signed URL, then
+     * use the {@see \Aws\S3\S3Client::createPresignedRequest} method and get
+     * the URI of the signed request.
+     *
+     * @param string $bucket  The name of the bucket where the object is located
+     * @param string $key     The key of the object
+     * @param array  $options Aws\Signature\SignatureInterface::presign options
+     *
+     * @return string The URL to the object
+     */
     public function getObjectUrl($bucket, $key)
     {
         $command = $this->getCommand('GetObject', [

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -34,7 +34,6 @@ interface S3ClientInterface extends AwsClientInterface
      *
      * @param string $bucket  The name of the bucket where the object is located
      * @param string $key     The key of the object
-     * @param array  $options Aws\Signature\SignatureInterface::presign options
      *
      * @return string The URL to the object
      */

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -27,7 +27,7 @@ interface S3ClientInterface extends AwsClientInterface
     /**
      * Returns the URL to an object identified by its bucket and key.
      *
-     * The URL returned by this method is not signed nor does it ensure the the
+     * The URL returned by this method is not signed nor does it ensure that the
      * bucket and key given to the method exist. If you need a signed URL, then
      * use the {@see \Aws\S3\S3Client::createPresignedRequest} method and get
      * the URI of the signed request.


### PR DESCRIPTION
Added docblock from "Aws\S3\S3ClientInterface::getObjectUrl()" to
"Aws\S3\S3Client::getObjectUrl()"

*Description of changes:*
Recent update got me a Indirect deprecation notice on my own phpunit tests inside my project that is using this library

>   1x: The "Aws\S3\S3Client::getObjectUrl()" method will require a new "array $options" argument in the next major version of its parent class "Aws\S3\S3ClientInterface", not defining it is deprecated.
>     1x in S3ManagerTest::testPutFileOnS3 from App\Manager\Tests

Resolved this notice by adding the docblock from the interface method to the object method itself.