### PR TITLE
Add dependency symfony/polyfill-intl-idn to build

### DIFF
--- a/.changes/nextrelease/package_builder.json
+++ b/.changes/nextrelease/package_builder.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "build/packager",
+        "description": "Adds package symfony/polyfill-intl-idn to .zip and .phar releases if the package exists in vendor directory."
+    }
+]

--- a/build/packager.php
+++ b/build/packager.php
@@ -28,16 +28,22 @@ $burgomaster->recursiveCopy('vendor/guzzlehttp/guzzle/src', 'GuzzleHttp');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/psr7/src', 'GuzzleHttp/Psr7');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/promises/src', 'GuzzleHttp/Promise');
 $burgomaster->recursiveCopy('vendor/psr/http-message/src', 'Psr/Http/Message');
-$burgomaster->recursiveCopy('vendor/symfony/polyfill-intl-idn', 'Symfony/Polyfill/IntlIdn');
 
-$burgomaster->createAutoloader([
-    'Aws/functions.php',
+$autoloaderContents = [
+   'Aws/functions.php',
     'GuzzleHttp/functions_include.php',
     'GuzzleHttp/Psr7/functions_include.php',
     'GuzzleHttp/Promise/functions_include.php',
     'JmesPath/JmesPath.php',
-    'Symfony/Polyfill/IntlIdn/bootstrap.php'
-], $autoloaderFilename);
+];
+
+if (file_exists($projectRoot . 'vendor/symfony/polyfill-intl-idn')) {
+    $burgomaster->recursiveCopy($projectRoot . 'vendor/symfony/polyfill-intl-idn', 'Symfony/Polyfill/IntlIdn');
+    array_push($autoloaderContents, 'Symfony/Polyfill/IntlIdn/bootstrap.php');
+}
+
+
+$burgomaster->createAutoloader($autoloaderContents, $autoloaderFilename);
 
 $burgomaster->createZip(__DIR__ . "/artifacts/aws.zip");
 $burgomaster->createPhar(

--- a/build/packager.php
+++ b/build/packager.php
@@ -42,7 +42,6 @@ if (file_exists($projectRoot . 'vendor/symfony/polyfill-intl-idn')) {
     array_push($autoloaderContents, 'Symfony/Polyfill/IntlIdn/bootstrap.php');
 }
 
-
 $burgomaster->createAutoloader($autoloaderContents, $autoloaderFilename);
 
 $burgomaster->createZip(__DIR__ . "/artifacts/aws.zip");

--- a/build/packager.php
+++ b/build/packager.php
@@ -28,6 +28,7 @@ $burgomaster->recursiveCopy('vendor/guzzlehttp/guzzle/src', 'GuzzleHttp');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/psr7/src', 'GuzzleHttp/Psr7');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/promises/src', 'GuzzleHttp/Promise');
 $burgomaster->recursiveCopy('vendor/psr/http-message/src', 'Psr/Http/Message');
+$burgomaster->recursiveCopy('vendor/symfony/polyfill-intl-idn', 'Symfony/Polyfill/IntlIdn');
 
 $burgomaster->createAutoloader([
     'Aws/functions.php',
@@ -35,6 +36,7 @@ $burgomaster->createAutoloader([
     'GuzzleHttp/Psr7/functions_include.php',
     'GuzzleHttp/Promise/functions_include.php',
     'JmesPath/JmesPath.php',
+    'Symfony/Polyfill/IntlIdn/bootstrap.php'
 ], $autoloaderFilename);
 
 $burgomaster->createZip(__DIR__ . "/artifacts/aws.zip");


### PR DESCRIPTION
*Issue #, if available:*
Fix #2006 

*Description of changes:*
Add [Symfony Polyfill / Intl: Idn](https://github.com/symfony/polyfill-intl-idn) to build as required by GuzzleHTTP version 6.5.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
