### PR TITLE
add documentation type for current changes test

### DIFF
--- a/tests/Build/Changelog/CurrentChangesTest.php
+++ b/tests/Build/Changelog/CurrentChangesTest.php
@@ -62,7 +62,7 @@ class CurrentChangesTest extends TestCase
 
             if (!in_array(
                 $data[0]['type'],
-                ['feature', 'api-change', 'enhancement', 'bugfix']
+                ['feature', 'api-change', 'enhancement', 'bugfix', 'documentation']
             )) {
                 $this->fail('Invalid `type` provided in `'
                         . $name . '` changelog document.');


### PR DESCRIPTION
add documentation type for current changes test on changelog.  Fixes https://github.com/aws/aws-sdk-php/pull/1845

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
