### PR TITLE
Guzzle 7 is released, no beta test needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
     - php: hhvm-3.24
     - php: nightly
   fast_finish: true
-  include:
-    - name: "PHP: 7.3 - Guzzle 7 beta"
-      php: 7.3
-      env: COMPOSER_OPTS="--no-interaction"
-      before_install:
-        - composer require "guzzlehttp/guzzle:^7.0@beta"
 
 sudo: false
 


### PR DESCRIPTION
We test with Guzzle 5 on "prefer-lowest".
We test with Guzzle 6 on PHP < 7.2
We test with Guzzle 7 on PHP ≥ 7.2