### PR TITLE
Bumped minimum jmespath.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^5.3.3|^6.2.1",
         "guzzlehttp/psr7": "^1.4.1",
-        "guzzlehttp/promises": "~1.0",
-        "mtdowling/jmespath.php": "~2.2",
+        "guzzlehttp/promises": "^1.0",
+        "mtdowling/jmespath.php": "^2.5",
         "ext-pcre": "*",
         "ext-json": "*",
         "ext-simplexml": "*"


### PR DESCRIPTION
`jmespath.php` causes deprecation exceptions to be raised on PHP 7.2 or higher, and totally crashes on PHP 7.4 due to the usage of the `fn` reserved word. This is fixed in the 1.5.0 release.

---

NB There is one outstanding jmespath spec compliance issue, affecting (all versions of) the PHP library: https://github.com/jmespath/jmespath.php/issues/56.