### PR TITLE
Fix broken link for Guzzle mock plugin

### DIFF
--- a/docs/feature-facades.rst
+++ b/docs/feature-facades.rst
@@ -167,4 +167,4 @@ showing how this is done:
     }
 
 Alternatively, if you are specifically only mocking responses from clients, you might consider using the `Guzzle Mock
-Plugin <http://guzzlephp.org/plugins/mock-plugin.html>`_.
+Plugin <https://guzzle3.readthedocs.io/plugins/mock-plugin.html>`_.

--- a/docs/feature-facades.rst
+++ b/docs/feature-facades.rst
@@ -166,5 +166,5 @@ showing how this is done:
         }
     }
 
-Alternatively, if you are specifically only mocking responses from clients, you might consider using the `Guzzle Mock
-Plugin <https://guzzle3.readthedocs.io/plugins/mock-plugin.html>`_.
+Alternatively, if you are specifically only mocking responses from clients, you might consider using the `Guzzle 3 Mock
+Plugin <https://guzzle3.readthedocs.io/plugins/mock-plugin.html>`_, the `Guzzle 5 Mock Subscriber <http://docs.guzzlephp.org/en/5.3/testing.html#mock-subscriber>`_, or the `Guzzle 6 Mock Handler <http://docs.guzzlephp.org/en/stable/testing.html#mock-handler>`_.


### PR DESCRIPTION
*Issue #, if available:*
Fix #2029 

*Description of changes:*
Update link for Guzzle mock plugin to working URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
