### PR TITLE
Add support for AWS_CONFIG_FILE environment variable for default config file location

### DIFF
--- a/.changes/nextrelease/default_config_file.json
+++ b/.changes/nextrelease/default_config_file.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "",
+    "description": "Adds support for the 'AWS_CONFIG_FILE' environment variable to set the default config file location. This is implemented for all configuration provider classes extending AbstractConfigurationProvider."
+  }
+]

--- a/src/AbstractConfigurationProvider.php
+++ b/src/AbstractConfigurationProvider.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Promise;
 abstract class AbstractConfigurationProvider
 {
     const ENV_PROFILE = 'AWS_PROFILE';
+    const ENV_CONFIG_FILE = 'AWS_CONFIG_FILE';
 
     public static $cacheKey;
 
@@ -94,6 +95,20 @@ abstract class AbstractConfigurationProvider
         $homePath = getenv('HOMEPATH');
 
         return ($homeDrive && $homePath) ? $homeDrive . $homePath : null;
+    }
+
+    /**
+     * Gets default config file location from environment, falling back to aws
+     * default location
+     *
+     * @return string
+     */
+    protected static function getDefaultConfigFilename()
+    {
+        if ($filename = getenv(self::ENV_CONFIG_FILE)) {
+            return $filename;
+        }
+        return self::getHomeDir() . '/.aws/config';
     }
 
     /**

--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -61,16 +61,17 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     protected static $exceptionClass = ConfigurationException::class;
 
     /**
-     * Create a default CSM config provider that first checks for environment
-     * variables, then checks for a specified profile in ~/.aws/config, then
-     * checks for the "aws_csm" profile in ~/.aws/config, and failing those uses
-     * a default fallback set of configuration options.
+     * Create a default config provider that first checks for environment
+     * variables, then checks for a specified profile in the environment-defined
+     * config file location (env variable is 'AWS_CONFIG_FILE', file location
+     * defaults to ~/.aws/config), then checks for the "default" profile in the
+     * environment-defined config file location, and failing those uses a default
+     * fallback set of configuration options.
      *
      * This provider is automatically wrapped in a memoize function that caches
      * previously provided config options.
      *
-     * @param array $config Optional array of ecs/instance profile credentials
-     *                      provider options.
+     * @param array $config
      *
      * @return callable
      */
@@ -140,13 +141,14 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     }
 
     /**
-     * CSM config provider that creates CSM config using an ini file stored
-     * in the current user's home directory.
+     * Config provider that creates config using a config file whose location
+     * is specified by an environment variable 'AWS_CONFIG_FILE', defaulting to
+     * ~/.aws/config if not specified
      *
      * @param string|null $profile  Profile to use. If not specified will use
-     *                              the "aws_csm" profile in "~/.aws/config".
+     *                              the "default" profile.
      * @param string|null $filename If provided, uses a custom filename rather
-     *                              than looking in the home directory.
+     *                              than looking in the default directory.
      *
      * @return callable
      */

--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -4,6 +4,7 @@ namespace Aws\ClientSideMonitoring;
 use Aws\AbstractConfigurationProvider;
 use Aws\CacheInterface;
 use Aws\ClientSideMonitoring\Exception\ConfigurationException;
+use Aws\ConfigurationProviderInterface;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
@@ -42,6 +43,7 @@ use GuzzleHttp\Promise\PromiseInterface;
  * </code>
  */
 class ConfigurationProvider extends AbstractConfigurationProvider
+    implements ConfigurationProviderInterface
 {
     const DEFAULT_CLIENT_ID = '';
     const DEFAULT_ENABLED = false;

--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -152,7 +152,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
      */
     public static function ini($profile = null, $filename = null)
     {
-        $filename = $filename ?: (self::getHomeDir() . '/.aws/config');
+        $filename = $filename ?: (self::getDefaultConfigFilename());
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'aws_csm');
 
         return function () use ($profile, $filename) {

--- a/src/EndpointDiscovery/ConfigurationProvider.php
+++ b/src/EndpointDiscovery/ConfigurationProvider.php
@@ -1,7 +1,9 @@
 <?php
 namespace Aws\EndpointDiscovery;
 
+use Aws\AbstractConfigurationProvider;
 use Aws\CacheInterface;
+use Aws\ConfigurationProviderInterface;
 use Aws\EndpointDiscovery\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -40,49 +42,19 @@ use GuzzleHttp\Promise\PromiseInterface;
  * $config = $promise->wait();
  * </code>
  */
-class ConfigurationProvider
+class ConfigurationProvider extends AbstractConfigurationProvider
+    implements ConfigurationProviderInterface
 {
-    const CACHE_KEY = 'aws_cached_endpoint_discovery_config';
     const DEFAULT_ENABLED = false;
     const DEFAULT_CACHE_LIMIT = 1000;
     const ENV_ENABLED = 'AWS_ENDPOINT_DISCOVERY_ENABLED';
     const ENV_ENABLED_ALT = 'AWS_ENABLE_ENDPOINT_DISCOVERY';
     const ENV_PROFILE = 'AWS_PROFILE';
 
-    /**
-     * Wraps a config provider and saves provided configuration in an
-     * instance of Aws\CacheInterface. Forwards calls when no config found
-     * in cache and updates cache with the results.
-     *
-     * @param callable $provider Configuration provider function to wrap
-     * @param CacheInterface $cache Cache to store credentials
-     * @param string|null $cacheKey (optional) Cache key to use
-     *
-     * @return callable
-     */
-    public static function cache(
-        callable $provider,
-        CacheInterface $cache,
-        $cacheKey = null
-    ) {
-        $cacheKey = $cacheKey ?: self::CACHE_KEY;
+    public static $cacheKey = 'aws_cached_endpoint_discovery_config';
 
-        return function () use ($provider, $cache, $cacheKey) {
-            $found = $cache->get($cacheKey);
-            if ($found instanceof ConfigurationInterface) {
-                return Promise\promise_for($found);
-            }
-
-            return $provider()
-                ->then(function (ConfigurationInterface $config) use (
-                    $cache,
-                    $cacheKey
-                ) {
-                    $cache->set($cacheKey, $config);
-                    return $config;
-                });
-        };
-    }
+    protected static $interfaceClass = ConfigurationInterface::class;
+    protected static $exceptionClass = ConfigurationException::class;
 
     /**
      * Creates an aggregate credentials provider that invokes the provided
@@ -138,7 +110,7 @@ class ConfigurationProvider
         if (isset($config['endpoint_discovery'])
             && $config['endpoint_discovery'] instanceof CacheInterface
         ) {
-            return self::cache($memo, $config['endpoint_discovery'], self::CACHE_KEY);
+            return self::cache($memo, $config['endpoint_discovery'], self::$cacheKey);
         }
 
         return $memo;
@@ -187,25 +159,6 @@ class ConfigurationProvider
     }
 
     /**
-     * Gets the environment's HOME directory if available.
-     *
-     * @return null|string
-     */
-    private static function getHomeDir()
-    {
-        // On Linux/Unix-like systems, use the HOME environment variable
-        if ($homeDir = getenv('HOME')) {
-            return $homeDir;
-        }
-
-        // Get the HOMEDRIVE and HOMEPATH values for Windows hosts
-        $homeDrive = getenv('HOMEDRIVE');
-        $homePath = getenv('HOMEPATH');
-
-        return ($homeDrive && $homePath) ? $homeDrive . $homePath : null;
-    }
-
-    /**
      * Config provider that creates config using an ini file stored
      * in the current user's home directory.
      *
@@ -248,52 +201,6 @@ class ConfigurationProvider
                 )
             );
         };
-    }
-
-    /**
-     * Wraps a config provider and caches previously provided configuration.
-     *
-     * Ensures that cached configuration is refreshed when it expires.
-     *
-     * @param callable $provider Config provider function to wrap.
-     *
-     * @return callable
-     */
-    public static function memoize(callable $provider)
-    {
-        return function () use ($provider) {
-            static $result;
-            static $isConstant;
-
-            // Constant config will be returned constantly.
-            if ($isConstant) {
-                return $result;
-            }
-
-            // Create the initial promise that will be used as the cached value
-            // until it expires.
-            if (null === $result) {
-                $result = $provider();
-            }
-
-            // Return config and set flag that provider is already set
-            return $result
-                ->then(function (ConfigurationInterface $config) use (&$isConstant) {
-                    $isConstant = true;
-                    return $config;
-                });
-        };
-    }
-
-    /**
-     * Reject promise with standardized exception.
-     *
-     * @param $msg
-     * @return Promise\RejectedPromise
-     */
-    private static function reject($msg)
-    {
-        return new Promise\RejectedPromise(new ConfigurationException($msg));
     }
 
     /**

--- a/src/EndpointDiscovery/ConfigurationProvider.php
+++ b/src/EndpointDiscovery/ConfigurationProvider.php
@@ -58,15 +58,16 @@ class ConfigurationProvider extends AbstractConfigurationProvider
 
     /**
      * Create a default config provider that first checks for environment
-     * variables, then checks for a specified profile in ~/.aws/config, then
-     * checks for the "default" profile in ~/.aws/config, and failing those uses
-     * a default fallback set of configuration options.
+     * variables, then checks for a specified profile in the environment-defined
+     * config file location (env variable is 'AWS_CONFIG_FILE', file location
+     * defaults to ~/.aws/config), then checks for the "default" profile in the
+     * environment-defined config file location, and failing those uses a default
+     * fallback set of configuration options.
      *
      * This provider is automatically wrapped in a memoize function that caches
      * previously provided config options.
      *
-     * @param array $config Optional array of ecs/instance profile credentials
-     *                      provider options.
+     * @param array $config
      *
      * @return callable
      */
@@ -134,14 +135,15 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     }
 
     /**
-     * Config provider that creates config using an ini file stored
-     * in the current user's home directory.
+     * Config provider that creates config using a config file whose location
+     * is specified by an environment variable 'AWS_CONFIG_FILE', defaulting to
+     * ~/.aws/config if not specified
      *
      * @param string|null $profile  Profile to use. If not specified will use
-     *                              the "default" profile in "~/.aws/config".
+     *                              the "default" profile.
      * @param string|null $filename If provided, uses a custom filename rather
-     *                              than looking in the home directory.
-     * @param int $cacheLimit
+     *                              than looking in the default directory.
+     * @param int         $cacheLimit
      *
      * @return callable
      */

--- a/src/EndpointDiscovery/ConfigurationProvider.php
+++ b/src/EndpointDiscovery/ConfigurationProvider.php
@@ -175,7 +175,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $filename = null,
         $cacheLimit = self::DEFAULT_CACHE_LIMIT
     ) {
-        $filename = $filename ?: (self::getHomeDir() . '/.aws/config');
+        $filename = $filename ?: (self::getDefaultConfigFilename());
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
         return function () use ($profile, $filename, $cacheLimit) {

--- a/src/EndpointDiscovery/ConfigurationProvider.php
+++ b/src/EndpointDiscovery/ConfigurationProvider.php
@@ -57,31 +57,6 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     protected static $exceptionClass = ConfigurationException::class;
 
     /**
-     * Creates an aggregate credentials provider that invokes the provided
-     * variadic providers one after the other until a provider returns
-     * credentials.
-     *
-     * @return callable
-     */
-    public static function chain()
-    {
-        $links = func_get_args();
-        if (empty($links)) {
-            throw new \InvalidArgumentException('No providers in chain');
-        }
-
-        return function () use ($links) {
-            /** @var callable $parent */
-            $parent = array_shift($links);
-            $promise = $parent();
-            while ($next = array_shift($links)) {
-                $promise = $promise->otherwise($next);
-            }
-            return $promise;
-        };
-    }
-
-    /**
      * Create a default config provider that first checks for environment
      * variables, then checks for a specified profile in ~/.aws/config, then
      * checks for the "default" profile in ~/.aws/config, and failing those uses

--- a/src/S3/RegionalEndpoint/ConfigurationProvider.php
+++ b/src/S3/RegionalEndpoint/ConfigurationProvider.php
@@ -55,9 +55,11 @@ class ConfigurationProvider extends AbstractConfigurationProvider
 
     /**
      * Create a default config provider that first checks for environment
-     * variables, then checks for a specified profile in ~/.aws/config, then
-     * checks for the "default" profile in ~/.aws/config, and failing those uses
-     * a default fallback set of configuration options.
+     * variables, then checks for a specified profile in the environment-defined
+     * config file location (env variable is 'AWS_CONFIG_FILE', file location
+     * defaults to ~/.aws/config), then checks for the "default" profile in the
+     * environment-defined config file location, and failing those uses a default
+     * fallback set of configuration options.
      *
      * This provider is automatically wrapped in a memoize function that caches
      * previously provided config options.
@@ -104,13 +106,14 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     }
 
     /**
-     * Config provider that creates config using an ini file stored
-     * in the current user's home directory.
+     * Config provider that creates config using a config file whose location
+     * is specified by an environment variable 'AWS_CONFIG_FILE', defaulting to
+     * ~/.aws/config if not specified
      *
      * @param string|null $profile  Profile to use. If not specified will use
-     *                              the "default" profile in "~/.aws/config".
+     *                              the "default" profile.
      * @param string|null $filename If provided, uses a custom filename rather
-     *                              than looking in the home directory.
+     *                              than looking in the default directory.
      *
      * @return callable
      */

--- a/src/S3/RegionalEndpoint/ConfigurationProvider.php
+++ b/src/S3/RegionalEndpoint/ConfigurationProvider.php
@@ -118,7 +118,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $profile = null,
         $filename = null
     ) {
-        $filename = $filename ?: (self::getHomeDir() . '/.aws/config');
+        $filename = $filename ?: (self::getDefaultConfigFilename());
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
         return function () use ($profile, $filename) {

--- a/src/S3/UseArnRegion/ConfigurationProvider.php
+++ b/src/S3/UseArnRegion/ConfigurationProvider.php
@@ -7,6 +7,40 @@ use Aws\ConfigurationProviderInterface;
 use Aws\S3\UseArnRegion\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 
+/**
+ * A configuration provider is a function that returns a promise that is
+ * fulfilled with a {@see \Aws\S3\UseArnRegion\ConfigurationInterface}
+ * or rejected with an {@see \Aws\S3\UseArnRegion\Exception\ConfigurationException}.
+ *
+ * <code>
+ * use Aws\S3\UseArnRegion\ConfigurationProvider;
+ * $provider = ConfigurationProvider::defaultProvider();
+ * // Returns a ConfigurationInterface or throws.
+ * $config = $provider()->wait();
+ * </code>
+ *
+ * Configuration providers can be composed to create configuration using
+ * conditional logic that can create different configurations in different
+ * environments. You can compose multiple providers into a single provider using
+ * {@see Aws\S3\UseArnRegion\ConfigurationProvider::chain}. This function
+ * accepts providers as variadic arguments and returns a new function that will
+ * invoke each provider until a successful configuration is returned.
+ *
+ * <code>
+ * // First try an INI file at this location.
+ * $a = ConfigurationProvider::ini(null, '/path/to/file.ini');
+ * // Then try an INI file at this location.
+ * $b = ConfigurationProvider::ini(null, '/path/to/other-file.ini');
+ * // Then try loading from environment variables.
+ * $c = ConfigurationProvider::env();
+ * // Combine the three providers together.
+ * $composed = ConfigurationProvider::chain($a, $b, $c);
+ * // Returns a promise that is fulfilled with a configuration or throws.
+ * $promise = $composed();
+ * // Wait on the configuration to resolve.
+ * $config = $promise->wait();
+ * </code>
+ */
 class ConfigurationProvider extends AbstractConfigurationProvider
     implements ConfigurationProviderInterface
 {
@@ -19,6 +53,20 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     protected static $interfaceClass = ConfigurationInterface::class;
     protected static $exceptionClass = ConfigurationException::class;
 
+    /**
+     * Create a default config provider that first checks for environment
+     * variables, then checks for a specified profile in the environment-defined
+     * config file location (defaults to ~/.aws/config), then checks for the
+     * "default" profile in the environment-defined config file location, and
+     * failing those uses a default fallback set of configuration options.
+     *
+     * This provider is automatically wrapped in a memoize function that caches
+     * previously provided config options.
+     *
+     * @param array $config
+     *
+     * @return callable
+     */
     public static function defaultProvider(array $config = [])
     {
         $configProviders = [
@@ -40,6 +88,11 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         return $memo;
     }
 
+    /**
+     * Provider that creates config from environment variables.
+     *
+     * @return callable
+     */
     public static function env()
     {
         return function () {
@@ -56,6 +109,18 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         };
     }
 
+    /**
+     * Config provider that creates config using a config file whose location
+     * is specified by an environment variable 'AWS_CONFIG_FILE', defaulting to
+     * ~/.aws/config if not specified
+     *
+     * @param string|null $profile  Profile to use. If not specified will use
+     *                              the "default" profile.
+     * @param string|null $filename If provided, uses a custom filename rather
+     *                              than looking in the default directory.
+     *
+     * @return callable
+     */
     public static function ini($profile = null, $filename = null)
     {
         $filename = $filename ?: (self::getDefaultConfigFilename());
@@ -90,6 +155,11 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         };
     }
 
+    /**
+     * Fallback config options when other sources are not set.
+     *
+     * @return callable
+     */
     public static function fallback()
     {
         return function () {

--- a/src/S3/UseArnRegion/ConfigurationProvider.php
+++ b/src/S3/UseArnRegion/ConfigurationProvider.php
@@ -56,9 +56,10 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     /**
      * Create a default config provider that first checks for environment
      * variables, then checks for a specified profile in the environment-defined
-     * config file location (defaults to ~/.aws/config), then checks for the
-     * "default" profile in the environment-defined config file location, and
-     * failing those uses a default fallback set of configuration options.
+     * config file location (env variable is 'AWS_CONFIG_FILE', file location
+     * defaults to ~/.aws/config), then checks for the "default" profile in the
+     * environment-defined config file location, and failing those uses a default
+     * fallback set of configuration options.
      *
      * This provider is automatically wrapped in a memoize function that caches
      * previously provided config options.

--- a/src/S3/UseArnRegion/ConfigurationProvider.php
+++ b/src/S3/UseArnRegion/ConfigurationProvider.php
@@ -58,7 +58,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
 
     public static function ini($profile = null, $filename = null)
     {
-        $filename = $filename ?: (self::getHomeDir() . '/.aws/config');
+        $filename = $filename ?: (self::getDefaultConfigFilename());
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
         return function () use ($profile, $filename) {

--- a/src/Sts/RegionalEndpoints/ConfigurationProvider.php
+++ b/src/Sts/RegionalEndpoints/ConfigurationProvider.php
@@ -139,7 +139,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $profile = null,
         $filename = null
     ) {
-        $filename = $filename ?: (self::getHomeDir() . '/.aws/config');
+        $filename = $filename ?: (self::getDefaultConfigFilename());
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
         return function () use ($profile, $filename) {

--- a/src/Sts/RegionalEndpoints/ConfigurationProvider.php
+++ b/src/Sts/RegionalEndpoints/ConfigurationProvider.php
@@ -57,9 +57,11 @@ class ConfigurationProvider extends AbstractConfigurationProvider
 
     /**
      * Create a default config provider that first checks for environment
-     * variables, then checks for a specified profile in ~/.aws/config, then
-     * checks for the "default" profile in ~/.aws/config, and failing those uses
-     * a default fallback set of configuration options.
+     * variables, then checks for a specified profile in the environment-defined
+     * config file location (env variable is 'AWS_CONFIG_FILE', file location
+     * defaults to ~/.aws/config), then checks for the "default" profile in the
+     * environment-defined config file location, and failing those uses a default
+     * fallback set of configuration options.
      *
      * This provider is automatically wrapped in a memoize function that caches
      * previously provided config options.
@@ -125,13 +127,14 @@ class ConfigurationProvider extends AbstractConfigurationProvider
     }
 
     /**
-     * Config provider that creates config using an ini file stored
-     * in the current user's home directory.
+     * Config provider that creates config using a config file whose location
+     * is specified by an environment variable 'AWS_CONFIG_FILE', defaulting to
+     * ~/.aws/config if not specified
      *
      * @param string|null $profile  Profile to use. If not specified will use
-     *                              the "default" profile in "~/.aws/config".
+     *                              the "default" profile.
      * @param string|null $filename If provided, uses a custom filename rather
-     *                              than looking in the home directory.
+     *                              than looking in the default directory.
      *
      * @return callable
      */

--- a/tests/ClientSideMonitoring/ConfigurationProviderTest.php
+++ b/tests/ClientSideMonitoring/ConfigurationProviderTest.php
@@ -33,6 +33,19 @@ csm_client_id = CustomIniApp
 csm_enabled = true
 EOT;
 
+    private $altIniFile = <<<EOT
+[aws_csm]
+csm_enabled = false
+csm_host = 987.6.5.4
+csm_port = 888
+csm_client_id = AltIniApp
+[custom]
+csm_enabled = true
+csm_host = 192.168.5.5
+csm_port = 999
+csm_client_id = CustomAltIniApp
+EOT;
+
     public static function setUpBeforeClass()
     {
         self::$originalEnv = [
@@ -51,6 +64,7 @@ EOT;
         putenv(ConfigurationProvider::ENV_PORT . '=');
         putenv(ConfigurationProvider::ENV_CLIENT_ID . '=');
         putenv(ConfigurationProvider::ENV_PROFILE . '=');
+        putenv(ConfigurationProvider::ENV_CONFIG_FILE . '=');
 
         $dir = sys_get_temp_dir() . '/.aws';
 
@@ -139,6 +153,21 @@ EOT;
         $result = call_user_func(ConfigurationProvider::ini())->wait();
         $this->assertSame($expected->toArray(), $result->toArray());
         unlink($dir . '/config');
+    }
+
+    public function testCreatesFromIniFileWithDifferentDefaultFilename()
+    {
+        $dir = $this->clearEnv();
+        putenv(ConfigurationProvider::ENV_CONFIG_FILE . '=' . $dir . "/alt_config");
+        $expected  = new Configuration(false, '987.6.5.4', 888, 'AltIniApp');
+        file_put_contents($dir . '/config', $this->iniFile);
+        file_put_contents($dir . '/alt_config', $this->altIniFile);
+        putenv('HOME=' . dirname($dir));
+        /** @var ConfigurationInterface $result */
+        $result = call_user_func(ConfigurationProvider::ini(null, null))->wait();
+        $this->assertSame($expected->toArray(), $result->toArray());
+        unlink($dir . '/config');
+        unlink($dir . '/alt_config');
     }
 
     public function testCreatesFromIniFileWithSpecifiedProfile()

--- a/tests/ClientSideMonitoring/ConfigurationProviderTest.php
+++ b/tests/ClientSideMonitoring/ConfigurationProviderTest.php
@@ -364,7 +364,7 @@ EOT;
         $cache = $cacheBuilder->getMock();
         $cache->expects($this->any())
             ->method('get')
-            ->with(ConfigurationProvider::CACHE_KEY)
+            ->with(ConfigurationProvider::$cacheKey)
             ->willReturn($expected);
 
         $provider = ConfigurationProvider::defaultProvider(['csm' => $cache]);

--- a/tests/EndpointDiscovery/ConfigurationProviderTest.php
+++ b/tests/EndpointDiscovery/ConfigurationProviderTest.php
@@ -345,7 +345,7 @@ EOT;
         $cache = $cacheBuilder->getMock();
         $cache->expects($this->any())
             ->method('get')
-            ->with(ConfigurationProvider::CACHE_KEY)
+            ->with(ConfigurationProvider::$cacheKey)
             ->willReturn($expected);
 
         $provider = ConfigurationProvider::defaultProvider(['endpoint_discovery' => $cache]);

--- a/tests/EndpointDiscovery/ConfigurationProviderTest.php
+++ b/tests/EndpointDiscovery/ConfigurationProviderTest.php
@@ -26,6 +26,13 @@ endpoint_discovery_enabled = true
 endpoint_discovery_enabled = false
 EOT;
 
+    private $altIniFile = <<<EOT
+[custom]
+endpoint_discovery_enabled = true
+[default]
+endpoint_discovery_enabled = false
+EOT;
+
     public static function setUpBeforeClass()
     {
         self::$originalEnv = [
@@ -40,6 +47,7 @@ EOT;
     {
         putenv(ConfigurationProvider::ENV_ENABLED . '=');
         putenv(ConfigurationProvider::ENV_ENABLED_ALT . '=');
+        putenv(ConfigurationProvider::ENV_CONFIG_FILE . '=');
 
         $dir = sys_get_temp_dir() . '/.aws';
 
@@ -120,6 +128,21 @@ EOT;
         $result = call_user_func(ConfigurationProvider::ini(null, null, 2000))->wait();
         $this->assertSame($expected->toArray(), $result->toArray());
         unlink($dir . '/config');
+    }
+
+    public function testCreatesFromIniFileWithDifferentDefaultFilename()
+    {
+        $dir = $this->clearEnv();
+        putenv(ConfigurationProvider::ENV_CONFIG_FILE . '=' . $dir . "/alt_config");
+        $expected  = new Configuration(false);
+        file_put_contents($dir . '/config', $this->iniFile);
+        file_put_contents($dir . '/alt_config', $this->altIniFile);
+        putenv('HOME=' . dirname($dir));
+        /** @var ConfigurationInterface $result */
+        $result = call_user_func(ConfigurationProvider::ini(null, null))->wait();
+        $this->assertSame($expected->toArray(), $result->toArray());
+        unlink($dir . '/config');
+        unlink($dir . '/alt_config');
     }
 
     public function testCreatesFromIniFileWithSpecifiedProfile()

--- a/tests/Sts/RegionalEndpoints/ConfigurationProviderTest.php
+++ b/tests/Sts/RegionalEndpoints/ConfigurationProviderTest.php
@@ -24,6 +24,13 @@ sts_regional_endpoints = regional
 sts_regional_endpoints = legacy
 EOT;
 
+    private $altIniFile = <<<EOT
+[custom]
+sts_regional_endpoints = legacy
+[default]
+sts_regional_endpoints = regional
+EOT;
+
     public static function setUpBeforeClass()
     {
         self::$originalEnv = [
@@ -36,6 +43,7 @@ EOT;
     private function clearEnv()
     {
         putenv(ConfigurationProvider::ENV_ENDPOINTS_TYPE . '=');
+        putenv(ConfigurationProvider::ENV_CONFIG_FILE . '=');
 
         $dir = sys_get_temp_dir() . '/.aws';
 
@@ -102,6 +110,21 @@ EOT;
         $result = call_user_func(ConfigurationProvider::ini(null, null))->wait();
         $this->assertSame($expected->toArray(), $result->toArray());
         unlink($dir . '/config');
+    }
+
+    public function testCreatesFromIniFileWithDifferentDefaultFilename()
+    {
+        $dir = $this->clearEnv();
+        putenv(ConfigurationProvider::ENV_CONFIG_FILE . '=' . $dir . "/alt_config");
+        $expected  = new Configuration('regional');
+        file_put_contents($dir . '/config', $this->iniFile);
+        file_put_contents($dir . '/alt_config', $this->altIniFile);
+        putenv('HOME=' . dirname($dir));
+        /** @var ConfigurationInterface $result */
+        $result = call_user_func(ConfigurationProvider::ini(null, null))->wait();
+        $this->assertSame($expected->toArray(), $result->toArray());
+        unlink($dir . '/config');
+        unlink($dir . '/alt_config');
     }
 
     public function testCreatesFromIniFileWithSpecifiedProfile()

--- a/tests/Sts/RegionalEndpoints/ConfigurationProviderTest.php
+++ b/tests/Sts/RegionalEndpoints/ConfigurationProviderTest.php
@@ -297,7 +297,7 @@ EOT;
         $cache = $cacheBuilder->getMock();
         $cache->expects($this->any())
             ->method('get')
-            ->with(ConfigurationProvider::CACHE_KEY)
+            ->with(ConfigurationProvider::$cacheKey)
             ->willReturn($expected);
 
         $provider = ConfigurationProvider::defaultProvider(['sts_regional_endpoints' => $cache]);


### PR DESCRIPTION
* Adds support for the `AWS_CONFIG_FILE` environment variable to set the default config file location. This is implemented for all configuration provider classes extending `AbstractConfigurationProvider`.

Resolves #1931 