### PR TITLE
Elastic inference prefix change

### DIFF
--- a/.changes/nextrelease/parition_endpoint_provider_tweak.json
+++ b/.changes/nextrelease/parition_endpoint_provider_tweak.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Endpoint",
+    "description": "Fix for partition endpoint history logic for keys with hyphens."
+  }
+]

--- a/src/Endpoint/PartitionEndpointProvider.php
+++ b/src/Endpoint/PartitionEndpointProvider.php
@@ -114,10 +114,10 @@ class PartitionEndpointProvider
 
         foreach ($data["partitions"] as $index => $partition) {
             foreach ($prefixGroups as $current => $old) {
-                $serviceData = Env::search("services.{$current}", $partition);
+                $serviceData = Env::search("services.\"{$current}\"", $partition);
                 if (!empty($serviceData)) {
                     foreach ($old as $prefix) {
-                        if (empty(Env::search("services.{$prefix}", $partition))) {
+                        if (empty(Env::search("services.\"{$prefix}\"", $partition))) {
                             $data["partitions"][$index]["services"][$prefix] = $serviceData;
                         }
                     }

--- a/src/data/endpoints_prefix_history.json
+++ b/src/data/endpoints_prefix_history.json
@@ -1,8 +1,10 @@
 {
     "prefix-groups": {
         "api.ecr": ["ecr"],
+        "api.elastic-inference": ["elastic-inference"],
         "api.sagemaker": ["sagemaker"],
         "ecr": ["api.ecr"],
+        "elastic-inference": ["api.elastic-inference"],
         "sagemaker": ["api.sagemaker"]
     }
 }

--- a/src/data/endpoints_prefix_history.json.php
+++ b/src/data/endpoints_prefix_history.json.php
@@ -1,3 +1,3 @@
 <?php
 // This file was auto-generated from sdk-root/src/data/endpoints_prefix_history.json
-return [ 'prefix-groups' => [ 'api.ecr' => [ 'ecr', ], 'api.sagemaker' => [ 'sagemaker', ], 'ecr' => [ 'api.ecr', ], 'sagemaker' => [ 'api.sagemaker', ], ],];
+return [ 'prefix-groups' => [ 'api.ecr' => [ 'ecr', ], 'api.elastic-inference' => [ 'elastic-inference', ], 'api.sagemaker' => [ 'sagemaker', ], 'ecr' => [ 'api.ecr', ], 'elastic-inference' => [ 'api.elastic-inference', ], 'sagemaker' => [ 'api.sagemaker', ], ],];

--- a/tests/Endpoint/PartitionEndpointProviderTest.php
+++ b/tests/Endpoint/PartitionEndpointProviderTest.php
@@ -242,7 +242,7 @@ class PartitionEndpointProviderTest extends TestCase
     {
         $prefixData = [
             "prefix-groups" => [
-                "ec2" => ["ec2_old", "ec2_deprecated"],
+                "ec2" => ["ec2_old", "ec2_deprecated", "ec2-hyphen"],
                 "s3" => ["s3_old"],
             ],
         ];


### PR DESCRIPTION
* Fix for partition endpoint history logic for keys with hyphens.
* Adds elastic-inference to endpoint history aliases