### PR TITLE
Update inaccurate documentation for CredentialProvider::cache() method

### DIFF
--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -215,8 +215,6 @@ class CredentialProvider
      * instance of Aws\CacheInterface. Forwards calls when no credentials found
      * in cache and updates cache with the results.
      *
-     * Defaults to using a simple file-based cache when none provided.
-     *
      * @param callable $provider Credentials provider function to wrap
      * @param CacheInterface $cache Cache to store credentials
      * @param string|null $cacheKey (optional) Cache key to use


### PR DESCRIPTION
**Description of changes:**

Very little contribution. This is about removing inaccurate documentation for `CredentialProvider::cache()` method


------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
