### PR TITLE
Fix error thrown when invalid debug option is passed

### DIFF
--- a/.changes/nextrelease/fix_invalid_debug_option
+++ b/.changes/nextrelease/fix_invalid_debug_option
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "S3\\Transfer",
+        "description": "Fix handling of 'debug' values different than true and valid resources."
+    }
+]

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -129,7 +129,9 @@ class Transfer implements PromisorInterface
             if ($options['debug'] === true) {
                 $options['debug'] = fopen('php://output', 'w');
             }
-            $this->addDebugToBefore($options['debug']);
+            if (is_resource($options['debug'])) {
+                $this->addDebugToBefore($options['debug']);
+            }
         }
     }
 

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -193,6 +193,31 @@ class TransferTest extends TestCase
         `rm -rf $dir`;
     }
 
+    public function testDebugFalse()
+    {
+        $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [
+            new Result(['UploadId' => '123']),
+            new Result(['ETag' => 'a']),
+            new Result(['ETag' => 'b']),
+            new Result(['UploadId' => '123']),
+        ]);
+
+        $dir = sys_get_temp_dir() . '/unittest';
+        `rm -rf $dir`;
+        mkdir($dir);
+        $filename = $dir . '/large.txt';
+        $f = fopen($filename, 'w+');
+        fwrite($f, '...');
+        fclose($f);
+
+        $t = new Transfer($s3, $dir, 's3://foo/bar', [
+            'debug' => false
+        ]);
+
+        $this->assertNull($t->transfer());
+    }
+
     public function testDownloadsObjectsWithAccessPointArn()
     {
         $s3 = $this->getTestClient('s3');


### PR DESCRIPTION
Hello, 
When a S3 transfer is initiated with the `debug` option set to false, an error occurs, preventing us using the library like this:
```php
$transfer = new Transfer($client, $folder, $target, [
    'debug' => $output->isVeryVerbose(),
]);
```

This patch fixes this, asserting the output is a resource before writing