### PR TITLE
Fixed guzzle v6 compatibility

### DIFF
--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -48,7 +48,7 @@ class AwsException extends \RuntimeException implements
         $message,
         CommandInterface $command,
         array $context = [],
-        \Exception $previous = null
+        \Throwable $previous = null
     ) {
         $this->data = isset($context['body']) ? $context['body'] : [];
         $this->command = $command;

--- a/src/Handler/GuzzleV6/GuzzleHandler.php
+++ b/src/Handler/GuzzleV6/GuzzleHandler.php
@@ -42,7 +42,7 @@ class GuzzleHandler
 
         return $this->client->sendAsync($request, $this->parseOptions($options))
             ->otherwise(
-                static function (\Exception $e) {
+                static function (\Throwable $e) {
                     $error = [
                         'exception'        => $e,
                         'connection_error' => $e instanceof ConnectException,


### PR DESCRIPTION
This fix resolve compatibility problem with Guzzle v6 closure. After search trought internet there is probably same error in v5 handler too. 

Major problem in this case is incompatibility with PHP 5.5+ - throwable is available since PHP 7.0. However PHP < 7.2 is dead - currently only 7.2, 7.3. and 7.4 is supported. 

`Uncaught Exception TypeError: "Argument 1 passed to Aws\Handler\GuzzleV6\GuzzleHandler::Aws\Handler\GuzzleV6\{closure}() must be an instance of Exception, instance of Error given, called in /application/vendor/guzzlehttp/promises/src/Promise.php on line 203" at /application/vendor/aws/aws-sdk-php/src/Handler/GuzzleV6/GuzzleHandler.php line 45`