### PR TITLE
bugfix on parsing empty timestamps

### DIFF
--- a/.changes/nextrelease/bugfix-parse-null-timestamps.json
+++ b/.changes/nextrelease/bugfix-parse-null-timestamps.json
@@ -1,0 +1,8 @@
+
+[
+  {
+    "type": "bugfix",
+    "category": "Api",
+    "description": "Fixed bug with marshalling empty strings from dynamodb"
+  }
+]

--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -49,7 +49,7 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
      */
     public static function fromTimestamp($timestamp, $expectedFormat = null)
     {
-        if (empty($timestamp)){
+        if (empty($timestamp)) {
             return self::fromEpoch(0);
         }
 

--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -49,26 +49,31 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
      */
     public static function fromTimestamp($timestamp, $expectedFormat = null)
     {
-            if (empty($timestamp) || !(is_string($timestamp) || is_numeric($timestamp))) {
-                throw new ParserException('Invalid timestamp value passed to DateTimeResult::fromTimestamp');
-            }
-            try {
-                if ($expectedFormat == 'iso8601') {
-                    try {
-                        return self::fromISO8601($timestamp);
-                    } catch (Exception $exception) {
-                        return self::fromEpoch($timestamp);
-                    }
-                } else if ($expectedFormat == 'unixTimestamp') {
-                    try {
-                        return self::fromEpoch($timestamp);
-                    } catch (Exception $exception) {
-                        return self::fromISO8601($timestamp);
-                    }
-                } else if (\Aws\is_valid_epoch($timestamp)) {
+        if (empty($timestamp)){
+            return self::fromEpoch(0);
+        }
+
+        if (!(is_string($timestamp) || is_numeric($timestamp))) {
+            throw new ParserException('Invalid timestamp value passed to DateTimeResult::fromTimestamp');
+        }
+
+        try {
+            if ($expectedFormat == 'iso8601') {
+                try {
+                    return self::fromISO8601($timestamp);
+                } catch (Exception $exception) {
                     return self::fromEpoch($timestamp);
                 }
-                return self::fromISO8601($timestamp);
+            } else if ($expectedFormat == 'unixTimestamp') {
+                try {
+                    return self::fromEpoch($timestamp);
+                } catch (Exception $exception) {
+                    return self::fromISO8601($timestamp);
+                }
+            } else if (\Aws\is_valid_epoch($timestamp)) {
+                return self::fromEpoch($timestamp);
+            }
+            return self::fromISO8601($timestamp);
         } catch (Exception $exception) {
             throw new ParserException('Invalid timestamp value passed to DateTimeResult::fromTimestamp');
         }

--- a/tests/Api/Parser/JsonParserTest.php
+++ b/tests/Api/Parser/JsonParserTest.php
@@ -39,6 +39,12 @@ class JsonParserTest extends TestCase
             ["1999-07-17T00:00:00.5", "ParseIso8601", "1999-07-17T00:00:00+00:00"],
             ["1999-07-17T00:00:00.5", "ParseUnix", "1999-07-17T00:00:00+00:00"],
             ["1999-07-17T00:00:00.5", "ParseUnknown", "1999-07-17T00:00:00+00:00"],
+            [[], "ParseIso8601", "1970-01-01T00:00:00+00:00"],
+            [[], "ParseUnix", "1970-01-01T00:00:00+00:00"],
+            [[], "ParseUnknown", '1970-01-01T00:00:00+00:00'],
+            [(float) 0, "ParseIso8601", "1970-01-01T00:00:00+00:00"],
+            [(float) 0, "ParseUnix", "1970-01-01T00:00:00+00:00"],
+            [(float) 0, "ParseUnknown", '1970-01-01T00:00:00+00:00'],
         ];
     }
 
@@ -66,15 +72,9 @@ class JsonParserTest extends TestCase
             ["[]", "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             ["[]", "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             ["[]", "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [false, "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [false, "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [false, "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             ["null", "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             ["null", "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             ["null", "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [[], "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [[], "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [[], "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             [true, "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             [true, "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             [true, "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
@@ -84,7 +84,7 @@ class JsonParserTest extends TestCase
     /**
      * @dataProvider timeStampModelProvider
      */
-    public function testHandlesTimeStampsWhenIso8601Expected(
+    public function testHandlesTimeStamps(
         $timestamp,
         $commandName,
         $expectedValue

--- a/tests/Api/Parser/XmlParserTest.php
+++ b/tests/Api/Parser/XmlParserTest.php
@@ -41,6 +41,15 @@ class XmlParserTest extends TestCase
             ["2002-05-30T09:30:10.5", "ParseIso8601", "2002-05-30T09:30:10+00:00"],
             ["2002-05-30T09:30:10.5", "ParseUnix", "2002-05-30T09:30:10+00:00"],
             ["2002-05-30T09:30:10.5", "ParseUnknown", "2002-05-30T09:30:10+00:00"],
+            [null, "ParseIso8601", "1970-01-01T00:00:00+00:00"],
+            [null, "ParseUnix", "1970-01-01T00:00:00+00:00"],
+            [null, "ParseUnknown", '1970-01-01T00:00:00+00:00'],
+            [false, "ParseIso8601", "1970-01-01T00:00:00+00:00"],
+            [false, "ParseUnix", "1970-01-01T00:00:00+00:00"],
+            [false, "ParseUnknown", '1970-01-01T00:00:00+00:00'],
+            [(float) 0, "ParseIso8601", "1970-01-01T00:00:00+00:00"],
+            [(float) 0, "ParseUnix", "1970-01-01T00:00:00+00:00"],
+            [(float) 0, "ParseUnknown", '1970-01-01T00:00:00+00:00'],
         ];
     }
 
@@ -68,12 +77,6 @@ class XmlParserTest extends TestCase
             [acos(1.01), "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             [acos(1.01), "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
             [acos(1.01), "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [false, "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [false, "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [false, "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [null, "ParseIso8601", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [null, "ParseUnix", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
-            [null, "ParseUnknown", ParserException::class, "Invalid timestamp value passed to DateTimeResult::fromTimestamp"],
         ];
     }
 


### PR DESCRIPTION
*Issue #, if available:*
fix #2053
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
