### PR TITLE
Client-side encryption wrap name tweak

### DIFF
--- a/.changes/nextrelease/cse_wrap_name_tweak.json
+++ b/.changes/nextrelease/cse_wrap_name_tweak.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Crypto",
+        "description": "Tweaks the wrap algorithm name for KmsMaterialsProviderV2 for the sake of cross-SDK consistency."
+    }
+]

--- a/src/Crypto/KmsMaterialsProviderV2.php
+++ b/src/Crypto/KmsMaterialsProviderV2.php
@@ -59,7 +59,7 @@ class KmsMaterialsProviderV2 extends MaterialsProviderV2 implements MaterialsPro
      */
     public function getWrapAlgorithmName()
     {
-        return 'kms';
+        return 'kms+context';
     }
 
     /**

--- a/tests/Crypto/KmsMaterialsProviderV2Test.php
+++ b/tests/Crypto/KmsMaterialsProviderV2Test.php
@@ -22,7 +22,7 @@ class KmsMaterialsProviderV2Test extends TestCase
         $keyId = '11111111-2222-3333-4444-555555555555';
 
         $provider = new KmsMaterialsProviderV2($client, $keyId);
-        $this->assertEquals('kms', $provider->getWrapAlgorithmName());
+        $this->assertEquals('kms+context', $provider->getWrapAlgorithmName());
     }
 
     public function testGeneratesCek()

--- a/tests/S3/Crypto/S3EncryptionMultipartUploaderV2Test.php
+++ b/tests/S3/Crypto/S3EncryptionMultipartUploaderV2Test.php
@@ -413,7 +413,7 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
                     $this->assertEquals('foo', $command['Bucket']);
                     $this->assertEquals('bar', $command['Key']);
                     $this->assertEquals(
-                        'kms',
+                        'kms+context',
                         $command['Metadata']['x-amz-wrap-alg']
                     );
                 },


### PR DESCRIPTION
* Tweaks the wrap algorithm name for KmsMaterialsProviderV2 for the sake of cross-SDK consistency.
