### PR TITLE
changed AwsClient's getSignatureProvider method from protected to public

### DIFF
--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -277,7 +277,7 @@ class AwsClient implements AwsClientInterface
      *
      * @return callable
      */
-    final protected function getSignatureProvider()
+    final public function getSignatureProvider()
     {
         return $this->signatureProvider;
     }


### PR DESCRIPTION
*Issue #, if available:*
1896
*Description of changes:*
Made Awsclient's getsignatureprovider method public

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
