### PR TITLE
Fixed crash on PHP 8.0

### DIFF
--- a/.changes/nextrelease/php-8-patch.json
+++ b/.changes/nextrelease/php-8-patch.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Credentials",
+        "description": "Fixes a crash in PHP 8.0 by calling array_values on the default chain array passed into self::chain"
+    }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -122,7 +122,7 @@ class CredentialProvider
         return self::memoize(
             call_user_func_array(
                 'self::chain',
-                $defaultChain
+                array_values($defaultChain)
             )
         );
     }


### PR DESCRIPTION
Fixes:

```
Error: Unknown named parameter $env

.../vendor/aws/aws-sdk-php/src/Credentials/CredentialProvider.php:124
.../vendor/aws/aws-sdk-php/src/ClientResolver.php:473
.../vendor/aws/aws-sdk-php/src/ClientResolver.php:295
.../vendor/aws/aws-sdk-php/src/AwsClient.php:199
.../vendor/aws/aws-sdk-php/src/S3/S3Client.php:328
```

---

Evidence this fix is correct: https://3v4l.org/LJchL, https://3v4l.org/IBO1U.