### PR TITLE
Allow a Sleep Between Pages when Using a Paginator

### DIFF
--- a/.changes/nextrelease/paginatorSleep.json
+++ b/.changes/nextrelease/paginatorSleep.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "ResultPaginator",
+    "description": "Allow paginator to be configured with a sleep between pages."
+  }
+]

--- a/docs/guide/paginators.rst
+++ b/docs/guide/paginators.rst
@@ -49,6 +49,11 @@ the paginator would need to do 10 requests total. When you iterate through the
 results, the first request is executed when you start iterating, the second in
 the second iteration of the loop, and so forth.
 
+Because some APIs are rate limited (e.g. Route53 ``ListResourceRecordSets``), you
+may want to add a short sleep between each page request. You can do so by
+calling ``setSubsequentPageSleep`` on the ``Aws\ResultPaginator`` instance
+returned from ``getPaginator()``.
+
 Enumerating Data from Results
 -----------------------------
 

--- a/src/ResultPaginator.php
+++ b/src/ResultPaginator.php
@@ -55,7 +55,7 @@ class ResultPaginator implements \Iterator
      *
      * @param int $usec Sleep time in microseconds
      */
-    public function setSubsequentPageSleep(int $usec)
+    public function setSubsequentPageSleep($usec)
     {
         $this->apiDelayUsec = $usec;
     }


### PR DESCRIPTION
*Description of changes:*
This is useful for APIs such as the Route53 `ListResourceRecordSets`
operation, which has a rate limit of 5 requests/sec (see
https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests).

It allows you to add a sleep between pages to avoid going over rate limits on APIs with low limits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
