### PR TITLE
undefined index source_profile when using credential_source

### DIFF
--- a/.changes/nextrelease/bugfix-undefined-source-index.json
+++ b/.changes/nextrelease/bugfix-undefined-source-index.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Credentials",
+    "description": "Fix credentialprovider error with undefined index source_profile when using credential_source"
+  }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -612,7 +612,7 @@ class CredentialProvider
                 'preferStaticCredentials' => true
             ];
             $sourceCredentials = null;
-            if ($roleProfile['source_profile']){
+            if (!empty($roleProfile['source_profile'])){
                 $sourceCredentials = call_user_func(
                     CredentialProvider::ini($sourceProfileName, $filename, $config)
                 )->wait();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When using credential_source in default profile, source_profile is not defined. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
