### PR TITLE
DynamoDB marshal empty strings

### DIFF
--- a/.changes/nextrelease/dynamodb_marshal_empty_strings.json
+++ b/.changes/nextrelease/dynamodb_marshal_empty_strings.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "DynamoDb",
+    "description": "Marshal empty strings."
+  }
+]

--- a/src/DynamoDb/Marshaler.php
+++ b/src/DynamoDb/Marshaler.php
@@ -136,10 +136,6 @@ class Marshaler
 
         // Handle string values.
         if ($type === 'string') {
-            if ($value === '') {
-                return $this->handleInvalid('empty strings are invalid');
-            }
-
             return ['S' => $value];
         }
 

--- a/tests/DynamoDb/MarshalerTest.php
+++ b/tests/DynamoDb/MarshalerTest.php
@@ -41,7 +41,7 @@ class MarshalerTest extends TestCase
             // "S"
             ['S', ['S' => 'S']],
             ['3', ['S' => '3']],
-            ['', ['NULL' => true], ['nullify_invalid' => true]],
+            ['', ['S' => '']],
 
             // "N"
             [1, ['N' => '1']],
@@ -329,7 +329,7 @@ JSON;
         $m = new Marshaler(['ignore_invalid' => true]);
         $result = $m->marshalItem([
             'foo' => 'bar',
-            'bar' => '',
+            'bar' => new SetValue([]),
             'baz' => new \SplFileInfo(__FILE__)
         ]);
         $this->assertSame(['foo' => ['S' => 'bar']], $result);


### PR DESCRIPTION
*Description of changes:*
As of mid-may [DynamoDB supports empty string values](https://aws.amazon.com/about-aws/whats-new/2020/05/amazon-dynamodb-now-supports-empty-values-for-non-key-string-and-binary-attributes-in-dynamodb-tables/), but this SDK is throwing an exception when trying to marshal an empty string.
This PR removes the check for the empty strings, allowing to save them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
