### PR TITLE
Tweaks for Guzzle version update

### DIFF
--- a/.changes/nextrelease/version_update_tweaks.json
+++ b/.changes/nextrelease/version_update_tweaks.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "bugfix",
-    "category": "build",
+    "category": "Build",
     "description": "Updated packager code to work with Guzzle 7."
   }
 ]

--- a/.changes/nextrelease/version_update_tweaks.json
+++ b/.changes/nextrelease/version_update_tweaks.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "build",
+    "description": "Updated packager code to work with Guzzle 7."
+  }
+]

--- a/build/packager.php
+++ b/build/packager.php
@@ -28,9 +28,10 @@ $burgomaster->recursiveCopy('vendor/guzzlehttp/guzzle/src', 'GuzzleHttp');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/psr7/src', 'GuzzleHttp/Psr7');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/promises/src', 'GuzzleHttp/Promise');
 $burgomaster->recursiveCopy('vendor/psr/http-message/src', 'Psr/Http/Message');
+$burgomaster->recursiveCopy('vendor/psr/http-client/src', 'Psr/Http/Client');
 
 $autoloaderContents = [
-   'Aws/functions.php',
+    'Aws/functions.php',
     'GuzzleHttp/functions_include.php',
     'GuzzleHttp/Psr7/functions_include.php',
     'GuzzleHttp/Promise/functions_include.php',

--- a/build/packager.php
+++ b/build/packager.php
@@ -28,7 +28,6 @@ $burgomaster->recursiveCopy('vendor/guzzlehttp/guzzle/src', 'GuzzleHttp');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/psr7/src', 'GuzzleHttp/Psr7');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/promises/src', 'GuzzleHttp/Promise');
 $burgomaster->recursiveCopy('vendor/psr/http-message/src', 'Psr/Http/Message');
-$burgomaster->recursiveCopy('vendor/psr/http-client/src', 'Psr/Http/Client');
 
 $autoloaderContents = [
     'Aws/functions.php',
@@ -41,6 +40,10 @@ $autoloaderContents = [
 if (file_exists($projectRoot . 'vendor/symfony/polyfill-intl-idn')) {
     $burgomaster->recursiveCopy($projectRoot . 'vendor/symfony/polyfill-intl-idn', 'Symfony/Polyfill/IntlIdn');
     array_push($autoloaderContents, 'Symfony/Polyfill/IntlIdn/bootstrap.php');
+}
+
+if (file_exists($projectRoot . 'vendor/psr/http-client/src')) {
+    $burgomaster->recursiveCopy($projectRoot . 'vendor/psr/http-client/src', 'Psr/Http/Client');
 }
 
 $burgomaster->createAutoloader($autoloaderContents, $autoloaderFilename);

--- a/build/test-phar.php
+++ b/build/test-phar.php
@@ -20,7 +20,6 @@ Aws\DynamoDb\DynamoDbClient::factory($conf);
 
 // React autoloader
 $checks = [
-    'GuzzleHttp\\uri_template',
     'GuzzleHttp\\Psr7\\stream_for',
     'GuzzleHttp\\Promise\\inspect',
     'JmesPath\\search',
@@ -29,7 +28,7 @@ $checks = [
 
 foreach ($checks as $check) {
     if (!function_exists($check)) {
-        echo $checks . ' not found';
+        echo $check . ' not found';
         exit(1);
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,4 +24,7 @@ parameters:
     # Guzzle V5 classes & interfaces changed in V6
     - '#Call to an undefined static method GuzzleHttp\\Client::getDefaultUserAgent\(\)\.#'
 
+    # There is a check for availability of constant that phpstan does not detect.
+    - '#Access to undefined constant GuzzleHttp\\ClientInterface::VERSION\.#'
+
   reportUnmatchedIgnoredErrors: false

--- a/tests/bootstrap/PHPUnit_Framework_MockObject_Generator_7.4.php
+++ b/tests/bootstrap/PHPUnit_Framework_MockObject_Generator_7.4.php
@@ -1004,7 +1004,7 @@ class PHPUnit_Framework_MockObject_Generator
         }
 
         if ($this->hasReturnType($method)) {
-            $returnType = (string) $method->getReturnType();
+            $returnType = $method->getReturnType()->getName();
         } else {
             $returnType = '';
         }


### PR DESCRIPTION
* Fix failing Travis tests due to PHP warnings in static and unit tests for new versions of Guzzle and PHP 7.4.
