### PR TITLE
Use region for AssumeRoleWithWebIdentityCredentialProvider

### DIFF
--- a/.changes/nextrelease/client_region_for_web_identity_sts.json
+++ b/.changes/nextrelease/client_region_for_web_identity_sts.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "bugfix",
+      "category": "",
+      "description": "Respect client region when assuming credential role via web identity token."
+    }
+]

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -139,7 +139,7 @@ class ClientResolver
             'valid'   => [CredentialsInterface::class, CacheInterface::class, 'array', 'bool', 'callable'],
             'doc'     => 'Specifies the credentials used to sign requests. Provide an Aws\Credentials\CredentialsInterface object, an associative array of "key", "secret", and an optional "token" key, `false` to use null credentials, or a callable credentials provider used to create credentials or return null. See Aws\\Credentials\\CredentialProvider for a list of built-in credentials providers. If no credentials are provided, the SDK will attempt to load them from the environment.',
             'fn'      => [__CLASS__, '_apply_credentials'],
-            'default' => [CredentialProvider::class, 'defaultProvider'],
+            'default' => [__CLASS__, '_default_credential_provider'],
         ],
         'endpoint_discovery' => [
             'type'     => 'value',
@@ -441,6 +441,11 @@ class ClientResolver
                 . 'array that contains "key", "secret", and an optional "token" '
                 . 'key-value pairs, a credentials provider function, or false.');
         }
+    }
+
+    public static function _default_credential_provider(array $args)
+    {
+        return CredentialProvider::defaultProvider($args);
     }
 
     public static function _apply_csm($value, array &$args, HandlerList $list)

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -57,12 +57,16 @@ class AssumeRoleWithWebIdentityCredentialProvider
             ? $config['SessionName']
             : 'aws-sdk-php-' . round(microtime(true) * 1000);
 
+        $region = isset($config['region'])
+            ? $config['region']
+            : 'us-east-1';
+
         if (isset($config['client'])) {
             $this->client = $config['client'];
         } else {
             $this->client = new StsClient([
                 'credentials' => false,
-                'region' => 'us-east-1',
+                'region' => $region,
                 'version' => 'latest'
             ]);
         }

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -362,6 +362,9 @@ class CredentialProvider
 
             if (isset($profiles[$profileName])) {
                 $profile = $profiles[$profileName];
+                if (isset($profile['region'])) {
+                    $region = $profile['region'];
+                }
                 if (isset($profile['web_identity_token_file'])
                     && isset($profile['role_arn'])
                 ) {
@@ -372,7 +375,8 @@ class CredentialProvider
                         'RoleArn' => $profile['role_arn'],
                         'WebIdentityTokenFile' => $profile['web_identity_token_file'],
                         'SessionName' => $sessionName,
-                        'client' => $stsClient
+                        'client' => $stsClient,
+                        'region' => $region
                     ]);
 
                     return $provider();

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -82,7 +82,7 @@ class CredentialProvider
 
         $defaultChain = [
             'env' => self::env(),
-            'web_identity' => self::assumeRoleWithWebIdentityCredentialProvider(),
+            'web_identity' => self::assumeRoleWithWebIdentityCredentialProvider($config),
             'ini' => self::ini(),
             'ini_config' => self::ini('profile default', self::getHomeDir() . '/.aws/config'),
         ];
@@ -334,6 +334,9 @@ class CredentialProvider
             $stsClient = isset($config['stsClient'])
                 ? $config['stsClient']
                 : null;
+            $region = isset($config['region'])
+                ? $config['region']
+                : null;
 
             if ($tokenFromEnv && $arnFromEnv) {
                 $sessionName = getenv(self::ENV_ROLE_SESSION_NAME)
@@ -343,7 +346,8 @@ class CredentialProvider
                     'RoleArn' => $arnFromEnv,
                     'WebIdentityTokenFile' => $tokenFromEnv,
                     'SessionName' => $sessionName,
-                    'client' => $stsClient
+                    'client' => $stsClient,
+                    'region' => $region
                 ]);
 
                 return $provider();


### PR DESCRIPTION
AssumeRoleWithWebIdentityCredentialProvider should use configured region instead of 'us-east-1'.

StsClient used by AssumeRoleWithWebIdentityCredentialProvider will now respect region configured on the parent client, or the region specified in profile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
