### PR TITLE
Clear expired web id token path cache

### DIFF
--- a/.changes/nextrelease/webidentity_credentialprovider.json
+++ b/.changes/nextrelease/webidentity_credentialprovider.json
@@ -1,0 +1,7 @@
+[
+    {
+      "type": "bugfix",
+      "category": "Credentials",
+      "description": "Web identity credential provider now clears cached path for web identity token if token file fails to load."
+    }
+]

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -95,6 +95,12 @@ class AssumeRoleWithWebIdentityCredentialProvider
             while ($result == null) {
                 try {
                     $token = file_get_contents($this->tokenFile);
+                    if (false === $token) {
+                        clearstatcache(true, dirname($this->tokenFile) . "/" . readlink($this->tokenFile));
+                        clearstatcache(true, dirname($this->tokenFile) . "/" . dirname(readlink($this->tokenFile)));
+                        clearstatcache(true, $this->tokenFile);
+                        $token = file_get_contents($this->tokenFile);   
+                    }
                 } catch (\Exception $exception) {
                     throw new CredentialsException(
                         "Error reading WebIdentityTokenFile from " . $this->tokenFile,


### PR DESCRIPTION
*Issue #, if available:*
Fix #2014 

*Description of changes:*
Clear realpath cache for web identity token file & related directories if token file fails to load. This allows the SDK to retrieve the new token file's location once the previous token file expires.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
