### PR TITLE
Allow changing RDS AuthToken lifetime

### DIFF
--- a/.changes/nextrelease/allow_changing_RDS_authtoken_lifetime.json
+++ b/.changes/nextrelease/allow_changing_RDS_authtoken_lifetime.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "Rds",
+    "description": "Added optional configurable lifetime value to Rds AuthTokenGenerator"
+  }
+]

--- a/src/Rds/AuthTokenGenerator.php
+++ b/src/Rds/AuthTokenGenerator.php
@@ -39,12 +39,19 @@ class AuthTokenGenerator
      *                         (e.g., host:port)
      * @param string $region The region where the database is located
      * @param string $username The username to login as
-     * @param int $lifetime The lifetime of the token in minutes 
+     * @param int $lifetime The lifetime of the token in minutes
      *
      * @return string Token generated
      */
     public function createToken($endpoint, $region, $username, $lifetime = 15)
     {
+        if (!is_numeric($lifetime) || $lifetime > 15 || $lifetime <= 0) {
+            throw new \InvalidArgumentException(
+                "Lifetime must be a positive number less than or equal to 15, was {$lifetime}",
+                null
+            );
+        }
+
         $uri = new Uri($endpoint);
         $uri = $uri->withPath('/');
         $uri = $uri->withQuery('Action=connect&DBUser=' . $username);

--- a/src/Rds/AuthTokenGenerator.php
+++ b/src/Rds/AuthTokenGenerator.php
@@ -39,10 +39,11 @@ class AuthTokenGenerator
      *                         (e.g., host:port)
      * @param string $region The region where the database is located
      * @param string $username The username to login as
+     * @param int $lifetime The lifetime of the token in minutes 
      *
      * @return string Token generated
      */
-    public function createToken($endpoint, $region, $username)
+    public function createToken($endpoint, $region, $username, $lifetime = 15)
     {
         $uri = new Uri($endpoint);
         $uri = $uri->withPath('/');
@@ -55,7 +56,7 @@ class AuthTokenGenerator
         $url = (string) $signer->presign(
             $request,
             $provider()->wait(),
-            '+15 minutes'
+            '+' . $lifetime . ' minutes'
         )->getUri();
 
         // Remove 2 extra slash from the presigned url result

--- a/tests/Rds/AuthTokenGeneratorTest.php
+++ b/tests/Rds/AuthTokenGeneratorTest.php
@@ -55,4 +55,24 @@ class AuthTokenGeneratorTest extends TestCase
         $this->assertContains('DBUser=myDBUser', $token);
         $this->assertContains('Action=connect', $token);
     }
+
+    public function testCanCreateAuthTokenWthNonDefaultLifetime()
+    {
+        $creds = new Credentials('foo', 'bar', 'baz');
+        $connect = new AuthTokenGenerator($creds);
+        $token = $connect->createToken(
+            'prod-instance.us-east-1.rds.amazonaws.com:3306',
+            'us-west-2',
+            'myDBUser',
+            2
+        );
+
+        $this->assertContains('prod-instance.us-east-1.rds.amazonaws.com:3306', $token);
+        $this->assertContains('us-west-2', $token);
+        $this->assertContains('X-Amz-Credential=foo', $token);
+        $this->assertContains('X-Amz-Expires=120', $token);
+        $this->assertContains('X-Amz-SignedHeaders=host', $token);
+        $this->assertContains('DBUser=myDBUser', $token);
+        $this->assertContains('Action=connect', $token);
+    }
 }

--- a/tests/Rds/AuthTokenGeneratorTest.php
+++ b/tests/Rds/AuthTokenGeneratorTest.php
@@ -56,7 +56,22 @@ class AuthTokenGeneratorTest extends TestCase
         $this->assertContains('Action=connect', $token);
     }
 
-    public function testCanCreateAuthTokenWthNonDefaultLifetime()
+    public function lifetimeProvider()
+    {
+        return [
+            [1],
+            [14],
+            ['14'],
+            [15],
+        ];
+    }
+
+    /**
+     * @dataProvider lifetimeProvider
+     *
+     * @param $lifetime
+     */
+    public function testCanCreateAuthTokenWthNonDefaultLifetime($lifetime)
     {
         $creds = new Credentials('foo', 'bar', 'baz');
         $connect = new AuthTokenGenerator($creds);
@@ -64,15 +79,47 @@ class AuthTokenGeneratorTest extends TestCase
             'prod-instance.us-east-1.rds.amazonaws.com:3306',
             'us-west-2',
             'myDBUser',
-            2
+            $lifetime
         );
-
+        $lifetimeInSeconds = $lifetime * 60;
         $this->assertContains('prod-instance.us-east-1.rds.amazonaws.com:3306', $token);
         $this->assertContains('us-west-2', $token);
         $this->assertContains('X-Amz-Credential=foo', $token);
-        $this->assertContains('X-Amz-Expires=120', $token);
+        $this->assertContains("X-Amz-Expires={$lifetimeInSeconds}", $token);
         $this->assertContains('X-Amz-SignedHeaders=host', $token);
         $this->assertContains('DBUser=myDBUser', $token);
         $this->assertContains('Action=connect', $token);
+    }
+
+    public function lifetimeFailureProvider()
+    {
+        return [
+            [0],
+            ['0'],
+            [''],
+            [16],
+            ['16'],
+            [10000],
+            [null],
+        ];
+    }
+
+    /**
+     * @dataProvider lifetimeFailureProvider
+     * @param $lifetime
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Lifetime must be a positive number less than or equal to 15, was
+     */
+    public function testThrowsExceptionWithInvalidLifetime($lifetime)
+    {
+        $creds = new Credentials('foo', 'bar', 'baz');
+        $connect = new AuthTokenGenerator($creds);
+        $connect->createToken(
+            'prod-instance.us-east-1.rds.amazonaws.com:3306',
+            'us-west-2',
+            'myDBUser',
+            $lifetime
+        );
     }
 }


### PR DESCRIPTION
All the docs I can find for IAM based RDS access say tokens have a 15 minute lifetime, but I can't find a documented reason why this value couldn't be configurable, it appears to be signed using standard AWS signature version 4.

Having generated tokens manually they seem to work fine with much shorter lifetimes, which is what I would like to happen in a particular project of mine. Shorter token lifetime == a bit more secure.

Seems to be a fairly small edit to make this user adjustable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
