### PR TITLE
Instantiate Credentials with expires correctly.

### DIFF
--- a/.changes/nextrelease/fix-1877-caching-credentials.json
+++ b/.changes/nextrelease/fix-1877-caching-credentials.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Fixed an issue that the credentials by process provider won't cache."
+}

--- a/.changes/nextrelease/fix-1877-caching-credentials.json
+++ b/.changes/nextrelease/fix-1877-caching-credentials.json
@@ -1,5 +1,7 @@
-{
-  "type": "bugfix",
-  "category": "Credentials",
-  "description": "Fixed an issue that the credentials by process provider won't cache."
-}
+[
+    {
+        "type": "bugfix",
+        "category": "Credentials",
+        "description": "Fixed an issue that the credentials by process provider won't cache."
+    }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -545,8 +545,9 @@ class CredentialProvider
                 if ($expiration < $now) {
                     return self::reject("credential_process returned expired credentials");
                 }
+                $expires = $expiration->getTimestamp();
             } else {
-                $processData['Expiration'] = null;
+                $expires = null;
             }
 
             if (empty($processData['SessionToken'])) {
@@ -558,7 +559,7 @@ class CredentialProvider
                     $processData['AccessKeyId'],
                     $processData['SecretAccessKey'],
                     $processData['SessionToken'],
-                    $processData['Expiration']
+                    $expires
                 )
             );
         };

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -325,6 +325,7 @@ EOT;
     {
         $dir = $this->clearEnv();
         $expiration = new DateTimeResult("+1 hour");
+        $expires = $expiration->getTimestamp();
         $ini = <<<EOT
 [foo]
 credential_process = echo '{"AccessKeyId":"foo","SecretAccessKey":"bar", "SessionToken": "baz", "Expiration":"$expiration", "Version":1}'
@@ -337,7 +338,7 @@ EOT;
         $this->assertEquals('foo', $creds->getAccessKeyId());
         $this->assertEquals('bar', $creds->getSecretKey());
         $this->assertEquals('baz', $creds->getSecurityToken());
-        $this->assertEquals($expiration, $creds->getExpiration());
+        $this->assertEquals($expires, $creds->getExpiration());
     }
 
     /**


### PR DESCRIPTION
Fix #1877 

Correct expires for `Credentials`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
