### PR TITLE
pin travis to trusty (14.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:


### PR DESCRIPTION
Travis should default to Trusty (14.04).  This makes the build distribution explicit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
