### PR TITLE
Fixed the `Trying to access array offset on value of type null` error on php7.4

### DIFF
--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -143,7 +143,7 @@ class RetryMiddleware
         }
 
         if (!$error) {
-            return is_array($result['@metadata']) ? isset($statusCodes[$result['@metadata']['statusCode']]) : false;
+            return isset($statusCodes[$result['@metadata']['statusCode'] ?? null]);
         }
 
         if (!($error instanceof AwsException)) {

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -143,7 +143,7 @@ class RetryMiddleware
         }
 
         if (!$error) {
-            return isset($statusCodes[$result['@metadata']['statusCode']]);
+            return is_array($result['@metadata']) ? isset($statusCodes[$result['@metadata']['statusCode']]) : false;
         }
 
         if (!($error instanceof AwsException)) {

--- a/src/S3/PutObjectUrlMiddleware.php
+++ b/src/S3/PutObjectUrlMiddleware.php
@@ -44,7 +44,7 @@ class PutObjectUrlMiddleware
                 switch ($name) {
                     case 'PutObject':
                     case 'CopyObject':
-                        $result['ObjectURL'] = $result['@metadata']['effectiveUri'];
+                        $result['ObjectURL'] = $result['@metadata']['effectiveUri'] ?? null;
                         break;
                     case 'CompleteMultipartUpload':
                         $result['ObjectURL'] = $result['Location'];


### PR DESCRIPTION
Issue https://github.com/aws/aws-sdk-php/issues/1889

I just included a simple check to ensure that we're not using a null variable as an array.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
