### PR TITLE
#1953 Host validation for IP address while trying to use host-style requests

### DIFF
--- a/.changes/nextrelease/1953-host-style-ip-address-check.json
+++ b/.changes/nextrelease/1953-host-style-ip-address-check.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Fixing incorrect detection of host-style endpoint pattern while using IP address"
+  }
+]

--- a/src/S3/S3EndpointMiddleware.php
+++ b/src/S3/S3EndpointMiddleware.php
@@ -110,7 +110,8 @@ class S3EndpointMiddleware
             && (
                 $request->getUri()->getScheme() === 'http'
                 || strpos($command['Bucket'], '.') === false
-            );
+            )
+            && filter_var($request->getUri()->getHost(), FILTER_VALIDATE_IP) === false;
     }
 
     private function endpointPatternDecider(


### PR DESCRIPTION
Resolves issue #1953 

We validate for host while trying to use host-style requests (we have to make sure that it's not a valid IP address)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
