### PR TITLE
Allow Guzzle 7

### DIFF
--- a/.changes/nextrelease/guzzle7.json
+++ b/.changes/nextrelease/guzzle7.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "",
+    "description": "Add support for Guzzle7."
+  }
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
     - php: hhvm
     - php: nightly
   fast_finish: true
+  include:
+    - name: "Guzzle 7 beta"
+      php: 7.3
+      env: COMPOSER_OPTS="--no-interaction"
+      before_install:
+        - composer require "guzzlehttp/guzzle:^7.0@beta"
 
 sudo: false
 
@@ -49,6 +55,7 @@ install:
   # Resolve dependencies
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
+  - composer show guzzlehttp/guzzle
 
 script:
   # Unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - php: nightly
   fast_finish: true
   include:
-    - name: "Guzzle 7 beta"
+    - name: "PHP: 7.3 - Guzzle 7 beta"
       php: 7.3
       env: COMPOSER_OPTS="--no-interaction"
       before_install:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^5.3.3|^6.2.1",
+        "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
         "guzzlehttp/psr7": "^1.4.1",
         "guzzlehttp/promises": "~1.0",
         "mtdowling/jmespath.php": "~2.2",

--- a/src/functions.php
+++ b/src/functions.php
@@ -272,13 +272,15 @@ function describe_type($input)
  */
 function default_http_handler()
 {
-    $version = (string) ClientInterface::VERSION;
-    if ($version[0] === '5') {
-        return new \Aws\Handler\GuzzleV5\GuzzleHandler();
+    $version = guzzle_major_version();
+    // If Guzzle 6 or 7 installed
+    if ($version === 6 || $version === 7) {
+        return new \Aws\Handler\GuzzleV6\GuzzleHandler();
     }
 
-    if ($version[0] === '6') {
-        return new \Aws\Handler\GuzzleV6\GuzzleHandler();
+    // If Guzzle 5 installed
+    if ($version === 5) {
+        return new \Aws\Handler\GuzzleV5\GuzzleHandler();
     }
 
     throw new \RuntimeException('Unknown Guzzle version: ' . $version);
@@ -291,16 +293,42 @@ function default_http_handler()
  */
 function default_user_agent()
 {
-    $version = (string) ClientInterface::VERSION;
-    if ($version[0] === '5') {
-        return \GuzzleHttp\Client::getDefaultUserAgent();
-    }
-
-    if ($version[0] === '6') {
+    $version = guzzle_major_version();
+    // If Guzzle 6 or 7 installed
+    if ($version === 6 || $version === 7) {
         return \GuzzleHttp\default_user_agent();
     }
 
+    // If Guzzle 5 installed
+    if ($version === 5) {
+        return \GuzzleHttp\Client::getDefaultUserAgent();
+    }
+
     throw new \RuntimeException('Unknown Guzzle version: ' . $version);
+}
+
+/**
+ * Get the major version of guzzle that is installed.
+ *
+ * @internal This function is internal and should not be used outside aws/aws-sdk-php.
+ * @return int
+ * @throws \RuntimeException
+ */
+function guzzle_major_version()
+{
+    if (defined('\GuzzleHttp\ClientInterface::VERSION')) {
+        $version = (string) ClientInterface::VERSION;
+        if ($version[0] === '6') {
+            return 6;
+        }
+        if ($version[0] === '5') {
+            return 5;
+        }
+    } elseif (method_exists('\GuzzleHttp\Client', 'sendRequest')) {
+        return 7;
+    }
+
+    throw new \RuntimeException('Unable to determine what Guzzle version is installed.');
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -317,16 +317,21 @@ function default_user_agent()
  */
 function guzzle_major_version()
 {
+    static $cache = null;
+    if (null !== $cache) {
+        return $cache;
+    }
+
     if (defined('\GuzzleHttp\ClientInterface::VERSION')) {
         $version = (string) ClientInterface::VERSION;
         if ($version[0] === '6') {
-            return 6;
+            return $cache = 6;
         }
         if ($version[0] === '5') {
-            return 5;
+            return $cache = 5;
         }
     } elseif (method_exists(Client::class, 'sendRequest')) {
-        return 7;
+        return $cache = 7;
     }
 
     throw new \RuntimeException('Unable to determine what Guzzle version is installed.');

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws;
 
+use GuzzleHttp\Client;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
@@ -324,7 +325,7 @@ function guzzle_major_version()
         if ($version[0] === '5') {
             return 5;
         }
-    } elseif (method_exists('\GuzzleHttp\Client', 'sendRequest')) {
+    } elseif (method_exists(Client::class, 'sendRequest')) {
         return 7;
     }
 

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -113,9 +113,9 @@ class EcsCredentialProviderTest extends TestCase
     {
         $t = (time() + 1000);
         $credentials = $this->getCredentialArray('foo', 'baz', null, "@{$t}");
-        $version = (string) ClientInterface::VERSION;
+        $version = \Aws\guzzle_major_version();
 
-        if ($version[0] === '5') {
+        if ($version === 5) {
             return new \Aws\Handler\GuzzleV5\GuzzleHandler(
                 new Client([
                     'handler' => function (
@@ -134,7 +134,7 @@ class EcsCredentialProviderTest extends TestCase
             );
         }
 
-        if ($version[0] === '6') {
+        if ($version === 6 || $version === 7) {
             return new \Aws\Handler\GuzzleV6\GuzzleHandler(
                 new Client([
                     'handler' => function (

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -51,8 +51,8 @@ class InstanceProfileProviderTest extends TestCase
     private function getRequestClass()
     {
         // Guzzle 5 vs 6 namespace differences
-        $version = (string) ClientInterface::VERSION;
-        if ($version[0] === '5') {
+        $version = \Aws\guzzle_major_version();
+        if ($version === 5) {
             return "\GuzzleHttp\Message\Request";
         }
         return "\GuzzleHttp\Psr7\Request";
@@ -61,8 +61,8 @@ class InstanceProfileProviderTest extends TestCase
     private function getResponseClass()
     {
         // Guzzle 5 vs 6 namespace differences
-        $version = (string) ClientInterface::VERSION;
-        if ($version[0] === '5') {
+        $version = \Aws\guzzle_major_version();
+        if ($version === 5) {
             return "\GuzzleHttp\Message\Response";
         }
         return "\GuzzleHttp\Psr7\Response";
@@ -70,13 +70,13 @@ class InstanceProfileProviderTest extends TestCase
 
     private function getRequestException()
     {
-        $version = (string) ClientInterface::VERSION;
-        if ($version[0] === '6') {
+        $version = \Aws\guzzle_major_version();
+        if ($version === 6 || $version === 7) {
             return new RequestException(
                 'test',
                 new Psr7\Request('GET', 'http://www.example.com')
             );
-        } elseif ($version[0] === '5') {
+        } elseif ($version === 5) {
             return new RequestException(
                 'test',
                 new \GuzzleHttp\Message\Request('GET', 'http://www.example.com')

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -91,8 +91,8 @@ class RetryMiddlewareTest extends TestCase
         $decider = RetryMiddleware::createDefaultDecider();
         $command = new Command('foo');
         $request = new Request('GET', 'http://www.example.com');
-        $version = (string) ClientInterface::VERSION;
-        if ($version[0] === '6') {
+        $version = \Aws\guzzle_major_version();
+        if ($version === 6 || $version === 7) {
             $previous = new RequestException(
                 'test',
                 $request,
@@ -100,7 +100,7 @@ class RetryMiddlewareTest extends TestCase
                 null,
                 ['errno' => CURLE_RECV_ERROR]
             );
-        } elseif ($version[0] === '5') {
+        } elseif ($version === 5) {
             $previous = new RequestException(
                 'cURL error ' . CURLE_RECV_ERROR . ': test',
                 new \GuzzleHttp\Message\Request('GET', 'http://www.example.com')
@@ -126,10 +126,10 @@ class RetryMiddlewareTest extends TestCase
         );
         $command = new Command('foo');
         $request = new Request('GET', 'http://www.example.com');
-        $version = (string) ClientInterface::VERSION;
+        $version = \Aws\guzzle_major_version();
 
         // Custom error passed in to decider config should result in a retry
-        if ($version[0] === '6') {
+        if ($version === 6 || $version === 7) {
             $previous = new RequestException(
                 'test',
                 $request,
@@ -137,7 +137,7 @@ class RetryMiddlewareTest extends TestCase
                 null,
                 ['errno' => CURLE_BAD_CONTENT_ENCODING]
             );
-        } elseif ($version[0] === '5') {
+        } elseif ($version === 5) {
             $previous = new RequestException(
                 'cURL error ' . CURLE_BAD_CONTENT_ENCODING . ': test',
                 new \GuzzleHttp\Message\Request('GET', 'http://www.example.com')
@@ -152,7 +152,7 @@ class RetryMiddlewareTest extends TestCase
         $this->assertTrue($decider(0, $command, $request, null, $err));
 
         // Error not passed in to decider config should result in no retry
-        if ($version[0] === '6') {
+        if ($version === 6 || $version === 7) {
             $previous = new RequestException(
                 'test',
                 $request,
@@ -160,7 +160,7 @@ class RetryMiddlewareTest extends TestCase
                 null,
                 ['errno' => CURLE_ABORTED_BY_CALLBACK]
             );
-        } elseif ($version[0] === '5') {
+        } elseif ($version === 5) {
             $previous = new RequestException(
                 'cURL error ' . CURLE_ABORTED_BY_CALLBACK . ': test',
                 new \GuzzleHttp\Message\Request('GET', 'http://www.example.com')


### PR DESCRIPTION
We just released a beta of Guzzle 7 today. The [BC breaking changes](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70) have been kept to a minimum. 

This PR allows users to use AWS SDK with Guzzle 7. 