### PR TITLE
Corrected urlencoding of CopySource key for S3 MultipartCopy

### DIFF
--- a/.changes/nextrelease/s3_copy_source_encoding_fix.json
+++ b/.changes/nextrelease/s3_copy_source_encoding_fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Corrected urlencoding of CopySource key for MultipartCopy"
+  }
+]

--- a/src/S3/MultipartCopy.php
+++ b/src/S3/MultipartCopy.php
@@ -129,12 +129,13 @@ class MultipartCopy extends AbstractUploadManager
         }
 
         list($bucket, $key) = explode('/', ltrim($this->source, '/'), 2);
-        $data['CopySource'] = '/' . $bucket . '/' . rawurlencode(
-                implode(
-                    '/',
-                    array_map('urlencode', explode('/', $key))
-                )
-            );
+        $data['CopySource'] = '/' . $bucket . '/' . implode(
+            '/',
+            array_map(
+                'urlencode',
+                explode('/', rawurldecode($key))
+            )
+        );
         $data['PartNumber'] = $partNumber;
 
         $defaultPartSize = $this->determinePartSize();


### PR DESCRIPTION
*Description of changes:*

Corrected urlencoding of CopySource key for S3 MultipartCopy. It was encoding it three times.
Fixed incorrect unittest.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.