### PR TITLE
Region validation

### DIFF
--- a/.changes/nextrelease/region_validation.json
+++ b/.changes/nextrelease/region_validation.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Adds region validation as a valid host label when region is being used to construct an endpoint. Note this does not take effect when a custom endpoint is supplied."
+    }
+]

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -13,6 +13,7 @@ use Aws\Endpoint\PartitionEndpointProvider;
 use Aws\EndpointDiscovery\ConfigurationInterface;
 use Aws\EndpointDiscovery\ConfigurationProvider;
 use Aws\EndpointDiscovery\EndpointDiscoveryMiddleware;
+use Aws\Exception\InvalidRegionException;
 use Aws\Retry\ConfigurationInterface as RetryConfigInterface;
 use Aws\Retry\ConfigurationProvider as RetryConfigProvider;
 use Aws\Signature\SignatureProvider;
@@ -536,6 +537,13 @@ class ClientResolver
                 ? $args['api']['metadata']['endpointPrefix']
                 : $args['service'];
 
+            // Check region is a valid host label when it is being used to
+            // generate an endpoint
+            if (!self::isValidRegion($args['region'])) {
+                throw new InvalidRegionException('Region must be a valid RFC'
+                    . ' host label.');
+            }
+
             // Invoke the endpoint provider and throw if it does not resolve.
             $result = EndpointProvider::resolve($value, [
                 'service' => $endpointPrefix,
@@ -856,5 +864,16 @@ EOT;
             }
         }
         return $options;
+    }
+
+    /**
+     * Validates a region to be used for endpoint construction
+     *
+     * @param $region
+     * @return bool
+     */
+    private static function isValidRegion($region)
+    {
+        return is_valid_hostlabel($region);
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -440,8 +440,7 @@ function is_valid_hostname($hostname)
  */
 function is_valid_hostlabel($label)
 {
-    return preg_match("/^([a-z\d](-*[a-z\d])*)$/", $label)
-        && preg_match("/^.{1,63}$/", $label);
+    return preg_match("/^(?!-)[a-zA-Z0-9-]{1,63}(?<!-)$/", $label);
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -433,6 +433,18 @@ function is_valid_hostname($hostname)
 }
 
 /**
+ * Checks if supplied parameter is a valid host label
+ *
+ * @param $label
+ * @return bool
+ */
+function is_valid_hostlabel($label)
+{
+    return preg_match("/^([a-z\d](-*[a-z\d])*)$/", $label)
+        && preg_match("/^.{1,63}$/", $label);
+}
+
+/**
  * Ignores '#' full line comments, which parse_ini_file no longer does
  * in PHP 7+.
  *

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -10,6 +10,7 @@ use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Endpoint\Partition;
+use Aws\Exception\InvalidRegionException;
 use Aws\LruArrayCache;
 use Aws\S3\S3Client;
 use Aws\HandlerList;
@@ -937,6 +938,57 @@ EOT;
             ['truthy', false],
             ['openssl_random_pseudo_bytes', true],
             [function ($length) { return 'foo'; }, true],
+        ];
+    }
+
+    /**
+     * @dataProvider validateRegionProvider
+     *
+     * @param $region
+     * @param $expected
+     */
+    public function testValidatesRegion($region, $expected)
+    {
+        $resolver = new ClientResolver(ClientResolver::getDefaultArguments());
+        try {
+            $result = $resolver->resolve(
+                [
+                    'service' => 's3',
+                    'version' => 'latest',
+                    'region' => $region
+                ],
+                new HandlerList()
+            );
+
+            if ($expected instanceof \Exception) {
+                $this->fail('Expected an exception with: ' . $expected->getMessage());
+            }
+            $this->assertEquals($expected, $result['region']);
+
+        } catch (InvalidRegionException $e) {
+            $this->assertEquals($expected->getMessage(), $e->getMessage());
+        }
+    }
+
+    public function validateRegionProvider()
+    {
+        return [
+            [
+                'us-west-2',
+                'us-west-2',
+            ],
+            [
+                'x',
+                'x',
+            ],
+            [
+                '',
+                new InvalidRegionException('Region must be a valid RFC host label.'),
+            ],
+            [
+                'hosthijack.com/',
+                new InvalidRegionException('Region must be a valid RFC host label.'),
+            ],
         ];
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -388,22 +388,26 @@ class FunctionsTest extends TestCase
     public function getHostlabelTestCases()
     {
         return [
+            ['us-west-2', true],
             ['a', true],
-            ['a.', false],
-            ['0', true],
-            ['a-b', true],
+            ['a.b', false],
+            ['2-us-west', true],
+            ['1-us-west-2', true],
+            ['42', true],
+            ['us_west_2', false],
+            ['-west-2', false],
+            ['@uncoolwebsite.com', false],
             ['a-b.c-d', false],
             ['a--b', true],
             ['a b', false],
             ['<a', false],
-            ['(a', false],
             ['a>', false],
-            ['a)', false],
             [' ', false],
             ['-', false],
             ['', false],
             [str_repeat('a', 63), true],
             [str_repeat('a', 64), false],
+            ['us-west-2-certainly-this-label-must-be-longer-than-63-characters-by-now', false],
         ];
     }
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -375,6 +375,39 @@ class FunctionsTest extends TestCase
     }
 
     /**
+     * @covers Aws\is_valid_hostlabel()
+     * @dataProvider getHostlabelTestCases
+     * @param string $label
+     * @param bool $expected
+     */
+    public function testValidatesHostlabels($label, $expected)
+    {
+        $this->assertEquals($expected, Aws\is_valid_hostlabel($label));
+    }
+
+    public function getHostlabelTestCases()
+    {
+        return [
+            ['a', true],
+            ['a.', false],
+            ['0', true],
+            ['a-b', true],
+            ['a-b.c-d', false],
+            ['a--b', true],
+            ['a b', false],
+            ['<a', false],
+            ['(a', false],
+            ['a>', false],
+            ['a)', false],
+            [' ', false],
+            ['-', false],
+            ['', false],
+            [str_repeat('a', 63), true],
+            [str_repeat('a', 64), false],
+        ];
+    }
+
+    /**
      * @covers Aws\parse_ini_file()
      * @dataProvider getIniFileTestCases
      */


### PR DESCRIPTION
* Adds region validation as a valid host label when region is being used to construct an endpoint. Note this does not take effect when a custom endpoint is supplied.
