### PR TITLE
Update SMS Smoke Test for Failure Only

### DIFF
--- a/features/smoke/sms.feature
+++ b/features/smoke/sms.feature
@@ -9,4 +9,4 @@ Feature: AWS Server Migration Service
   Scenario: Handling errors
     When I attempt to call the "DeleteReplicationJob" API with:
       | replicationJobId | invalidId |
-    Then I expect the response error code to be "InvalidParameterException"
+    Then the request should fail


### PR DESCRIPTION
Only smoke test SMS failure, not specific InvalidParameterException.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
