### PR TITLE
Smoke cleanup waiter

### DIFF
--- a/.changes/nextrelease/smoke_cleanup_waiter.json
+++ b/.changes/nextrelease/smoke_cleanup_waiter.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Test\\Integ",
+    "description": "Add waiter to S3 integration test to prevent failed bucket deletions on cleanup."
+  }
+]


### PR DESCRIPTION
* Add waiter to S3 integration test to prevent failed bucket deletions on cleanup.