### PR TITLE
Catch generic exceptions when assuming role using web identity creds

### DIFF
--- a/.changes/nextrelease/webidentityexceptions.json
+++ b/.changes/nextrelease/webidentityexceptions.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "CredentialProvider",
+        "description": "Adds extra catch block in AssumeRoleWithWebIdentityCredentialProvider to account for non-AWS exceptions."
+    }
+]

--- a/.changes/nextrelease/webidentityexceptions.json
+++ b/.changes/nextrelease/webidentityexceptions.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "bugfix",
-        "category": "CredentialProvider",
+        "category": "Credentials",
         "description": "Adds extra catch block in AssumeRoleWithWebIdentityCredentialProvider to account for non-AWS exceptions."
     }
 ]

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Credentials;
 
+use Aws\Exception\AwsException;
 use Aws\Exception\CredentialsException;
 use Aws\Result;
 use Aws\Sts\StsClient;
@@ -109,7 +110,7 @@ class AssumeRoleWithWebIdentityCredentialProvider
 
                 try {
                     $result = $client->assumeRoleWithWebIdentity($assumeParams);
-                } catch (\Exception $e) {
+                } catch (AwsException $e) {
                     if ($e->getAwsErrorCode() == 'InvalidIdentityToken') {
                         if ($this->attempts < $this->retries) {
                             sleep(pow(1.2, $this->attempts));
@@ -125,6 +126,12 @@ class AssumeRoleWithWebIdentityCredentialProvider
                             $e
                         );
                     }
+                } catch (\Exception $e) {
+                    throw new CredentialsException(
+                        "Error retrieving web identity credentials: " . $e->getMessage()
+                        . " (" . $e->getCode() . ")"
+                    );
+
                 }
                 $this->attempts++;
             }

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -131,7 +131,6 @@ class AssumeRoleWithWebIdentityCredentialProvider
                         "Error retrieving web identity credentials: " . $e->getMessage()
                         . " (" . $e->getCode() . ")"
                     );
-
                 }
                 $this->attempts++;
             }

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -196,6 +196,43 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         }
     }
 
+    /**
+     * @expectedException \Aws\Exception\CredentialsException
+     * @expectedExceptionMessage Error retrieving web identity credentials: Found 1 error while validating the input provided for the AssumeRoleWithWebIdentity operation:
+    [RoleArn] expected string length to be >= 20, but found string length of 11 (0)
+     */
+    public function testThrowsNonAwsExceptionWhenRetrievingAssumeRoleCredentialFails()
+    {
+        $dir = $this->clearEnv();
+        $sts = new StsClient([
+            'region' => 'us-west-2',
+            'version' => 'latest',
+            'credentials' => false,
+            'http_handler' => function () {
+                return new RejectedPromise([
+                    'connection_error' => false,
+                    'exception' => new \Exception("", 0),
+                    'result' => null,
+                ]);
+            }
+        ]);
+
+        $tokenPath = $dir . '/my-token.jwt';
+        file_put_contents($tokenPath, 'token');
+
+        $args['client'] = $sts;
+        $args['RoleArn'] = "invalidrole";
+        $args['WebIdentityTokenFile'] = $tokenPath;
+        $provider = new AssumeRoleWithWebIdentityCredentialProvider($args);
+        try {
+            $provider()->wait();
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            unlink($tokenPath);
+        }
+    }
+
     public function testRetryInvalidIdentityToken()
     {
         $dir = $this->clearEnv();
@@ -225,10 +262,10 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
                 );
             }
         ]);
-        
+
         $tokenPath = $dir . '/my-token.jwt';
         file_put_contents($tokenPath, 'token');
-        
+
         $args['client'] = $sts;
         $args['RoleArn'] = self::SAMPLE_ROLE_ARN;
         $args['WebIdentityTokenFile'] = $tokenPath;
@@ -280,10 +317,10 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
                 );
             }
         ]);
-        
+
         $tokenPath = $dir . '/my-token.jwt';
         file_put_contents($tokenPath, 'token');
-        
+
         $args['client'] = $sts;
         $args['RoleArn'] = self::SAMPLE_ROLE_ARN;
         $args['WebIdentityTokenFile'] = $tokenPath;
@@ -330,7 +367,7 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
                 );
             }
         ]);
-        
+
         $tokenPath = $dir . '/my-token.jwt';
         file_put_contents($tokenPath, 'token');
 

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -199,7 +199,6 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
     /**
      * @expectedException \Aws\Exception\CredentialsException
      * @expectedExceptionMessage Error retrieving web identity credentials: Found 1 error while validating the input provided for the AssumeRoleWithWebIdentity operation:
-    [RoleArn] expected string length to be >= 20, but found string length of 11 (0)
      */
     public function testThrowsNonAwsExceptionWhenRetrievingAssumeRoleCredentialFails()
     {


### PR DESCRIPTION
Fix #1891 

*Description of changes:*
Modified existing catch block for `assumeRoleWithWebIdentity` to catch AwsExceptions, added new catch block to handle generic exceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
