### PR TITLE
Correct name of instance metadata service

### DIFF
--- a/docs/guide/credentials.rst
+++ b/docs/guide/credentials.rst
@@ -59,7 +59,7 @@ almost no work on your part.
 
 If you do not explicitly provide credentials to the client object and no
 environment variable credentials are available, the SDK attempts to retrieve
-instance profile credentials from an Amazon EC2 instance metadata server. These
+instance profile credentials from an Amazon EC2 instance metadata service. These
 credentials are available only when running on Amazon EC2 instances that have
 been configured with an IAM role.
 

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
- * Credential provider that provides credentials from the EC2 metadata server.
+ * Credential provider that provides credentials from the EC2 metadata service.
  */
 class InstanceProfileProvider
 {
@@ -191,7 +191,7 @@ class InstanceProfileProvider
         $disabled = getenv(self::ENV_DISABLE) ?: false;
         if (strcasecmp($disabled, 'true') === 0) {
             throw new CredentialsException(
-                $this->createErrorMessage('EC2 metadata server access disabled')
+                $this->createErrorMessage('EC2 metadata service access disabled')
             );
         }
 
@@ -254,7 +254,7 @@ class InstanceProfileProvider
     private function createErrorMessage($previous)
     {
         return "Error retrieving credentials from the instance profile "
-            . "metadata server. ({$previous})";
+            . "metadata service. ({$previous})";
     }
 
     private function decodeResult($response)

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -518,7 +518,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (401 Unathorized)'
+                    . 'metadata service. (401 Unathorized)'
                 )
             ],
 
@@ -532,7 +532,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (401 Unathorized)'
+                    . 'metadata service. (401 Unathorized)'
                 )
             ],
 
@@ -546,7 +546,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (401 Unathorized)'
+                    . 'metadata service. (401 Unathorized)'
                 )
             ],
 
@@ -560,7 +560,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (401 Unathorized)'
+                    . 'metadata service. (401 Unathorized)'
                 )
             ],
 
@@ -578,7 +578,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (Error retrieving metadata token)'
+                    . 'metadata service. (Error retrieving metadata token)'
                 )
             ],
 
@@ -596,7 +596,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (503 ThrottlingException)'
+                    . 'metadata service. (503 ThrottlingException)'
                 )
             ],
 
@@ -614,7 +614,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (503 ThrottlingException)'
+                    . 'metadata service. (503 ThrottlingException)'
                 )
             ],
 
@@ -632,7 +632,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (503 ThrottlingException)'
+                    . 'metadata service. (503 ThrottlingException)'
                 )
             ],
 
@@ -650,7 +650,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (503 ThrottlingException)'
+                    . 'metadata service. (503 ThrottlingException)'
                 )
             ],
 
@@ -668,7 +668,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (Invalid JSON response, retries exhausted)'
+                    . 'metadata service. (Invalid JSON response, retries exhausted)'
                 )
             ],
 
@@ -686,7 +686,7 @@ class InstanceProfileProviderTest extends TestCase
                 ),
                 new CredentialsException(
                     'Error retrieving credentials from the instance profile '
-                    . 'metadata server. (Invalid JSON response, retries exhausted)'
+                    . 'metadata service. (Invalid JSON response, retries exhausted)'
                 )
             ],
         ];
@@ -694,7 +694,7 @@ class InstanceProfileProviderTest extends TestCase
 
     /**
      * @expectedException \Aws\Exception\CredentialsException
-     * @expectedExceptionMessage Error retrieving credentials from the instance profile metadata server. (999 Expected Exception)
+     * @expectedExceptionMessage Error retrieving credentials from the instance profile metadata service. (999 Expected Exception)
      */
     public function testSwitchesBackToSecureModeOn401()
     {
@@ -823,7 +823,7 @@ class InstanceProfileProviderTest extends TestCase
             )->wait();
             $this->fail('Did not throw expected CredentialException.');
         } catch (CredentialsException $e) {
-            if (strstr($e->getMessage(), 'EC2 metadata server access disabled') === false) {
+            if (strstr($e->getMessage(), 'EC2 metadata service access disabled') === false) {
                 $this->fail('Did not throw expected CredentialException when '
                     . 'provider is disabled.');
             }


### PR DESCRIPTION
*Description of changes:*

Correcting the name of the instance metadata service (not server).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
