### PR TITLE
HHVM 4 doesn't support PHP anymore, as such

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
     fi
 
   - >
-    if [ $(phpenv version-name) != "hhvm-3.18" ] && [ $(phpenv version-name) != "nightly" ]; then
+    if [ $(phpenv version-name) != "hhvm-3.24" ] && [ $(phpenv version-name) != "nightly" ]; then
       echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - hhvm
+  - hhvm-3.18
   - nightly
 env:
   - COMPOSER_OPTS=""
@@ -18,7 +18,7 @@ env:
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php: hhvm-3.18
     - php: nightly
   fast_finish: true
 
@@ -37,7 +37,7 @@ install:
     fi
 
   - >
-    if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then
+    if [ $(phpenv version-name) != "hhvm-3.18" ] && [ $(phpenv version-name) != "nightly" ]; then
       echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - hhvm-3.18
+  - hhvm-3.24
   - nightly
 env:
   - COMPOSER_OPTS=""
@@ -18,7 +18,7 @@ env:
 
 matrix:
   allow_failures:
-    - php: hhvm-3.18
+    - php: hhvm-3.24
     - php: nightly
   fast_finish: true
 


### PR DESCRIPTION
HHVM 3.18 LTS can run both composer and PHPUnit, so it should be used to test against.