### PR TITLE
Load private key for cloudfront signer from variable

### DIFF
--- a/.changes/nextrelease/cloudfront_signer.json
+++ b/.changes/nextrelease/cloudfront_signer.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "CloudFront",
+    "description": "CloudFront Signer now accepts PEM formatted private keys stored as variables in addition to the path to a key file."
+  }
+]

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -31,8 +31,16 @@ class Signer
 
         $this->keyPairId = $keyPairId;
 
-        if (!file_exists($privateKey)) {
-            throw new \InvalidArgumentException("PK file not found: $privateKey");
+        if (!$this->pkHandle = openssl_pkey_get_private($privateKey, $passphrase)) {
+            if (!file_exists($privateKey)) {
+                throw new \InvalidArgumentException("PK file not found: $privateKey");
+            } else {
+                $this->pkHandle = openssl_get_privatekey("file://$privateKey", $passphrase);
+
+                if (!$this->pkHandle) {
+                    throw new \InvalidArgumentException(openssl_error_string());
+                }
+            }
         }
 
         $this->pkHandle = openssl_pkey_get_private("file://$privateKey", $passphrase);

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -35,18 +35,11 @@ class Signer
             if (!file_exists($privateKey)) {
                 throw new \InvalidArgumentException("PK file not found: $privateKey");
             } else {
-                $this->pkHandle = openssl_get_privatekey("file://$privateKey", $passphrase);
-
+                $this->pkHandle = openssl_pkey_get_private("file://$privateKey", $passphrase);
                 if (!$this->pkHandle) {
                     throw new \InvalidArgumentException(openssl_error_string());
                 }
             }
-        }
-
-        $this->pkHandle = openssl_pkey_get_private("file://$privateKey", $passphrase);
-
-        if (!$this->pkHandle) {
-            throw new \InvalidArgumentException(openssl_error_string());
         }
     }
 

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -27,18 +27,32 @@ class SignerTest extends TestCase
      * Assert that the key is parsed during construction
      *
      * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageRegExp /PK .*Not a real private key/
+     */
+    public function testBadPrivateKeyContents() {
+        $privateKey = "Not a real private key";
+        $s = new Signer(
+            "not a real keypair id",
+            $privateKey
+        );
+    }
+
+    /**
+     * Assert that the key is parsed during construction
+     *
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /PEM .*no start line/
      */
-    public function testBadPrivateKey() {
+    public function testBadPrivateKeyPath() {
         $filename = tempnam(sys_get_temp_dir(), 'cloudfront-fake-key');
         file_put_contents($filename, "Not a real private key");
         try {
-           $s = new Signer(
-               "not a real keypair id",
-               $filename
-           );
+            $s = new Signer(
+                "not a real keypair id",
+                $filename
+            );
         } finally {
-           unlink($filename);
+            unlink($filename);
         }
     }
 

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -24,7 +24,7 @@ class SignerTest extends TestCase
     }
 
     /**
-     * Assert that the key is parsed during construction
+     * Assert that the key variable contents are parsed during construction
      *
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /PK .*Not a real private key/
@@ -38,7 +38,7 @@ class SignerTest extends TestCase
     }
 
     /**
-     * Assert that the key is parsed during construction
+     * Assert that the key file is parsed during construction
      *
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /PEM .*no start line/


### PR DESCRIPTION
*Issue #, if available:* 
Resolves #1928 

*Description of changes:*
Added logic to CF signer's construct function to allow for private keys stored as variables in addition to those stored on disk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
