### PR TITLE
fix for encrypt/decrypt implementation method signature

### DIFF
--- a/.changes/nextrelease/abstract_crypto_impl.json
+++ b/.changes/nextrelease/abstract_crypto_impl.json
@@ -1,0 +1,7 @@
+[
+  {
+      "type": "bugfix",
+      "category": "Crypto",
+      "description": "This release fixes a discrepancy between the Encryption/Decryption trait implementations and AbstractCryptoClient method signature."
+  }
+]

--- a/src/Crypto/DecryptionTrait.php
+++ b/src/Crypto/DecryptionTrait.php
@@ -53,7 +53,7 @@ trait DecryptionTrait
      *
      * @internal
      */
-    protected function decrypt(
+    public function decrypt(
         $cipherText,
         MaterialsProvider $provider,
         MetadataEnvelope $envelope,

--- a/src/Crypto/EncryptionTrait.php
+++ b/src/Crypto/EncryptionTrait.php
@@ -48,7 +48,7 @@ trait EncryptionTrait
      *
      * @internal
      */
-    protected function encrypt(
+    public function encrypt(
         Stream $plaintext,
         array $cipherOptions,
         MaterialsProvider $provider,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-sdk-php/issues/1983

*Description of changes:*
PHP 7.4.2 released a patch (https://bugs.php.net/bug.php?id=78776) to verify method signature of traits implementing methods for abstract classes. This is breaking breaking classes that extend `AbstractCryptoClient` and use the `EncryptionTrait` and `DecryptionTrait` traits on PHP >= `7.4.2`.

Let me know if there is anything else I can add to this change. The tests didn't even previously run for `S3EncryptionClient`, was getting:
```
PHP Fatal error:  Access level to Aws\Crypto\EncryptionTrait::encrypt() must be public (as in class Aws\Crypto\AbstractCryptoClient) in /Users/trajano/dev/aws-sdk-php/src/S3/Crypto/S3EncryptionClient.php on line 51
```

This change fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
