### PR TITLE
Test enhancement about make assert eqauls strict

### DIFF
--- a/tests/AbstractConfigurationProviderTest.php
+++ b/tests/AbstractConfigurationProviderTest.php
@@ -30,7 +30,7 @@ class AbstractConfigurationProviderTest extends TestCase
         $ref = new \ReflectionClass('\Aws\AbstractConfigurationProvider');
         $meth = $ref->getMethod('getHomeDir');
         $meth->setAccessible(true);
-        $this->assertEquals('C:\\My\\Home', $meth->invoke(null));
+        $this->assertSame('C:\\My\\Home', $meth->invoke(null));
     }
 
     public function testMemoizes()
@@ -43,9 +43,9 @@ class AbstractConfigurationProviderTest extends TestCase
         };
         $p = call_user_func([$this->provider, 'memoize'], $f);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
     }
 
     public function testChainsConfiguration()
@@ -101,7 +101,7 @@ class AbstractConfigurationProviderTest extends TestCase
             )->wait();
         }
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
         $this->assertCount(1, $cache);
         $this->assertSame($expected->toArray(), $result->toArray());
     }

--- a/tests/Api/DateTimeResultTest.php
+++ b/tests/Api/DateTimeResultTest.php
@@ -13,7 +13,7 @@ class DateTimeResultTest extends TestCase
     {
         $t = time();
         $d = DateTimeResult::fromEpoch($t);
-        $this->assertEquals($t, $d->format('U'));
+        $this->assertSame((string)$t, $d->format('U'));
     }
 
     public function testCastToIso8601String()

--- a/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
+++ b/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
@@ -33,9 +33,9 @@ class JsonRpcErrorParserTest extends TestCase
     ) {
         $response = Psr7\parse_response($response);
         $parsed = $parser($response, $command);
-        $this->assertEquals(
+        $this->assertCount(
             count($expected),
-            count($parsed)
+            $parsed
         );
         foreach($parsed as $key => $value) {
             if ($key === 'error_shape') {

--- a/tests/Api/ErrorParser/RestJsonErrorParserTest.php
+++ b/tests/Api/ErrorParser/RestJsonErrorParserTest.php
@@ -30,9 +30,9 @@ class RestJsonErrorParserTest extends TestCase
     ) {
         $response = Psr7\parse_response($response);
         $parsed = $parser($response, $command);
-        $this->assertEquals(
+        $this->assertCount(
             count($expected),
-            count($parsed)
+            $parsed
         );
         foreach($parsed as $key => $value) {
             if ($key === 'error_shape') {

--- a/tests/Api/ErrorParser/XmlErrorParserTest.php
+++ b/tests/Api/ErrorParser/XmlErrorParserTest.php
@@ -338,7 +338,7 @@ class XmlErrorParserTest extends TestCase
         );
         $parser = new XmlErrorParser();
         $result = $parser($response);
-        $this->assertEquals('400 Bad Request', $result['message']);
+        $this->assertSame('400 Bad Request', $result['message']);
         $this->assertNull($result['parsed']);
     }
 
@@ -349,8 +349,8 @@ class XmlErrorParserTest extends TestCase
         );
         $parser = new XmlErrorParser();
         $result = $parser($response);
-        $this->assertEquals('400 Bad Request (Request-ID: Foo)', $result['message']);
-        $this->assertEquals('Foo', $result['request_id']);
+        $this->assertSame('400 Bad Request (Request-ID: Foo)', $result['message']);
+        $this->assertSame('Foo', $result['request_id']);
     }
 
     public function testUsesNotFoundWhen404()
@@ -360,6 +360,6 @@ class XmlErrorParserTest extends TestCase
         );
         $parser = new XmlErrorParser();
         $result = $parser($response);
-        $this->assertEquals('NotFound', $result['code']);
+        $this->assertSame('NotFound', $result['code']);
     }
 }

--- a/tests/Api/ListShapeTest.php
+++ b/tests/Api/ListShapeTest.php
@@ -20,7 +20,7 @@ class ListShapeTest extends TestCase
         $m = $s->getMember();
         $this->assertInstanceOf('Aws\Api\Shape', $m);
         $this->assertSame($m, $s->getMember());
-        $this->assertEquals('string', $m->getType());
+        $this->assertSame('string', $m->getType());
     }
 
     /**

--- a/tests/Api/MapShapeTest.php
+++ b/tests/Api/MapShapeTest.php
@@ -15,7 +15,7 @@ class MapShapeTest extends TestCase
         $s = new MapShape(['value' => ['type' => 'string']], new ShapeMap([]));
         $v = $s->getValue();
         $this->assertInstanceOf('Aws\Api\Shape', $v);
-        $this->assertEquals('string', $v->getType());
+        $this->assertSame('string', $v->getType());
         $this->assertSame($v, $s->getValue());
     }
 
@@ -32,7 +32,7 @@ class MapShapeTest extends TestCase
         $s = new MapShape(['key' => ['type' => 'string']], new ShapeMap([]));
         $k = $s->getKey();
         $this->assertInstanceOf('Aws\Api\Shape', $k);
-        $this->assertEquals('string', $k->getType());
+        $this->assertSame('string', $k->getType());
     }
 
     public function testReturnsEmptyKey()

--- a/tests/Api/OperationTest.php
+++ b/tests/Api/OperationTest.php
@@ -13,8 +13,8 @@ class OperationTest extends TestCase
     public function testCreatesDefaultMethodAndUri()
     {
         $o = new Operation([], new ShapeMap([]));
-        $this->assertEquals('POST', $o->getHttp()['method']);
-        $this->assertEquals('/', $o->getHttp()['requestUri']);
+        $this->assertSame('POST', $o->getHttp()['method']);
+        $this->assertSame('/', $o->getHttp()['requestUri']);
     }
 
     public function testReturnsEmptyShapes()
@@ -34,7 +34,7 @@ class OperationTest extends TestCase
         ]));
         $i = $o->getInput();
         $this->assertInstanceOf('Aws\Api\Shape', $i);
-        $this->assertEquals('structure', $i->getType());
+        $this->assertSame('structure', $i->getType());
         $this->assertSame($i, $o->getInput());
     }
 
@@ -47,7 +47,7 @@ class OperationTest extends TestCase
         ]));
         $os = $o->getOutput();
         $this->assertInstanceOf('Aws\Api\Shape', $os);
-        $this->assertEquals('structure', $os->getType());
+        $this->assertSame('structure', $os->getType());
         $this->assertSame($os, $o->getOutput());
     }
 
@@ -63,8 +63,8 @@ class OperationTest extends TestCase
         $this->assertInternalType('array', $e);
         $this->assertInstanceOf('Aws\Api\Shape', $e[0]);
         $this->assertInstanceOf('Aws\Api\Shape', $e[1]);
-        $this->assertEquals('structure', $e[0]->getType());
-        $this->assertEquals('list', $e[1]->getType());
+        $this->assertSame('structure', $e[0]->getType());
+        $this->assertSame('list', $e[1]->getType());
     }
 
     public function testErrorsDoesNotCreateReferences()
@@ -79,6 +79,6 @@ class OperationTest extends TestCase
         $errorsCopy = $errors;
         $errorsCopy[0]['a_copy'] = $errorsCopy[0]['a'];
         $errorsCopy[0]['a'] = 'test';
-        $this->assertEquals('structure', $errors[0]->getType());
+        $this->assertSame('structure', $errors[0]->getType());
     }
 }

--- a/tests/Api/Parser/ComplianceTest.php
+++ b/tests/Api/Parser/ComplianceTest.php
@@ -103,9 +103,9 @@ class ComplianceTest extends TestCase
             $parser = Service::createErrorParser($service->getProtocol(), $service);
             $parsed = $parser($response, $command);
             $result = $parsed['body'];
-            $this->assertEquals($errorCode, $parsed['code']);
+            $this->assertSame($errorCode, $parsed['code']);
             if (!is_null($errorMessage)) {
-                $this->assertEquals($errorMessage, $parsed['message']);
+                $this->assertSame($errorMessage, $parsed['message']);
             }
         } else {
             $parser = Service::createParser($service);

--- a/tests/Api/Parser/Crc32ValidatingParserTest.php
+++ b/tests/Api/Parser/Crc32ValidatingParserTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aws\Test\Api;
+namespace Aws\Test\Api\Parser;
 
 use Aws\Api\ApiProvider;
 use Aws\Api\Parser\Crc32ValidatingParser;

--- a/tests/Api/Parser/DecodingEventStreamIteratorTest.php
+++ b/tests/Api/Parser/DecodingEventStreamIteratorTest.php
@@ -66,7 +66,7 @@ class DecodingEventStreamIteratorTest extends TestCase
 
             $events->rewind();
             $this->assertTrue($events->valid());
-            $this->assertEquals(0, $events->key());
+            $this->assertSame(0, $events->key());
 
             $firstEvent['payload'] =
                 (string) $firstEvent['payload'];
@@ -76,7 +76,7 @@ class DecodingEventStreamIteratorTest extends TestCase
             $this->assertEquals($firstEvent, $current);
 
             $decodedEvent = json_decode((string) $decodedData, true);
-            $this->assertEquals(
+            $this->assertSame(
                 base64_decode(
                     $decodedEvent['payload']
                 ),
@@ -124,7 +124,7 @@ class DecodingEventStreamIteratorTest extends TestCase
 
                 $headerCount--;
             }
-            $this->assertEquals(0, $headerCount);
+            $this->assertSame(0, $headerCount);
         } catch (ParserException $e) {
             if (!$isNegative) {
                 $this->fail('Unsuccessful parse of event from valid source.');

--- a/tests/Api/Parser/EventParsingIteratorTest.php
+++ b/tests/Api/Parser/EventParsingIteratorTest.php
@@ -11,11 +11,12 @@ use Aws\Api\StructureShape;
 use Aws\Exception\EventStreamDataException;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Api\Parser\EventParsingIterator
  */
-class EventParsingIteratorTest extends \PHPUnit_Framework_TestCase
+class EventParsingIteratorTest extends TestCase
 {
     /** @var array */
     private static $successEventNames = [
@@ -119,12 +120,12 @@ class EventParsingIteratorTest extends \PHPUnit_Framework_TestCase
         );
 
         try {
-            $this->assertEquals(0, $iterator->key());
+            $this->assertSame(0, $iterator->key());
             $iterator->current();
             $this->fail('Got event when error expected from stream.');
         } catch (EventStreamDataException $e) {
-            $this->assertEquals('Event Error', $e->getAwsErrorMessage());
-            $this->assertEquals('FooError', $e->getAwsErrorCode());
+            $this->assertSame('Event Error', $e->getAwsErrorMessage());
+            $this->assertSame('FooError', $e->getAwsErrorCode());
         } catch (\Exception $e) {
             $this->fail('Got other exception when error expected from stream.');
         }

--- a/tests/Api/Parser/Exception/ParserExceptionTest.php
+++ b/tests/Api/Parser/Exception/ParserExceptionTest.php
@@ -21,7 +21,7 @@ class ParserExceptionTest extends TestCase
             ]
         );
 
-        $this->assertEquals('foo', $exception->getErrorCode());
-        $this->assertEquals('bar', $exception->getRequestId());
+        $this->assertSame('foo', $exception->getErrorCode());
+        $this->assertSame('bar', $exception->getRequestId());
     }
 }

--- a/tests/Api/Parser/JsonParserTest.php
+++ b/tests/Api/Parser/JsonParserTest.php
@@ -1,6 +1,5 @@
 <?php
-
-require_once __DIR__ . '/ParserTestServiceTrait.php';
+namespace Aws\Test\Api\Parser;
 
 use Aws\Api\Parser\Exception\ParserException;
 use PHPUnit\Framework\TestCase;

--- a/tests/Api/Parser/ParserTestServiceTrait.php
+++ b/tests/Api/Parser/ParserTestServiceTrait.php
@@ -1,4 +1,5 @@
 <?php
+namespace Aws\Test\Api\Parser;
 
 use Aws\Api\Service;
 use Aws\AwsClient;

--- a/tests/Api/Parser/XmlParserTest.php
+++ b/tests/Api/Parser/XmlParserTest.php
@@ -1,6 +1,5 @@
 <?php
-
-require_once __DIR__ . '/ParserTestServiceTrait.php';
+namespace Aws\Test\Api\Parser;
 
 use Aws\Api\Parser\Exception\ParserException;
 use PHPUnit\Framework\TestCase;

--- a/tests/Api/Serializer/JsonBodyTest.php
+++ b/tests/Api/Serializer/JsonBodyTest.php
@@ -18,7 +18,7 @@ class JsonBodyTest extends TestCase
     public function testUsesEmptyHashByDefault()
     {
         $j = new JsonBody(new Service([], function() { return []; }));
-        $this->assertEquals(
+        $this->assertSame(
             '{}',
             $j->build(new Shape([], new ShapeMap([])), [])
         );

--- a/tests/Api/Serializer/JsonRpcSerializerTest.php
+++ b/tests/Api/Serializer/JsonRpcSerializerTest.php
@@ -40,13 +40,13 @@ class JsonRpcSerializerTest extends TestCase
         $j = new JsonRpcSerializer($service, 'http://foo.com');
         $cmd = new Command('foo', ['baz' => 'bam']);
         $request = $j($cmd);
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com', (string) $request->getUri());
-        $this->assertEquals(
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com', (string) $request->getUri());
+        $this->assertSame(
             'application/x-amz-json-1.1',
             $request->getHeaderLine('Content-Type')
         );
-        $this->assertEquals('test.foo', $request->getHeaderLine('X-Amz-Target'));
-        $this->assertEquals('{"baz":"bam"}', (string) $request->getBody());
+        $this->assertSame('test.foo', $request->getHeaderLine('X-Amz-Target'));
+        $this->assertSame('{"baz":"bam"}', (string) $request->getBody());
     }
 }

--- a/tests/Api/Serializer/QuerySerializerTest.php
+++ b/tests/Api/Serializer/QuerySerializerTest.php
@@ -43,8 +43,8 @@ class QuerySerializerTest extends TestCase
         $q = new QuerySerializer($service, 'http://foo.com');
         $cmd = new Command('foo', ['baz' => []]);
         $request = $q($cmd);
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com', (string) $request->getUri());
-        $this->assertEquals('Action=foo&Version=1&baz=', (string) $request->getBody());
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com', (string) $request->getUri());
+        $this->assertSame('Action=foo&Version=1&baz=', (string) $request->getBody());
     }
 }

--- a/tests/Api/Serializer/RestJsonSerializerTest.php
+++ b/tests/Api/Serializer/RestJsonSerializerTest.php
@@ -97,10 +97,10 @@ class RestJsonSerializerTest extends TestCase
     public function testPreparesRequestsWithContentType()
     {
         $request = $this->getRequest('foo', ['baz' => 'bar']);
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com/', (string) $request->getUri());
-        $this->assertEquals('{"baz":"bar"}', (string) $request->getBody());
-        $this->assertEquals(
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com/', (string) $request->getUri());
+        $this->assertSame('{"baz":"bar"}', (string) $request->getBody());
+        $this->assertSame(
             'application/json',
             $request->getHeaderLine('Content-Type')
         );
@@ -109,10 +109,10 @@ class RestJsonSerializerTest extends TestCase
     public function testPreparesRequestsWithEndpointWithPath()
     {
         $request = $this->getPathEndpointRequest('foo', ['baz' => 'bar']);
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com/bar', (string) $request->getUri());
-        $this->assertEquals('{"baz":"bar"}', (string) $request->getBody());
-        $this->assertEquals(
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com/bar', (string) $request->getUri());
+        $this->assertSame('{"baz":"bar"}', (string) $request->getBody());
+        $this->assertSame(
             'application/json',
             $request->getHeaderLine('Content-Type')
         );
@@ -121,20 +121,20 @@ class RestJsonSerializerTest extends TestCase
     public function testPreparesRequestsWithBlobButNoForcedContentType()
     {
         $request = $this->getRequest('bar', ['baz' => 'bar']);
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com/', (string) $request->getUri());
-        $this->assertEquals('bar', (string) $request->getBody());
-        $this->assertEquals('', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com/', (string) $request->getUri());
+        $this->assertSame('bar', (string) $request->getBody());
+        $this->assertSame('', $request->getHeaderLine('Content-Type'));
     }
 
     public function testPreparesRequestsWithJsonValueTraitString()
     {
         $jsonValueArgs = '{"a":"b"}';
         $request = $this->getRequest('foobar', ['baz' => $jsonValueArgs]);
-        $this->assertEquals('IntcImFcIjpcImJcIn0i', $request->getHeaderLine('baz'));
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com/', (string) $request->getUri());
-        $this->assertEquals('', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('IntcImFcIjpcImJcIn0i', $request->getHeaderLine('baz'));
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com/', (string) $request->getUri());
+        $this->assertSame('', $request->getHeaderLine('Content-Type'));
     }
 
     public function testPreparesRequestsWithJsonValueTraitArray()
@@ -143,20 +143,20 @@ class RestJsonSerializerTest extends TestCase
             "a" => "b"
         ];
         $request = $this->getRequest('foobar', ['baz' => $jsonValueArgs]);
-        $this->assertEquals('eyJhIjoiYiJ9', $request->getHeaderLine('baz'));
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com/', (string) $request->getUri());
-        $this->assertEquals('', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('eyJhIjoiYiJ9', $request->getHeaderLine('baz'));
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com/', (string) $request->getUri());
+        $this->assertSame('', $request->getHeaderLine('Content-Type'));
     }
 
     public function testPreparesRequestsWithJsonValueTraitEmptyString()
     {
         $jsonValueArgs = '';
         $request = $this->getRequest('foobar', ['baz' => $jsonValueArgs]);
-        $this->assertEquals('IiI=', $request->getHeaderLine('baz'));
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com/', (string) $request->getUri());
-        $this->assertEquals('', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('IiI=', $request->getHeaderLine('baz'));
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com/', (string) $request->getUri());
+        $this->assertSame('', $request->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -172,10 +172,10 @@ class RestJsonSerializerTest extends TestCase
     public function testPreparesRequestsWithStructPayload()
     {
         $request = $this->getRequest('baz', ['baz' => ['baz' => '1234']]);
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('http://foo.com/', (string) $request->getUri());
-        $this->assertEquals('{"baz":"1234"}', (string) $request->getBody());
-        $this->assertEquals(
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('http://foo.com/', (string) $request->getUri());
+        $this->assertSame('{"baz":"1234"}', (string) $request->getBody());
+        $this->assertSame(
             'application/json',
             $request->getHeaderLine('Content-Type')
         );

--- a/tests/Api/Serializer/RestXmlSerializerTest.php
+++ b/tests/Api/Serializer/RestXmlSerializerTest.php
@@ -28,7 +28,7 @@ class RestXmlSerializerTest extends TestCase
             'Body'        => 'baz',
             'ContentType' => 'abc'
         ]);
-        $this->assertEquals('abc', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('abc', $request->getHeaderLine('Content-Type'));
     }
 
     public function testPreparesRequestsWithNoContentType()
@@ -38,7 +38,7 @@ class RestXmlSerializerTest extends TestCase
             'Key'         => 'bar',
             'Body'        => 'baz'
         ]);
-        $this->assertEquals('', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('', $request->getHeaderLine('Content-Type'));
     }
 
     public function testPreparesRequestsWithStructurePayloadXmlContentType()
@@ -53,7 +53,7 @@ class RestXmlSerializerTest extends TestCase
                 ]
             ]
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'application/xml',
             $request->getHeaderLine('Content-Type')
         );

--- a/tests/Api/ServiceTest.php
+++ b/tests/Api/ServiceTest.php
@@ -25,10 +25,10 @@ class ServiceTest extends TestCase
     public function testImplementsArrayAccess()
     {
         $s = new Service(['metadata' => ['foo' => 'bar']], function () { return []; });
-        $this->assertEquals('bar', $s['metadata']['foo']);
+        $this->assertSame('bar', $s['metadata']['foo']);
         $this->assertNull($s['missing']);
         $s['abc'] = '123';
-        $this->assertEquals('123', $s['abc']);
+        $this->assertSame('123', $s['abc']);
         $this->assertSame([], $s['shapes']);
     }
 
@@ -49,14 +49,14 @@ class ServiceTest extends TestCase
             ],
             function () { return []; }
         );
-        $this->assertEquals('Foo Service', $s->getServiceFullName());
-        $this->assertEquals('foo', $s->getServiceName());
-        $this->assertEquals('Foo', $s->getServiceId());
-        $this->assertEquals('bar', $s->getEndpointPrefix());
-        $this->assertEquals('baz', $s->getApiVersion());
-        $this->assertEquals('qux', $s->getSigningName());
-        $this->assertEquals('yak', $s->getProtocol());
-        $this->assertEquals('foo-2016-12-09', $s->getUid());
+        $this->assertSame('Foo Service', $s->getServiceFullName());
+        $this->assertSame('foo', $s->getServiceName());
+        $this->assertSame('Foo', $s->getServiceId());
+        $this->assertSame('bar', $s->getEndpointPrefix());
+        $this->assertSame('baz', $s->getApiVersion());
+        $this->assertSame('qux', $s->getSigningName());
+        $this->assertSame('yak', $s->getProtocol());
+        $this->assertSame('foo-2016-12-09', $s->getUid());
     }
 
     public function testReturnsMetadata()
@@ -68,7 +68,7 @@ class ServiceTest extends TestCase
             'endpointPrefix'  => 'bar',
             'apiVersion'      => 'baz'
         ];
-        $this->assertEquals('foo', $s->getMetadata('serviceFullName'));
+        $this->assertSame('foo', $s->getMetadata('serviceFullName'));
         $this->assertNull($s->getMetadata('baz'));
     }
 
@@ -77,9 +77,9 @@ class ServiceTest extends TestCase
         $service = $this->generateTestService('rest-json');
         $errorShapes = $service->getErrorShapes();
         $errorShape = $errorShapes[0];
-        $this->assertEquals(1, count($errorShapes));
+        $this->assertCount(1, $errorShapes);
         $this->assertInstanceOf(StructureShape::class, $errorShape);
-        $this->assertEquals('TestException', $errorShape->getName());
+        $this->assertSame('TestException', $errorShape->getName());
     }
 
     public function testReturnsIfOperationExists()

--- a/tests/Api/ShapeTest.php
+++ b/tests/Api/ShapeTest.php
@@ -17,7 +17,7 @@ class ShapeTest extends TestCase
         $this->assertSame(['foo' => 'bar'], $s['metadata']);
         $this->assertNull($s['missing']);
         $s['abc'] = '123';
-        $this->assertEquals('123', $s['abc']);
+        $this->assertSame('123', $s['abc']);
         $this->assertArrayHasKey('abc', $s);
         $this->assertEquals(
             ['metadata' => ['foo' => 'bar'], 'abc' => '123'],
@@ -56,7 +56,7 @@ class ShapeTest extends TestCase
         $m->setAccessible(true);
         $result = $m->invoke($s, 'foo');
         $this->assertInstanceOf('Aws\Api\Shape', $result);
-        $this->assertEquals('string', $result->getType());
+        $this->assertSame('string', $result->getType());
     }
 
     public function testCreatesNestedShapeReferences()
@@ -66,7 +66,7 @@ class ShapeTest extends TestCase
             new ShapeMap(['bar' => ['type' => 'float']])
         );
         $this->assertInstanceOf('Aws\Api\Shape', $s);
-        $this->assertEquals('float', $s->getType());
+        $this->assertSame('float', $s->getType());
     }
 
     /**

--- a/tests/Api/StructureShapeTest.php
+++ b/tests/Api/StructureShapeTest.php
@@ -24,7 +24,7 @@ class StructureShapeTest extends TestCase
         ], new ShapeMap([]));
         $this->assertTrue($s->hasMember('foo'));
         $this->assertInstanceOf('Aws\Api\Shape', $s->getMember('foo'));
-        $this->assertEquals('string', $s->getMember('foo')->getType());
+        $this->assertSame('string', $s->getMember('foo')->getType());
     }
 
     public function testReturnsAllMembers()
@@ -39,8 +39,8 @@ class StructureShapeTest extends TestCase
         $this->assertInternalType('array', $members);
         $this->assertInstanceOf('Aws\Api\Shape', $members['foo']);
         $this->assertInstanceOf('Aws\Api\Shape', $members['baz']);
-        $this->assertEquals('string', $members['foo']->getType());
-        $this->assertEquals('integer', $members['baz']->getType());
+        $this->assertSame('string', $members['foo']->getType());
+        $this->assertSame('integer', $members['baz']->getType());
     }
 
     /**

--- a/tests/Arn/S3/OutpostsAccessPointArnTest.php
+++ b/tests/Arn/S3/OutpostsAccessPointArnTest.php
@@ -126,7 +126,7 @@ class OutpostsAccessPointArnTest extends TestCase
             $this->fail('This was expected to fail with: ' . $expected->getMessage());
         } catch (\Exception $e) {
             $this->assertTrue($e instanceof $expected);
-            $this->assertEquals(
+            $this->assertSame(
                 $expected->getMessage(),
                 $e->getMessage()
             );

--- a/tests/Arn/S3/OutpostsBucketArnTest.php
+++ b/tests/Arn/S3/OutpostsBucketArnTest.php
@@ -127,7 +127,7 @@ class OutpostsBucketArnTest extends TestCase
             $this->fail('This was expected to fail with: ' . $expected->getMessage());
         } catch (\Exception $e) {
             $this->assertTrue($e instanceof $expected);
-            $this->assertEquals(
+            $this->assertSame(
                 $expected->getMessage(),
                 $e->getMessage()
             );

--- a/tests/AwsClientTest.php
+++ b/tests/AwsClientTest.php
@@ -56,7 +56,7 @@ class AwsClientTest extends TestCase
         $this->assertSame($config['handler'], $this->readAttribute($client->getHandlerList(), 'handler'));
         $this->assertSame($config['credentials'], $client->getCredentials()->wait());
         $this->assertSame($config['region'], $client->getRegion());
-        $this->assertEquals('foo', $client->getApi()->getEndpointPrefix());
+        $this->assertSame('foo', $client->getApi()->getEndpointPrefix());
     }
 
     /**
@@ -238,15 +238,15 @@ class AwsClientTest extends TestCase
             'version' => 'latest'
         ]);
         $this->assertInstanceOf('Aws\Sts\StsClient', $client);
-        $this->assertEquals('us-west-2', $client->getRegion());
+        $this->assertSame('us-west-2', $client->getRegion());
     }
 
     public function testCanGetEndpoint()
     {
         $client = $this->createClient();
-        $this->assertEquals(
+        $this->assertSame(
             'http://us-east-1.foo.amazonaws.com',
-            $client->getEndpoint()
+            (string)$client->getEndpoint()
         );
     }
 
@@ -366,7 +366,7 @@ class AwsClientTest extends TestCase
                     foreach (['Authorization','X-Amz-Content-Sha256', 'X-Amz-Date'] as $signatureHeader) {
                         $this->assertTrue($request->hasHeader($signatureHeader));
                     }
-                    $this->assertEquals('UNSIGNED-PAYLOAD', $request->getHeader('X-Amz-Content-Sha256')[0]);
+                    $this->assertSame('UNSIGNED-PAYLOAD', $request->getHeader('X-Amz-Content-Sha256')[0]);
                     return new Result;
                 }
             ]

--- a/tests/Build/Changelog/ChangelogBuilderTest.php
+++ b/tests/Build/Changelog/ChangelogBuilderTest.php
@@ -63,11 +63,11 @@ class ChangelogBuilderTest extends TestCase
         $obj->buildChangelog();
         $this->assertTrue($obj->isNewService());
         $lines = file($tempDir . 'CHANGELOG.md');
-        $this->assertEquals("## next release\n", $lines[2]);
-        $this->assertEquals("* `Aws\Ec2` - Added Support to Tag Instance\n", $lines[4]);
-        $this->assertEquals("* `Aws\Ecs` - Test string placeholder for new docs\n", $lines[5]);
-        $this->assertEquals("* `Aws\s3` - Test string placeholder for new service\n", $lines[6]);
-        $this->assertEquals("* `Aws\util` - Parse ini files containing comments using #\n", $lines[7]);
+        $this->assertSame("## next release\n", $lines[2]);
+        $this->assertSame("* `Aws\Ec2` - Added Support to Tag Instance\n", $lines[4]);
+        $this->assertSame("* `Aws\Ecs` - Test string placeholder for new docs\n", $lines[5]);
+        $this->assertSame("* `Aws\s3` - Test string placeholder for new service\n", $lines[6]);
+        $this->assertSame("* `Aws\util` - Parse ini files containing comments using #\n", $lines[7]);
         unlink($tempDir . '/CHANGELOG.md');
         $expected = file_get_contents($this->RESOURCE_DIR . "/release-json-valid");
         $output = file_get_contents($tempDir . "/.changes/3.22.0");
@@ -76,7 +76,7 @@ class ChangelogBuilderTest extends TestCase
             json_decode($output, true)
         );
         // Verify last character newline matches expected value
-        $this->assertEquals(substr($expected, -1), substr($output, -1));
+        $this->assertSame(substr($expected, -1), substr($output, -1));
         unlink($tempDir . "/.changes/3.22.0");
     }
 

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -193,7 +193,7 @@ class ClientResolverTest extends TestCase
             ]
         ]);
         $res = $r->resolve([], new HandlerList());
-        $this->assertEquals('callable_test', $res['foo']);
+        $this->assertSame('callable_test', $res['foo']);
     }
 
     public function checkCallable()
@@ -213,7 +213,7 @@ class ClientResolverTest extends TestCase
         ]);
         $res = $r->resolve([], new HandlerList());
         $this->assertInternalType('callable', $callableFunction);
-        $this->assertEquals(
+        $this->assertSame(
             '\Aws\test\ClientResolverTest::checkCallable',
             $res['foo']
         );
@@ -245,8 +245,8 @@ class ClientResolverTest extends TestCase
         ], new HandlerList());
         $c = call_user_func($conf['credentials'])->wait();
         $this->assertInstanceOf('Aws\Credentials\CredentialsInterface', $c);
-        $this->assertEquals('foo', $c->getAccessKeyId());
-        $this->assertEquals('bar', $c->getSecretKey());
+        $this->assertSame('foo', $c->getAccessKeyId());
+        $this->assertSame('bar', $c->getSecretKey());
         putenv(CredentialProvider::ENV_KEY . "=$key");
         putenv(CredentialProvider::ENV_SECRET . "=$secret");
     }
@@ -267,10 +267,10 @@ class ClientResolverTest extends TestCase
             ]
         ], new HandlerList());
         $creds = call_user_func($conf['credentials'])->wait();
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('baz', $creds->getSecretKey());
-        $this->assertEquals('tok', $creds->getSecurityToken());
-        $this->assertEquals($exp, $creds->getExpiration());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('baz', $creds->getSecretKey());
+        $this->assertSame('tok', $creds->getSecurityToken());
+        $this->assertSame($exp, $creds->getExpiration());
     }
 
     public function testCanDisableRetries()
@@ -334,7 +334,7 @@ class ClientResolverTest extends TestCase
         ], new HandlerList());
         $creds = call_user_func($conf['credentials'])->wait();
         $this->assertInstanceOf('Aws\Credentials\Credentials', $creds);
-        $this->assertEquals('anonymous', $conf['config']['signature_version']);
+        $this->assertSame('anonymous', $conf['config']['signature_version']);
     }
 
     public function testCanCreateCredentialsFromProvider()
@@ -375,9 +375,9 @@ EOT;
             'version' => 'latest'
         ], new HandlerList());
         $creds = call_user_func($conf['credentials'])->wait();
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('baz', $creds->getSecretKey());
-        $this->assertEquals('tok', $creds->getSecurityToken());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('baz', $creds->getSecretKey());
+        $this->assertSame('tok', $creds->getSecurityToken());
         unlink($dir . '/credentials');
         putenv("HOME=$home");
     }
@@ -491,7 +491,7 @@ EOT;
             'endpoint_provider' => $p,
             'version' => 'latest'
         ], new HandlerList());
-        $this->assertEquals('v4', $conf['config']['signature_version']);
+        $this->assertSame('v4', $conf['config']['signature_version']);
     }
 
     public function testCanPassStsRegionalEndpointsToEndpointProvider()
@@ -510,7 +510,7 @@ EOT;
             'endpoint_provider'         => $partition
         ], new HandlerList());
 
-        $this->assertEquals(
+        $this->assertSame(
             'https://sts.us-west-2.amazonaws.com',
             $conf['endpoint']
         );
@@ -595,7 +595,7 @@ EOT;
             'version' => 'latest',
             'http'    => ['foo' => 'bar']
         ], new HandlerList());
-        $this->assertEquals('bar', $conf['http']['foo']);
+        $this->assertSame('bar', $conf['http']['foo']);
     }
 
     public function testCanAddConfigOptions()

--- a/tests/ClientSideMonitoring/ConfigurationProviderTest.php
+++ b/tests/ClientSideMonitoring/ConfigurationProviderTest.php
@@ -322,7 +322,7 @@ EOT;
         $ref = new \ReflectionClass('Aws\ClientSideMonitoring\ConfigurationProvider');
         $meth = $ref->getMethod('getHomeDir');
         $meth->setAccessible(true);
-        $this->assertEquals('C:\\Michael\\Home', $meth->invoke(null));
+        $this->assertSame('C:\\Michael\\Home', $meth->invoke(null));
     }
 
     public function testMemoizes()
@@ -335,9 +335,9 @@ EOT;
         };
         $p = ConfigurationProvider::memoize($f);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
     }
 
     public function testChainsConfiguration()
@@ -414,7 +414,7 @@ EOT;
                 ->wait();
         }
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
         $this->assertCount(1, $cache);
         $this->assertSame($expected->toArray(), $result->toArray());
     }

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -156,7 +156,7 @@ class SignerTest extends TestCase
         $m = new \ReflectionMethod(Signer::class, 'createCannedPolicy');
         $m->setAccessible(true);
         $result = $m->invoke($this->instance, $resource, $ts);
-        $this->assertEquals(
+        $this->assertSame(
             '{"Statement":[{"Resource":"' . $resource
             . '","Condition":{"DateLessThan":{"AWS:EpochTime":'
             . $ts . '}}}]}',

--- a/tests/CloudSearchDomain/CloudSearchDomainTest.php
+++ b/tests/CloudSearchDomain/CloudSearchDomainTest.php
@@ -29,7 +29,7 @@ class CloudSearchDomainTest extends TestCase
             'signature' => 'v4',
             'version'   => 'latest'
         ]);
-        $this->assertEquals('us-west-2', $client->getRegion());
+        $this->assertSame('us-west-2', $client->getRegion());
     }
 
     public function testConvertGetToPost()
@@ -41,10 +41,10 @@ class CloudSearchDomainTest extends TestCase
             ''
         );
         $request = CloudSearchDomainClient::convertGetToPost($request);
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
-        $this->assertEquals(7, $request->getHeaderLine('Content-Length'));
-        $this->assertEquals('foo=bar', $request->getBody());
+        $this->assertSame('POST', $request->getMethod());
+        $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('7', $request->getHeaderLine('Content-Length'));
+        $this->assertSame('foo=bar', (string)$request->getBody());
         $this->assertSame('', $request->getUri()->getQuery());
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -14,7 +14,7 @@ class CommandTest extends TestCase
     public function testHasName()
     {
         $c = new Command('foo');
-        $this->assertEquals('foo', $c->getName());
+        $this->assertSame('foo', $c->getName());
     }
 
     public function testHasParam()
@@ -40,7 +40,7 @@ class CommandTest extends TestCase
     public function testHasGetMethod()
     {
         $c = new Command('foo', ['bar' => 'baz']);
-        $this->assertEquals('baz', $c->get('bar'));
+        $this->assertSame('baz', $c->get('bar'));
     }
 
     public function testIsIterable()
@@ -71,15 +71,15 @@ class CommandTest extends TestCase
     public function testCanAccessLikeArray()
     {
         $c = new Command('foo', ['bar' => 'baz', 'qux' => 'boo']);
-        $this->assertEquals('baz', $c['bar']);
+        $this->assertSame('baz', $c['bar']);
         $this->assertNull($c['boo']);
-        $this->assertEquals('boo', $c['qux']);
+        $this->assertSame('boo', $c['qux']);
         $this->assertArrayHasKey('qux', $c);
         $this->assertArrayNotHasKey('boo', $c);
 
         $c['boo'] = 'hi!';
         $this->assertArrayHasKey('boo', $c);
-        $this->assertEquals('hi!', $c['boo']);
+        $this->assertSame('hi!', $c['boo']);
 
         unset($c['boo']);
         $this->assertArrayNotHasKey('boo', $c);

--- a/tests/Credentials/AssumeRoleCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleCredentialProviderTest.php
@@ -87,8 +87,8 @@ class AssumeRoleCredentialProviderTest extends TestCase
         $provider = new AssumeRoleCredentialProvider($args);
         $creds = $provider()->wait();
 
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('bar', $creds->getSecretKey());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('bar', $creds->getSecretKey());
         $this->assertNull($creds->getSecurityToken());
         $this->assertInternalType('int', $creds->getExpiration());
         $this->assertFalse($creds->isExpired());

--- a/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
+++ b/tests/Credentials/AssumeRoleWithWebIdentityCredentialProviderTest.php
@@ -90,7 +90,7 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         $sts = $this->getTestClient('Sts', ['credentials' => false]);
         $sts->getHandlerList()->setHandler(
             function ($c, $r) use ($result) {
-                $this->assertEquals('fooSession', $c->toArray()['RoleSessionName']);
+                $this->assertSame('fooSession', $c->toArray()['RoleSessionName']);
                 return Promise\promise_for(new Result($result));
             }
         );
@@ -103,9 +103,9 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         $creds = $provider()->wait();
 
         try {
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('bar', $creds->getSecretKey());
-            $this->assertEquals('baz', $creds->getSecurityToken());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('bar', $creds->getSecretKey());
+            $this->assertSame('baz', $creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
         } catch (\Error $e) {
@@ -271,9 +271,9 @@ class AssumeRoleWithWebIdentityCredentialProviderTest extends TestCase
         $provider = new AssumeRoleWithWebIdentityCredentialProvider($args);
         $creds = $provider()->wait();
         try {
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('bar', $creds->getSecretKey());
-            $this->assertEquals('baz', $creds->getSecurityToken());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('bar', $creds->getSecretKey());
+            $this->assertSame('baz', $creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
         } catch (\Exception $e) {

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -86,8 +86,8 @@ EOT;
         )
             ->wait();
 
-        $this->assertEquals($saved->getAccessKeyId(), $found->getAccessKeyId());
-        $this->assertEquals($saved->getSecretKey(), $found->getSecretKey());
+        $this->assertSame($saved->getAccessKeyId(), $found->getAccessKeyId());
+        $this->assertSame($saved->getSecretKey(), $found->getSecretKey());
         $this->assertEquals($saved->getSecurityToken(), $found->getSecurityToken());
         $this->assertEquals($saved->getExpiration(), $found->getExpiration());
     }
@@ -110,7 +110,7 @@ EOT;
         )
             ->wait();
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
     }
 
     public function testPersistsToCache()
@@ -137,10 +137,10 @@ EOT;
                 ->wait();
         }
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
         $this->assertCount(1, $cache);
-        $this->assertEquals($creds->getAccessKeyId(), $found->getAccessKeyId());
-        $this->assertEquals($creds->getSecretKey(), $found->getSecretKey());
+        $this->assertSame($creds->getAccessKeyId(), $found->getAccessKeyId());
+        $this->assertSame($creds->getSecretKey(), $found->getSecretKey());
         $this->assertEquals($creds->getSecurityToken(), $found->getSecurityToken());
         $this->assertEquals($creds->getExpiration(), $found->getExpiration());
     }
@@ -152,9 +152,9 @@ EOT;
         putenv(CredentialProvider::ENV_SECRET . '=123');
         putenv(CredentialProvider::ENV_SESSION . '=456');
         $creds = call_user_func(CredentialProvider::env())->wait();
-        $this->assertEquals('abc', $creds->getAccessKeyId());
-        $this->assertEquals('123', $creds->getSecretKey());
-        $this->assertEquals('456', $creds->getSecurityToken());
+        $this->assertSame('abc', $creds->getAccessKeyId());
+        $this->assertSame('123', $creds->getSecretKey());
+        $this->assertSame('456', $creds->getSecurityToken());
     }
 
     public function testCreatesFromEnvironmentVariablesNullToken()
@@ -164,8 +164,8 @@ EOT;
         putenv(CredentialProvider::ENV_SECRET . '=123');
         putenv(CredentialProvider::ENV_SESSION . '');
         $creds = call_user_func(CredentialProvider::env())->wait();
-        $this->assertEquals('abc', $creds->getAccessKeyId());
-        $this->assertEquals('123', $creds->getSecretKey());
+        $this->assertSame('abc', $creds->getAccessKeyId());
+        $this->assertSame('123', $creds->getSecretKey());
         $this->assertNull($creds->getSecurityToken());
     }
 
@@ -349,8 +349,8 @@ EOT;
 
         $creds = call_user_func(CredentialProvider::process('foo'))->wait();
         unlink($dir . '/credentials');
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('bar', $creds->getSecretKey());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('bar', $creds->getSecretKey());
     }
 
     public function testCreatesFromProcessCredentialWithFilename()
@@ -365,8 +365,8 @@ EOT;
 
         $creds = call_user_func(CredentialProvider::process('baz', $dir . '/mycreds'))->wait();
         unlink($dir . '/mycreds');
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('bar', $creds->getSecretKey());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('bar', $creds->getSecretKey());
     }
 
     public function testCreatesTemporaryFromProcessCredential()
@@ -383,10 +383,10 @@ EOT;
 
         $creds = call_user_func(CredentialProvider::process('foo'))->wait();
         unlink($dir . '/credentials');
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('bar', $creds->getSecretKey());
-        $this->assertEquals('baz', $creds->getSecurityToken());
-        $this->assertEquals($expires, $creds->getExpiration());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('bar', $creds->getSecretKey());
+        $this->assertSame('baz', $creds->getSecurityToken());
+        $this->assertSame($expires, $creds->getExpiration());
     }
 
     /**
@@ -538,8 +538,8 @@ EOT;
 
             $body = (string) $history->getLastRequest()->getBody();
             $this->assertContains('RoleSessionName=foobar', $body);
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -778,8 +778,8 @@ EOT;
                 $dir . '/credentials',
                 []
             ))->wait();
-            $this->assertEquals('abc', $creds->getAccessKeyId());
-            $this->assertEquals('123', $creds->getSecretKey());
+            $this->assertSame('abc', $creds->getAccessKeyId());
+            $this->assertSame('123', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
         } catch (\Exception $e) {
             throw $e;
@@ -1008,8 +1008,8 @@ EOT;
                 $configFilename,
                 ['ssoClient' => $sso]
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertGreaterThan(
                 DateTimeResult::fromEpoch(time())->getTimestamp(),
@@ -1072,8 +1072,8 @@ EOT;
             $creds = call_user_func(CredentialProvider::defaultProvider(
                 ['ssoClient' => $sso]
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertGreaterThan(
                 DateTimeResult::fromEpoch(time())->getTimestamp(),
@@ -1285,8 +1285,8 @@ EOT;
                 null,
                 $config
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -1338,8 +1338,8 @@ EOT;
                 null,
                 $config
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -1388,8 +1388,8 @@ EOT;
                 null,
                 $config
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -1430,7 +1430,7 @@ EOT;
         $sts = $this->getTestClient('Sts', ['credentials' => false]);
         $sts->getHandlerList()->setHandler(
             function ($c, $r) use ($result) {
-                $this->assertEquals('fooEnv', $c->toArray()['RoleSessionName']);
+                $this->assertSame('fooEnv', $c->toArray()['RoleSessionName']);
                 return Promise\promise_for(new Result($result));
             }
         );
@@ -1442,8 +1442,8 @@ EOT;
             $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider(
                 $config
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -1482,7 +1482,7 @@ EOT;
         $sts = $this->getTestClient('Sts', ['credentials' => false]);
         $sts->getHandlerList()->setHandler(
             function ($c, $r) use ($result) {
-                $this->assertEquals('fooCreds', $c->toArray()['RoleSessionName']);
+                $this->assertSame('fooCreds', $c->toArray()['RoleSessionName']);
                 return Promise\promise_for(new Result($result));
             }
         );
@@ -1494,8 +1494,8 @@ EOT;
             $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider(
                 $config
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -1534,7 +1534,7 @@ EOT;
         $sts = $this->getTestClient('Sts', ['credentials' => false]);
         $sts->getHandlerList()->setHandler(
             function ($c, $r) use ($result) {
-                $this->assertEquals('fooConfig', $c->toArray()['RoleSessionName']);
+                $this->assertSame('fooConfig', $c->toArray()['RoleSessionName']);
                 return Promise\promise_for(new Result($result));
             }
         );
@@ -1546,8 +1546,8 @@ EOT;
             $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider(
                 $config
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -1585,7 +1585,7 @@ EOT;
         $sts = $this->getTestClient('Sts', ['credentials' => false]);
         $sts->getHandlerList()->setHandler(
             function ($c, $r) use ($result) {
-                $this->assertEquals('fooRole', $c->toArray()['RoleSessionName']);
+                $this->assertSame('fooRole', $c->toArray()['RoleSessionName']);
                 return Promise\promise_for(new Result($result));
             }
         );
@@ -1598,8 +1598,8 @@ EOT;
             $creds = call_user_func(CredentialProvider::assumeRoleWithWebIdentityCredentialProvider(
                 $config
             ))->wait();
-            $this->assertEquals('foo', $creds->getAccessKeyId());
-            $this->assertEquals('assumedSecret', $creds->getSecretKey());
+            $this->assertSame('foo', $creds->getAccessKeyId());
+            $this->assertSame('assumedSecret', $creds->getSecretKey());
             $this->assertNull($creds->getSecurityToken());
             $this->assertInternalType('int', $creds->getExpiration());
             $this->assertFalse($creds->isExpired());
@@ -1669,7 +1669,7 @@ EOT;
         $ref = new \ReflectionClass('Aws\Credentials\CredentialProvider');
         $meth = $ref->getMethod('getHomeDir');
         $meth->setAccessible(true);
-        $this->assertEquals('C:\\Michael\\Home', $meth->invoke(null));
+        $this->assertSame('C:\\Michael\\Home', $meth->invoke(null));
     }
 
     public function testMemoizes()
@@ -1682,9 +1682,9 @@ EOT;
         };
         $p = CredentialProvider::memoize($f);
         $this->assertSame($creds, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertSame($creds, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
     }
 
     public function testMemoizesCleansUpOnError()
@@ -1697,7 +1697,7 @@ EOT;
         $p = CredentialProvider::memoize($f);
         $p()->wait(false);
         $p()->wait(false);
-        $this->assertEquals(2, $called);
+        $this->assertSame(2, $called);
     }
 
     public function testCallsDefaultsCreds()
@@ -1710,8 +1710,8 @@ EOT;
         $creds = $provider()->wait();
         putenv(CredentialProvider::ENV_KEY . "={$k}");
         putenv(CredentialProvider::ENV_SECRET . "={$s}");
-        $this->assertEquals('abc', $creds->getAccessKeyId());
-        $this->assertEquals('123', $creds->getSecretKey());
+        $this->assertSame('abc', $creds->getAccessKeyId());
+        $this->assertSame('123', $creds->getSecretKey());
     }
 
     public function testCachesCacheableInDefaultChain()
@@ -1735,8 +1735,8 @@ EOT;
                 'credentials' => $cache,
             ]))
                 ->wait();
-            $this->assertEquals($credsForCache->getAccessKeyId(), $credentials->getAccessKeyId());
-            $this->assertEquals($credsForCache->getSecretKey(), $credentials->getSecretKey());
+            $this->assertSame($credsForCache->getAccessKeyId(), $credentials->getAccessKeyId());
+            $this->assertSame($credsForCache->getSecretKey(), $credentials->getSecretKey());
         }
     }
 
@@ -1755,16 +1755,16 @@ EOT;
             'credentials' => $cache,
         ]))
             ->wait();
-        $this->assertEquals($instanceCredential->getAccessKeyId(), $credentials->getAccessKeyId());
-        $this->assertEquals($instanceCredential->getSecretKey(), $credentials->getSecretKey());
+        $this->assertSame($instanceCredential->getAccessKeyId(), $credentials->getAccessKeyId());
+        $this->assertSame($instanceCredential->getSecretKey(), $credentials->getSecretKey());
 
         putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
         $credentials = call_user_func(CredentialProvider::defaultProvider([
             'credentials' => $cache,
         ]))
             ->wait();
-        $this->assertEquals($ecsCredential->getAccessKeyId(), $credentials->getAccessKeyId());
-        $this->assertEquals($ecsCredential->getSecretKey(), $credentials->getSecretKey());
+        $this->assertSame($ecsCredential->getAccessKeyId(), $credentials->getAccessKeyId());
+        $this->assertSame($ecsCredential->getSecretKey(), $credentials->getSecretKey());
     }
 
     public function testChainsCredentials()
@@ -1779,8 +1779,8 @@ EOT;
         $c = function () { $this->fail('Should not have called'); };
         $provider = CredentialProvider::chain($a, $b, $c);
         $creds = $provider()->wait();
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('baz', $creds->getSecretKey());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('baz', $creds->getSecretKey());
     }
 
     public function testProcessCredentialDefaultChain()
@@ -1795,7 +1795,7 @@ EOT;
         $provider = CredentialProvider::defaultProvider();
         $creds = $provider()->wait();
         unlink($dir . '/credentials');
-        $this->assertEquals('credentialsFoo', $creds->getAccessKeyId());
+        $this->assertSame('credentialsFoo', $creds->getAccessKeyId());
     }
 
     public function testProcessCredentialConfigDefaultChain()
@@ -1811,6 +1811,6 @@ EOT;
         $provider = CredentialProvider::defaultProvider();
         $creds = $provider()->wait();
         unlink($dir . '/config');
-        $this->assertEquals('configFoo', $creds->getAccessKeyId());
+        $this->assertSame('configFoo', $creds->getAccessKeyId());
     }
 }

--- a/tests/Credentials/CredentialsTest.php
+++ b/tests/Credentials/CredentialsTest.php
@@ -13,10 +13,10 @@ class CredentialsTest extends TestCase
     {
         $exp = time() + 500;
         $creds = new Credentials('foo', 'baz', 'tok', $exp);
-        $this->assertEquals('foo', $creds->getAccessKeyId());
-        $this->assertEquals('baz', $creds->getSecretKey());
-        $this->assertEquals('tok', $creds->getSecurityToken());
-        $this->assertEquals($exp, $creds->getExpiration());
+        $this->assertSame('foo', $creds->getAccessKeyId());
+        $this->assertSame('baz', $creds->getSecretKey());
+        $this->assertSame('tok', $creds->getSecurityToken());
+        $this->assertSame($exp, $creds->getExpiration());
         $this->assertEquals([
             'key'     => 'foo',
             'secret'  => 'baz',

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -64,10 +64,10 @@ class EcsCredentialProviderTest extends TestCase
         $c = $this->getTestCreds(
             $this->getCredentialArray('foo', 'baz', null, "@{$t}")
         )->wait();
-        $this->assertEquals('foo', $c->getAccessKeyId());
-        $this->assertEquals('baz', $c->getSecretKey());
+        $this->assertSame('foo', $c->getAccessKeyId());
+        $this->assertSame('baz', $c->getSecretKey());
         $this->assertNull($c->getSecurityToken());
-        $this->assertEquals($t, $c->getExpiration());
+        $this->assertSame($t, $c->getExpiration());
     }
 
     public function testDoesNotRequireConfig()
@@ -121,7 +121,7 @@ class EcsCredentialProviderTest extends TestCase
                     'handler' => function (
                         array $request
                     ) use ($credentials) {
-                        $this->assertEquals('', $request['client']['proxy']);
+                        $this->assertSame('', $request['client']['proxy']);
                         return new CompletedFutureArray([
                             'status'  => 200,
                             'headers' => [],
@@ -141,7 +141,7 @@ class EcsCredentialProviderTest extends TestCase
                         Psr7\Request $request,
                         array $options
                     ) use ($credentials) {
-                        $this->assertEquals('', $options['proxy']);
+                        $this->assertSame('', $options['proxy']);
                         return Promise\promise_for(
                             new Response(
                                 200,

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -306,11 +306,11 @@ class InstanceProfileProviderTest extends TestCase
 
         /** @var CredentialsInterface $credentials */
         $credentials = $provider()->wait();
-        $this->assertEquals(
+        $this->assertSame(
             $expected->getAccessKeyId(),
             $credentials->getAccessKeyId()
         );
-        $this->assertEquals(
+        $this->assertSame(
             $expected->getSecretKey(),
             $credentials->getSecretKey()
         );
@@ -525,8 +525,8 @@ class InstanceProfileProviderTest extends TestCase
             $provider()->wait();
             $this->fail('Provider should have thrown an exception.');
         } catch (\Exception $e) {
-            $this->assertEquals(get_class($expected), get_class($e));
-            $this->assertEquals($expected->getMessage(), $e->getMessage());
+            $this->assertInstanceOf(get_class($expected), $e);
+            $this->assertSame($expected->getMessage(), $e->getMessage());
         }
     }
 
@@ -872,7 +872,7 @@ class InstanceProfileProviderTest extends TestCase
     {
         $response = new Response(200, [], Psr7\stream_for('test'));
         $client = function (RequestInterface $request) use ($response) {
-            $this->assertEquals(
+            $this->assertSame(
                 'aws-sdk-php/' . Sdk::VERSION . ' ' . \Aws\default_user_agent(),
                 $request->getHeader('User-Agent')[0]
             );
@@ -890,10 +890,10 @@ class InstanceProfileProviderTest extends TestCase
             ['foo', 'baz', null, "@{$t}"],
             'foo'
         )->wait();
-        $this->assertEquals('foo', $c->getAccessKeyId());
-        $this->assertEquals('baz', $c->getSecretKey());
+        $this->assertSame('foo', $c->getAccessKeyId());
+        $this->assertSame('baz', $c->getSecretKey());
         $this->assertNull($c->getSecurityToken());
-        $this->assertEquals($t, $c->getExpiration());
+        $this->assertSame($t, $c->getExpiration());
     }
 
     /**
@@ -959,9 +959,9 @@ class InstanceProfileProviderTest extends TestCase
         ];
         $provider = new InstanceProfileProvider($args);
         $c = $provider()->wait();
-        $this->assertEquals('foo', $c->getAccessKeyId());
-        $this->assertEquals('baz', $c->getSecretKey());
+        $this->assertSame('foo', $c->getAccessKeyId());
+        $this->assertSame('baz', $c->getSecretKey());
         $this->assertNull($c->getSecurityToken());
-        $this->assertEquals($t, $c->getExpiration());
+        $this->assertSame($t, $c->getExpiration());
     }
 }

--- a/tests/Crypto/AesDecryptingStreamTest.php
+++ b/tests/Crypto/AesDecryptingStreamTest.php
@@ -46,12 +46,12 @@ class AesDecryptingStreamTest extends TestCase
             (string) $plainText
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $iv->getOpenSslName(),
             $aesDecryptingStream->getOpenSslName()
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             $iv->getAesName(),
             $aesDecryptingStream->getAesName()
         );

--- a/tests/Crypto/AesEncryptingStreamTest.php
+++ b/tests/Crypto/AesEncryptingStreamTest.php
@@ -56,7 +56,7 @@ class AesEncryptingStreamTest extends TestCase
         $key = 'foo';
         $cipherText = new AesEncryptingStream($plainText, $key, $iv);
 
-        $this->assertEquals(
+        $this->assertSame(
             $iv->getOpenSslName(),
             $cipherText->getOpenSslName()
         );
@@ -76,7 +76,7 @@ class AesEncryptingStreamTest extends TestCase
         $key = 'foo';
         $cipherText = new AesEncryptingStream($plainText, $key, $iv);
 
-        $this->assertEquals(
+        $this->assertSame(
             $iv->getCurrentIv(),
             $cipherText->getCurrentIv()
         );

--- a/tests/Crypto/AesGcmDecryptingStreamTest.php
+++ b/tests/Crypto/AesGcmDecryptingStreamTest.php
@@ -52,7 +52,7 @@ class AesGcmDecryptingStreamTest extends TestCase
             $keySize
         );
         $this->assertSame($iv, $decryptingStream->getCurrentIv());
-        $this->assertEquals(
+        $this->assertSame(
             'AES/GCM/NoPadding',
             $decryptingStream->getAesName()
         );
@@ -134,7 +134,7 @@ class AesGcmDecryptingStreamTest extends TestCase
         );
         $cipherText = (string) $stream;
 
-        $this->assertEquals($cipherText, $knownAnswerTest['PT']);
+        $this->assertSame($cipherText, $knownAnswerTest['PT']);
     }
 
     public function testIsNotWritable()

--- a/tests/Crypto/AesGcmEncryptingStreamTest.php
+++ b/tests/Crypto/AesGcmEncryptingStreamTest.php
@@ -188,8 +188,8 @@ class AesGcmEncryptingStreamTest extends TestCase
         $cipherText = (string) $stream;
         $tag = $stream->getTag();
 
-        $this->assertEquals($cipherText, $knownAnswerTest['CT']);
-        $this->assertEquals($tag, $knownAnswerTest['Tag']);
+        $this->assertSame($cipherText, $knownAnswerTest['CT']);
+        $this->assertSame($tag, $knownAnswerTest['Tag']);
     }
 
     public function testIsNotWritable()

--- a/tests/Crypto/Cipher/CbcTest.php
+++ b/tests/Crypto/Cipher/CbcTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aws\Test\EncryptionStreams;
+namespace Aws\Test\Crypto\Cipher;
 
 use Aws\Crypto\Cipher\Cbc;
 use PHPUnit\Framework\TestCase;

--- a/tests/Crypto/KmsMaterialsProviderTest.php
+++ b/tests/Crypto/KmsMaterialsProviderTest.php
@@ -26,7 +26,7 @@ class KmsMaterialsProviderTest extends TestCase
             ['kms_cmk_id' => $keyId],
             $provider->getMaterialsDescription()
         );
-        $this->assertEquals('kms', $provider->getWrapAlgorithmName());
+        $this->assertSame('kms', $provider->getWrapAlgorithmName());
     }
 
     public function testEncryptCek()
@@ -39,7 +39,7 @@ class KmsMaterialsProviderTest extends TestCase
         ]);
 
         $provider = new KmsMaterialsProvider($client, $keyId);
-        $this->assertEquals(
+        $this->assertSame(
             base64_encode('encrypted'),
             $provider->encryptCek(
                 'plaintext',
@@ -58,7 +58,7 @@ class KmsMaterialsProviderTest extends TestCase
         ]);
 
         $provider = new KmsMaterialsProvider($client, $keyId);
-        $this->assertEquals(
+        $this->assertSame(
             'plaintext',
             $provider->decryptCek(
                 'encrypted',

--- a/tests/Crypto/KmsMaterialsProviderV2Test.php
+++ b/tests/Crypto/KmsMaterialsProviderV2Test.php
@@ -22,7 +22,7 @@ class KmsMaterialsProviderV2Test extends TestCase
         $keyId = '11111111-2222-3333-4444-555555555555';
 
         $provider = new KmsMaterialsProviderV2($client, $keyId);
-        $this->assertEquals('kms+context', $provider->getWrapAlgorithmName());
+        $this->assertSame('kms+context', $provider->getWrapAlgorithmName());
     }
 
     public function testGeneratesCek()
@@ -41,11 +41,11 @@ class KmsMaterialsProviderV2Test extends TestCase
                 ],
                 $cmd['EncryptionContext']
             );
-            $this->assertEquals(
+            $this->assertSame(
                 'AES_256',
                 $cmd['KeySpec']
             );
-            $this->assertEquals(
+            $this->assertSame(
                 $keyId,
                 $cmd['KeyId']
             );
@@ -158,7 +158,7 @@ class KmsMaterialsProviderV2Test extends TestCase
                 ],
                 $cmd['EncryptionContext']
             );
-            $this->assertEquals(
+            $this->assertSame(
                 'encrypted',
                 $cmd['CiphertextBlob']
             );
@@ -170,7 +170,7 @@ class KmsMaterialsProviderV2Test extends TestCase
         ]);
 
         $provider = new KmsMaterialsProviderV2($client, $keyId);
-        $this->assertEquals(
+        $this->assertSame(
             'plaintext',
             $provider->decryptCek(
                 'encrypted',
@@ -213,7 +213,7 @@ class KmsMaterialsProviderV2Test extends TestCase
                 ],
                 $cmd['EncryptionContext']
             );
-            $this->assertEquals(
+            $this->assertSame(
                 'encrypted',
                 $cmd['CiphertextBlob']
             );
@@ -224,7 +224,7 @@ class KmsMaterialsProviderV2Test extends TestCase
         ]);
 
         $provider = new KmsMaterialsProviderV2($client);
-        $this->assertEquals(
+        $this->assertSame(
             'plaintext',
             $provider->decryptCek(
                 'encrypted',

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -133,10 +133,10 @@ class DynamoDbClientTest extends TestCase
             $client->getItem($params);
             $this->fail('This operation should have failed with a NonRetryableException.');
         } catch(AwsException $e) {
-            $this->assertEquals('NonRetryableException', $e->getAwsErrorCode());
+            $this->assertSame('NonRetryableException', $e->getAwsErrorCode());
         }
 
-        $this->assertEquals(3, $attemptCount);
+        $this->assertSame(3, $attemptCount);
     }
 
     public function dataProviderRetrySettings()

--- a/tests/DynamoDb/MarshalerTest.php
+++ b/tests/DynamoDb/MarshalerTest.php
@@ -282,8 +282,8 @@ JSON;
         $json = str_replace([" ", "\n"], '', $json); // remove whitespace
 
         $m = new Marshaler;
-        $this->assertEquals($json, $m->unmarshalJson($item));
-        $this->assertEquals($json, json_encode($m->unmarshalItem($item)));
+        $this->assertSame($json, $m->unmarshalJson($item));
+        $this->assertSame($json, json_encode($m->unmarshalItem($item)));
     }
 
     public function testCanUnmarshalToObjectFormat()
@@ -294,7 +294,7 @@ JSON;
         );
 
         $this->assertInstanceOf('stdClass', $result);
-        $this->assertEquals('b', $result->a);
+        $this->assertSame('b', $result->a);
     }
 
     /**
@@ -343,8 +343,8 @@ JSON;
             'bar' => ['N' => '99999999999999999999.99999999999999999999'],
         ]);
         $this->assertInstanceOf('Aws\DynamoDb\NumberValue', $result['bar']);
-        $this->assertEquals('99999999999999999999', (string) iterator_to_array($result['foo'])[0]);
-        $this->assertEquals('99999999999999999999.99999999999999999999', (string) $result['bar']);
+        $this->assertSame('99999999999999999999', (string) iterator_to_array($result['foo'])[0]);
+        $this->assertSame('99999999999999999999.99999999999999999999', (string) $result['bar']);
     }
 
     /**
@@ -353,8 +353,8 @@ JSON;
     public function testNumberValueCanBeFormattedAndSerialized()
     {
         $number = new NumberValue('99999999999999999999');
-        $this->assertEquals('99999999999999999999', (string) $number);
-        $this->assertEquals('"99999999999999999999"', json_encode($number));
+        $this->assertSame('99999999999999999999', (string) $number);
+        $this->assertSame('"99999999999999999999"', json_encode($number));
     }
 
     /**
@@ -367,8 +367,8 @@ JSON;
         fseek($resource, 0);
 
         $binary = new BinaryValue($resource);
-        $this->assertEquals('foo', (string) $binary);
-        $this->assertEquals('"foo"', json_encode($binary));
+        $this->assertSame('foo', (string) $binary);
+        $this->assertSame('"foo"', json_encode($binary));
     }
 
     /**
@@ -378,7 +378,7 @@ JSON;
     {
         $set = new SetValue(['foo', 'bar', 'baz']);
         $this->assertEquals(['foo', 'bar', 'baz'], $set->toArray());
-        $this->assertEquals('["foo","bar","baz"]', json_encode($set));
+        $this->assertSame('["foo","bar","baz"]', json_encode($set));
         $this->assertCount(3, $set);
         $this->assertCount(3, $set);
     }
@@ -392,6 +392,6 @@ JSON;
         $resultCopy = $result;
         $resultCopy['foo_copy'] = $resultCopy['foo'];
         $resultCopy['foo'] = 'baz';
-        $this->assertEquals('bar', $result['foo']);
+        $this->assertSame('bar', $result['foo']);
     }
 }

--- a/tests/DynamoDb/SessionConnectionConfigTraitTest.php
+++ b/tests/DynamoDb/SessionConnectionConfigTraitTest.php
@@ -15,18 +15,18 @@ class SessionConnectionConfigTraitTest extends TestCase
     {
         $scc = $this->getMockForTrait('Aws\DynamoDb\SessionConnectionConfigTrait');
         $scc->setSessionLifetime((int) ini_get('session.gc_maxlifetime'));
-        $this->assertEquals('sessions', $scc->getTableName());
-        $this->assertEquals('id', $scc->getHashKey());
-        $this->assertEquals('data', $scc->getDataAttribute());
-        $this->assertEquals('string', $scc->getDataAttributeType());
-        $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
-        $this->assertEquals('expires', $scc->getSessionLifetimeAttribute());
+        $this->assertSame('sessions', $scc->getTableName());
+        $this->assertSame('id', $scc->getHashKey());
+        $this->assertSame('data', $scc->getDataAttribute());
+        $this->assertSame('string', $scc->getDataAttributeType());
+        $this->assertSame((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
+        $this->assertSame('expires', $scc->getSessionLifetimeAttribute());
         $this->assertTrue($scc->isConsistentRead());
         $this->assertFalse($scc->isLocking());
         $this->assertEmpty($scc->getBatchConfig());
-        $this->assertEquals(10, $scc->getMaxLockWaitTime());
-        $this->assertEquals(10000, $scc->getMinLockRetryMicrotime());
-        $this->assertEquals(50000, $scc->getMaxLockRetryMicrotime());
+        $this->assertSame(10, $scc->getMaxLockWaitTime());
+        $this->assertSame(10000, $scc->getMinLockRetryMicrotime());
+        $this->assertSame(50000, $scc->getMaxLockRetryMicrotime());
     }
 
     public function testCustomConfig()
@@ -47,23 +47,23 @@ class SessionConnectionConfigTraitTest extends TestCase
         ];
         $scc = $this->getMockForTrait('Aws\DynamoDb\SessionConnectionConfigTrait');
         $scc->initConfig($config);
-        $this->assertEquals('sessions_custom', $scc->getTableName());
-        $this->assertEquals('id_custom', $scc->getHashKey());
-        $this->assertEquals('data_custom', $scc->getDataAttribute());
-        $this->assertEquals('binary', $scc->getDataAttributeType());
-        $this->assertEquals(2019, $scc->getSessionLifetime());
-        $this->assertEquals('expires_custom', $scc->getSessionLifetimeAttribute());
+        $this->assertSame('sessions_custom', $scc->getTableName());
+        $this->assertSame('id_custom', $scc->getHashKey());
+        $this->assertSame('data_custom', $scc->getDataAttribute());
+        $this->assertSame('binary', $scc->getDataAttributeType());
+        $this->assertSame(2019, $scc->getSessionLifetime());
+        $this->assertSame('expires_custom', $scc->getSessionLifetimeAttribute());
         $this->assertFalse($scc->isConsistentRead());
         $this->assertTrue($scc->isLocking());
         $this->assertEquals($scc->getBatchConfig(), ['hello' => 'hello']);
-        $this->assertEquals(2019, $scc->getMaxLockWaitTime());
-        $this->assertEquals(2019, $scc->getMinLockRetryMicrotime());
-        $this->assertEquals(2019, $scc->getMaxLockRetryMicrotime());
+        $this->assertSame(2019, $scc->getMaxLockWaitTime());
+        $this->assertSame(2019, $scc->getMinLockRetryMicrotime());
+        $this->assertSame(2019, $scc->getMaxLockRetryMicrotime());
 
         // Test Custom Config Without Session Lifetime
         unset($config['session_lifetime']);
         $scc = $this->getMockForTrait('Aws\DynamoDb\SessionConnectionConfigTrait');
         $scc->initConfig($config);
-        $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
+        $this->assertSame((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
     }
 }

--- a/tests/DynamoDb/SessionHandlerTest.php
+++ b/tests/DynamoDb/SessionHandlerTest.php
@@ -61,7 +61,7 @@ class SessionHandlerTest extends TestCase
 
         $sh = new SessionHandler($connection);
         $this->assertTrue($sh->open('foo', 'bar'));
-        $this->assertEquals('', $sh->read('test'));
+        $this->assertSame('', $sh->read('test'));
         $this->assertFalse($sh->write('test', serialize($data)));
         $this->assertTrue($sh->close());
     }

--- a/tests/DynamoDb/StandardSessionConnectionTest.php
+++ b/tests/DynamoDb/StandardSessionConnectionTest.php
@@ -19,17 +19,17 @@ class StandardSessionConnectionTest extends TestCase
     {
         $client = $this->getTestSdk()->createDynamoDb();
         $scc = new StandardSessionConnection($client);
-        $this->assertEquals('sessions', $scc->getTableName());
-        $this->assertEquals('id', $scc->getHashKey());
-        $this->assertEquals('data', $scc->getDataAttribute());
-        $this->assertEquals('string', $scc->getDataAttributeType());
-        $this->assertEquals((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
-        $this->assertEquals('expires', $scc->getSessionLifetimeAttribute());
+        $this->assertSame('sessions', $scc->getTableName());
+        $this->assertSame('id', $scc->getHashKey());
+        $this->assertSame('data', $scc->getDataAttribute());
+        $this->assertSame('string', $scc->getDataAttributeType());
+        $this->assertSame((int) ini_get('session.gc_maxlifetime'), $scc->getSessionLifetime());
+        $this->assertSame('expires', $scc->getSessionLifetimeAttribute());
         $this->assertTrue($scc->isConsistentRead());
         $this->assertFalse($scc->isLocking());
-        $this->assertEquals(10, $scc->getMaxLockWaitTime());
-        $this->assertEquals(10000, $scc->getMinLockRetryMicrotime());
-        $this->assertEquals(50000, $scc->getMaxLockRetryMicrotime());
+        $this->assertSame(10, $scc->getMaxLockWaitTime());
+        $this->assertSame(10000, $scc->getMinLockRetryMicrotime());
+        $this->assertSame(50000, $scc->getMaxLockRetryMicrotime());
     }
 
     public function testCustomConfig()
@@ -50,17 +50,17 @@ class StandardSessionConnectionTest extends TestCase
             'max_lock_retry_microtime'      => 2019
         ];
         $scc = new StandardSessionConnection($client, $config);
-        $this->assertEquals('sessions_custom', $scc->getTableName());
-        $this->assertEquals('id_custom', $scc->getHashKey());
-        $this->assertEquals('data_custom', $scc->getDataAttribute());
-        $this->assertEquals('binary', $scc->getDataAttributeType());
-        $this->assertEquals(2019, $scc->getSessionLifetime());
-        $this->assertEquals('expires_custom', $scc->getSessionLifetimeAttribute());
+        $this->assertSame('sessions_custom', $scc->getTableName());
+        $this->assertSame('id_custom', $scc->getHashKey());
+        $this->assertSame('data_custom', $scc->getDataAttribute());
+        $this->assertSame('binary', $scc->getDataAttributeType());
+        $this->assertSame(2019, $scc->getSessionLifetime());
+        $this->assertSame('expires_custom', $scc->getSessionLifetimeAttribute());
         $this->assertFalse($scc->isConsistentRead());
         $this->assertTrue($scc->isLocking());
-        $this->assertEquals(2019, $scc->getMaxLockWaitTime());
-        $this->assertEquals(2019, $scc->getMinLockRetryMicrotime());
-        $this->assertEquals(2019, $scc->getMaxLockRetryMicrotime());
+        $this->assertSame(2019, $scc->getMaxLockWaitTime());
+        $this->assertSame(2019, $scc->getMinLockRetryMicrotime());
+        $this->assertSame(2019, $scc->getMaxLockRetryMicrotime());
     }
 
     public function testReadRetrievesItemData()

--- a/tests/DynamoDb/WriteRequestBatchTest.php
+++ b/tests/DynamoDb/WriteRequestBatchTest.php
@@ -20,7 +20,7 @@ class WriteRequestBatchTest extends TestCase
     {
         // Ensure threshold is correctly calculated
         $batch = new WriteRequestBatch($this->getTestClient('DynamoDb'), ['pool_size' => 2]);
-        $this->assertEquals(50, $this->readAttribute($batch, 'config')['threshold']);
+        $this->assertSame(50, $this->readAttribute($batch, 'config')['threshold']);
     }
 
     /**
@@ -204,6 +204,6 @@ class WriteRequestBatchTest extends TestCase
         // After 2 complete flushes, the queue should be empty, and there should
         // been 2 unhandled errors that would have triggered the callback.
         $this->assertCount(0, $this->readAttribute($batch, 'queue'));
-        $this->assertEquals(2, $unhandledErrors);
+        $this->assertSame(2, $unhandledErrors);
     }
 }

--- a/tests/Ec2/Ec2ClientTest.php
+++ b/tests/Ec2/Ec2ClientTest.php
@@ -21,7 +21,7 @@ class Ec2ClientTest extends TestCase
         $mock = new MockHandler([
             function ($command, $request) {
                 $this->assertNotNull($command['PresignedUrl']);
-                $this->assertEquals('us-east-1', $command['DestinationRegion']);
+                $this->assertSame('us-east-1', $command['DestinationRegion']);
                 return new Result();
             }
         ]);
@@ -70,7 +70,7 @@ class Ec2ClientTest extends TestCase
 
         $mock = new MockHandler([
             function ($command, $request) {
-                $this->assertEquals('foo', $command['ClientToken']);
+                $this->assertSame('foo', $command['ClientToken']);
                 return new Result();
             }
         ]);

--- a/tests/Endpoint/EndpointProviderTest.php
+++ b/tests/Endpoint/EndpointProviderTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aws\Test;
+namespace Aws\Test\Endpoint;
 
 use Aws\Endpoint\EndpointProvider;
 use Aws\Endpoint\PartitionEndpointProvider;
@@ -39,6 +39,6 @@ class EndpointProviderTest extends TestCase
         ]);
         $this->assertInstanceOf('Aws\Endpoint\PatternEndpointProvider', $p);
         $result = EndpointProvider::resolve($p, []);
-        $this->assertEquals('https://foo.com', $result['endpoint']);
+        $this->assertSame('https://foo.com', $result['endpoint']);
     }
 }

--- a/tests/Endpoint/PartitionEndpointProviderTest.php
+++ b/tests/Endpoint/PartitionEndpointProviderTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aws\Test;
+namespace Aws\Test\Endpoint;
 
 use Aws\Endpoint\EndpointProvider;
 use Aws\Endpoint\Partition;
@@ -209,7 +209,7 @@ class PartitionEndpointProviderTest extends TestCase
             'region' => 'us-east-1',
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             'https://sts.us-east-1.amazonaws.com',
             $endpoint['endpoint']
         );

--- a/tests/Endpoint/PartitionTest.php
+++ b/tests/Endpoint/PartitionTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aws\Test;
+namespace Aws\Test\Endpoint;
 
 use Aws\Endpoint\Partition;
 use Aws\Endpoint\PartitionInterface;
@@ -18,7 +18,7 @@ class PartitionTest extends TestCase
     public function testAcceptsValidDefinitions(array $definition)
     {
         $this->assertInstanceOf(
-            PartitionInterface::class, 
+            PartitionInterface::class,
             new Partition($definition)
         );
     }

--- a/tests/Endpoint/PatternEndpointProviderTest.php
+++ b/tests/Endpoint/PatternEndpointProviderTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aws\Test;
+namespace Aws\Test\Endpoint;
 
 use Aws\Endpoint\EndpointProvider;
 use Aws\Endpoint\PatternEndpointProvider;
@@ -99,10 +99,10 @@ class PatternEndpointProviderTest extends TestCase
             'eu-west-1/s3' => ['endpoint' => 's3-{region}.amazonaws.com'],
             'ap-southeast-1/s3' => ['endpoint' => 's3-{region}.amazonaws.com'],
             'ap-southeast-2/s3' => ['endpoint' => 's3-{region}.amazonaws.com'],
-            'ap-northeast-1/s3' => ['endpoint' => 's3-{region}.amazonaws.com'], 
+            'ap-northeast-1/s3' => ['endpoint' => 's3-{region}.amazonaws.com'],
             'sa-east-1/s3' => ['endpoint' => 's3-{region}.amazonaws.com'],
         ]);
-        
+
         $this->assertEquals($output, call_user_func($p, $input));
     }
 }

--- a/tests/EndpointDiscovery/ConfigurationProviderTest.php
+++ b/tests/EndpointDiscovery/ConfigurationProviderTest.php
@@ -287,7 +287,7 @@ EOT;
         $ref = new \ReflectionClass('Aws\EndpointDiscovery\ConfigurationProvider');
         $meth = $ref->getMethod('getHomeDir');
         $meth->setAccessible(true);
-        $this->assertEquals('C:\\Michael\\Home', $meth->invoke(null));
+        $this->assertSame('C:\\Michael\\Home', $meth->invoke(null));
     }
 
     public function testMemoizes()
@@ -300,9 +300,9 @@ EOT;
         };
         $p = ConfigurationProvider::memoize($f);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
     }
 
     public function testChainsConfiguration()
@@ -386,7 +386,7 @@ EOT;
                 ->wait();
         }
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
         $this->assertCount(1, $cache);
         $this->assertSame($expected->toArray(), $result->toArray());
     }

--- a/tests/EndpointDiscovery/EndpointDiscoveryMiddlewareTest.php
+++ b/tests/EndpointDiscovery/EndpointDiscoveryMiddlewareTest.php
@@ -59,8 +59,8 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             );
             $uri = $req->getUri();
             $expectedUri = $expected->getUri();
-            $this->assertEquals($expectedUri->getHost(), $uri->getHost());
-            $this->assertEquals($expectedUri->getPath(), $uri->getPath());
+            $this->assertSame($expectedUri->getHost(), $uri->getHost());
+            $this->assertSame($expectedUri->getPath(), $uri->getPath());
             return Promise\promise_for(new Result([]));
         });
         $command = $client->getCommand($commandArgs[0], $commandArgs[1]);
@@ -350,7 +350,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             $this->fail('Should have failed with an UnresolvedEndpointException.');
         } catch (\Exception $e) {
             $this->assertTrue($e instanceof UnresolvedEndpointException);
-            $this->assertEquals(
+            $this->assertSame(
                 "The supplied endpoint '#!@$' is invalid.",
                 $e->getMessage()
             );
@@ -376,8 +376,8 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
                 return $this->generateSingleDescribeResult();
             }
             $operationCounter++;
-            $this->assertEquals('discovered.com', $req->getUri()->getHost());
-            $this->assertEquals('/some/path', $req->getUri()->getPath());
+            $this->assertSame('discovered.com', $req->getUri()->getHost());
+            $this->assertSame('/some/path', $req->getUri()->getPath());
             return $this->generateGenericResult();
         });
 
@@ -387,8 +387,8 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             $client->execute($command);
         }
 
-        $this->assertEquals(1, $describeCounter);
-        $this->assertEquals(5, $operationCounter);
+        $this->assertSame(1, $describeCounter);
+        $this->assertSame(5, $operationCounter);
     }
 
     /**
@@ -425,8 +425,8 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
                 ]));
             }
             $operationCounter++;
-            $this->assertEquals('discovered.com', $req->getUri()->getHost());
-            $this->assertEquals("/{$cmd['Sdk']}", $req->getUri()->getPath());
+            $this->assertSame('discovered.com', $req->getUri()->getHost());
+            $this->assertSame("/{$cmd['Sdk']}", $req->getUri()->getPath());
             return $this->generateGenericResult();
         });
 
@@ -446,8 +446,8 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
 
         // Only the repeated call to 'three' should be cached, so there should
         // be one fewer describe call
-        $this->assertEquals(5, $describeCounter);
-        $this->assertEquals(6, $operationCounter);
+        $this->assertSame(5, $describeCounter);
+        $this->assertSame(6, $operationCounter);
     }
 
     /**
@@ -472,7 +472,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             if ($cmd->getName() === 'DescribeEndpoints') {
                 return $this->generateDescribeException($cmd);
             }
-            $this->assertEquals(
+            $this->assertSame(
                 'awsendpointdiscoverytestservice.us-east-1.amazonaws.com',
                 $req->getUri()->getHost()
             );
@@ -507,11 +507,11 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             $this->fail('This operation should have failed with an '
                 . 'EndpointDiscoveryException.');
         } catch (AwsException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 'EndpointDiscoveryException',
                 $e->getAwsErrorCode()
             );
-            $this->assertEquals(
+            $this->assertSame(
                 'The endpoint required for this service is currently unable to '
                     . 'be retrieved, and your request can not be fulfilled '
                     . 'unless you manually specify an endpoint.',
@@ -633,7 +633,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
         try {
             $client->execute($command);
         } catch (AwsException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 'Test invalid endpoint exception',
                 $e->getAwsErrorMessage()
             );
@@ -688,7 +688,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
         try {
             $client->execute($command);
         } catch (AwsException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 'Test invalid endpoint exception',
                 $e->getAwsErrorMessage()
             );
@@ -736,7 +736,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             $this->fail('This operation should have failed with a '
                 . 'UnresolvedEndpointException!');
         } catch (\Exception $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 'This operation is contradictorily marked both as using endpoint '
                     . 'discovery and being the endpoint discovery operation. '
                     . 'Please verify the accuracy of your model files.',
@@ -783,7 +783,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             $this->fail('This operation should have failed with an '
                 . 'UnresolvedEndpointException.');
         } catch (AwsException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 'The endpoint required for this service is currently unable to '
                     . 'be retrieved, and your request can not be fulfilled '
                     . 'unless you manually specify an endpoint.',
@@ -791,7 +791,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             );
             $previous = $e->getPrevious();
             $this->assertTrue($previous instanceof UnresolvedEndpointException);
-            $this->assertEquals(
+            $this->assertSame(
                 'The endpoint discovery operation yielded a response that did '
                     . 'not contain properly formatted endpoint data.',
                 $previous->getMessage()
@@ -817,7 +817,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             $this->fail('This operation should have failed with an '
                 . 'UnresolvedEndpointException.');
         } catch (AwsException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 'The endpoint required for this service is currently unable to '
                     . 'be retrieved, and your request can not be fulfilled '
                     . 'unless you manually specify an endpoint.',
@@ -825,7 +825,7 @@ class EndpointDiscoveryMiddlewareTest extends TestCase
             );
             $previous = $e->getPrevious();
             $this->assertTrue($previous instanceof UnresolvedEndpointException);
-            $this->assertEquals(
+            $this->assertSame(
                 'This command is set to use endpoint discovery, but no endpoint '
                     . 'discovery operation was found. Please verify the '
                     . 'accuracy of your model files.',

--- a/tests/EndpointDiscovery/EndpointListTest.php
+++ b/tests/EndpointDiscovery/EndpointListTest.php
@@ -17,10 +17,10 @@ class EndpointListTest extends TestCase
             'endpoint_2' => time() + 100,
         ]);
 
-        $this->assertEquals('endpoint_1', $list->getActive());
-        $this->assertEquals('endpoint_2', $list->getActive());
-        $this->assertEquals('endpoint_1', $list->getActive());
-        $this->assertEquals('endpoint_2', $list->getActive());
+        $this->assertSame('endpoint_1', $list->getActive());
+        $this->assertSame('endpoint_2', $list->getActive());
+        $this->assertSame('endpoint_1', $list->getActive());
+        $this->assertSame('endpoint_2', $list->getActive());
     }
 
     public function testMovesToAndRetrievesFromExpiredEndpoints()
@@ -29,16 +29,16 @@ class EndpointListTest extends TestCase
             'endpoint_1' => time() + 2,
             'endpoint_2' => time() + 2,
         ]);
-        $this->assertEquals('endpoint_1', $list->getActive());
-        $this->assertEquals('endpoint_2', $list->getActive());
+        $this->assertSame('endpoint_1', $list->getActive());
+        $this->assertSame('endpoint_2', $list->getActive());
 
         sleep(4);
 
         $this->assertNull($list->getActive());
-        $this->assertEquals('endpoint_1', $list->getEndpoint());
-        $this->assertEquals('endpoint_2', $list->getEndpoint());
-        $this->assertEquals('endpoint_1', $list->getEndpoint());
-        $this->assertEquals('endpoint_2', $list->getEndpoint());
+        $this->assertSame('endpoint_1', $list->getEndpoint());
+        $this->assertSame('endpoint_2', $list->getEndpoint());
+        $this->assertSame('endpoint_1', $list->getEndpoint());
+        $this->assertSame('endpoint_2', $list->getEndpoint());
     }
 
     public function testGetEndpointSelectsActiveThenExpired()
@@ -48,12 +48,12 @@ class EndpointListTest extends TestCase
             'endpoint_2' => time() + 100,
         ]);
 
-        $this->assertEquals('endpoint_2', $list->getEndpoint());
+        $this->assertSame('endpoint_2', $list->getEndpoint());
         // Make sure list is not cycling to the expired endpoint
-        $this->assertEquals('endpoint_2', $list->getEndpoint());
+        $this->assertSame('endpoint_2', $list->getEndpoint());
 
         $list->remove('endpoint_2');
-        $this->assertEquals('endpoint_1', $list->getEndpoint());
+        $this->assertSame('endpoint_1', $list->getEndpoint());
     }
 
     public function testRemovesEndpoints()
@@ -63,13 +63,13 @@ class EndpointListTest extends TestCase
             'endpoint_2' => time() + 100,
         ]);
 
-        $this->assertEquals('endpoint_2', $list->getActive());
+        $this->assertSame('endpoint_2', $list->getActive());
 
         $list->remove('endpoint_2');
         $this->assertNull($list->getActive());
-        $this->assertEquals('endpoint_1', $list->getEndpoint());
+        $this->assertSame('endpoint_1', $list->getEndpoint());
         // Check that 'endpoint_2' was not moved to the expired list
-        $this->assertEquals('endpoint_1', $list->getEndpoint());
+        $this->assertSame('endpoint_1', $list->getEndpoint());
 
         $list->remove('endpoint_1');
         $this->assertNull($list->getEndpoint());

--- a/tests/EndpointParameterMiddlewareTest.php
+++ b/tests/EndpointParameterMiddlewareTest.php
@@ -32,7 +32,7 @@ class EndpointParameterMiddlewareTest extends TestCase
             $handler($command, new Request('POST', 'https://foo.com'));
             $this->fail('Test should have thrown an InvalidArgumentException for not having the host parameter set.');
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 "The parameter 'HostParameter' must be set and not empty.",
                 $e->getMessage()
             );
@@ -60,7 +60,7 @@ class EndpointParameterMiddlewareTest extends TestCase
             $handler($command, new Request('POST', 'https://foo.com'));
             $this->fail('Test should have thrown an InvalidArgumentException for having an invalid host parameter.');
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 "The supplied parameters result in an invalid hostname: '<bar).foo.com'.",
                 $e->getMessage()
             );

--- a/tests/Exception/AwsExceptionTest.php
+++ b/tests/Exception/AwsExceptionTest.php
@@ -1,6 +1,7 @@
 <?php
-namespace Aws\Test;
+namespace Aws\Test\Exception;
 
+use Aws\Test\UsesServiceTrait;
 use Aws\Api\ApiProvider;
 use Aws\Api\Service;
 use Aws\Api\StructureShape;
@@ -29,9 +30,9 @@ class AwsExceptionTest extends TestCase
 
         $command = new Command('foo');
         $e = new AwsException('Foo', $command, $ctx);
-        $this->assertEquals('10', $e->getAwsRequestId());
-        $this->assertEquals('mytype', $e->getAwsErrorType());
-        $this->assertEquals('mycode', $e->getAwsErrorCode());
+        $this->assertSame('10', $e->getAwsRequestId());
+        $this->assertSame('mytype', $e->getAwsErrorType());
+        $this->assertSame('mycode', $e->getAwsErrorCode());
         $this->assertSame($command, $e->getCommand());
         $this->assertNull($e->getResult());
     }
@@ -41,7 +42,7 @@ class AwsExceptionTest extends TestCase
         $ctx = ['response' => new Response(400)];
         $command = new Command('foo');
         $e = new AwsException('Foo', $command, $ctx);
-        $this->assertEquals(400, $e->getStatusCode());
+        $this->assertSame(400, $e->getStatusCode());
     }
 
     public function testSetsMaxRetriesExceeded()
@@ -128,12 +129,12 @@ class AwsExceptionTest extends TestCase
             new Command('bar'),
             ['body' => ['a' => 'b', 'c' => 'd']]
         );
-        $this->assertEquals('b', $e['a']);
-        $this->assertEquals('d', $e['c']);
-        $this->assertEquals('d', $e->get('c'));
+        $this->assertSame('b', $e['a']);
+        $this->assertSame('d', $e['c']);
+        $this->assertSame('d', $e->get('c'));
         $this->assertTrue($e->hasKey('c'));
         $this->assertFalse($e->hasKey('f'));
-        $this->assertEquals('b', $e->search('a'));
+        $this->assertSame('b', $e->search('a'));
     }
 
     public function testProvidesErrorShape()

--- a/tests/Exception/EventStreamDataExceptionTest.php
+++ b/tests/Exception/EventStreamDataExceptionTest.php
@@ -1,18 +1,19 @@
 <?php
 
-namespace Aws\Test;
+namespace Aws\Test\Exception;
 
 use Aws\Exception\EventStreamDataException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Aws\Exception\EventStreamDataException
  */
-class EventStreamDataExceptionTest extends \PHPUnit_Framework_TestCase
+class EventStreamDataExceptionTest extends TestCase
 {
     public function testAccessors()
     {
         $e = new EventStreamDataException('Code', 'This is a message.');
-        $this->assertEquals('Code', $e->getAwsErrorCode());
-        $this->assertEquals('This is a message.', $e->getAwsErrorMessage());
+        $this->assertSame('Code', $e->getAwsErrorCode());
+        $this->assertSame('This is a message.', $e->getAwsErrorMessage());
     }
 }

--- a/tests/Exception/MultipartUploadExceptionTest.php
+++ b/tests/Exception/MultipartUploadExceptionTest.php
@@ -22,7 +22,7 @@ class MultipartUploadExceptionTest extends TestCase
         $prev = new AwsException($msg, new Command($commandName));
         $exception = new MultipartUploadException($state, $prev);
 
-        $this->assertEquals(
+        $this->assertSame(
             "An exception occurred while {$status} a multipart upload: $msg",
             $exception->getMessage()
         );
@@ -59,6 +59,6 @@ An exception occurred while uploading parts to a multipart upload. The following
 
 MSG;
 
-        $this->assertEquals($expected, $exception->getMessage());
+        $this->assertSame($expected, $exception->getMessage());
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -40,7 +40,7 @@ class FunctionsTest extends TestCase
         $b = function ($a, $b) { return $a . $b; };
         $c = function ($a, $b) { return 'C'; };
         $comp = Aws\or_chain($a, $b, $c);
-        $this->assertEquals('+-', $comp('+', '-'));
+        $this->assertSame('+-', $comp('+', '-'));
     }
 
     /**
@@ -182,7 +182,7 @@ class FunctionsTest extends TestCase
     public function testDescribeObject()
     {
         $obj = new \stdClass();
-        $this->assertEquals('object(stdClass)', Aws\describe_type($obj));
+        $this->assertSame('object(stdClass)', Aws\describe_type($obj));
     }
 
     /**
@@ -191,7 +191,7 @@ class FunctionsTest extends TestCase
     public function testDescribeArray()
     {
         $arr = [0, 1, 2];
-        $this->assertEquals('array(3)', Aws\describe_type($arr));
+        $this->assertSame('array(3)', Aws\describe_type($arr));
     }
 
     /**
@@ -200,7 +200,7 @@ class FunctionsTest extends TestCase
     public function testDescribeDoubleToFloat()
     {
         $double = (double)1.3;
-        $this->assertEquals('float(1.3)', Aws\describe_type($double));
+        $this->assertSame('float(1.3)', Aws\describe_type($double));
     }
 
     /**
@@ -208,8 +208,8 @@ class FunctionsTest extends TestCase
      */
     public function testDescribeType()
     {
-        $this->assertEquals('int(1)', Aws\describe_type(1));
-        $this->assertEquals('string(4) "test"', Aws\describe_type("test"));
+        $this->assertSame('int(1)', Aws\describe_type(1));
+        $this->assertSame('string(4) "test"', Aws\describe_type("test"));
     }
 
     /**
@@ -264,13 +264,13 @@ class FunctionsTest extends TestCase
             'Body'   => '123'
         ]);
         $request = \Aws\serialize($command);
-        $this->assertEquals('/bar', $request->getRequestTarget());
-        $this->assertEquals('PUT', $request->getMethod());
-        $this->assertEquals('foo.s3.amazonaws.com', $request->getHeaderLine('Host'));
+        $this->assertSame('/bar', $request->getRequestTarget());
+        $this->assertSame('PUT', $request->getMethod());
+        $this->assertSame('foo.s3.amazonaws.com', $request->getHeaderLine('Host'));
         $this->assertTrue($request->hasHeader('Authorization'));
         $this->assertTrue($request->hasHeader('X-Amz-Content-Sha256'));
         $this->assertTrue($request->hasHeader('X-Amz-Date'));
-        $this->assertEquals('123', (string) $request->getBody());
+        $this->assertSame('123', (string) $request->getBody());
     }
 
     /**

--- a/tests/Glacier/GlacierClientTest.php
+++ b/tests/Glacier/GlacierClientTest.php
@@ -29,20 +29,20 @@ class GlacierClientTest extends TestCase
         $request = \Aws\serialize($command);
 
         // Added default accountId and the API version header.
-        $this->assertEquals('-', $command['accountId']);
+        $this->assertSame('-', $command['accountId']);
         $this->assertEquals(
             $client->getApi()->getMetadata('apiVersion'),
             $request->getHeaderLine('x-amz-glacier-version')
         );
 
         // Added Content-Type and Body
-        $this->assertEquals('foo', $command['body']);
-        $this->assertEquals('text/plain', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('foo', (string)$command['body']);
+        $this->assertSame('text/plain', $request->getHeaderLine('Content-Type'));
 
         // Added the tree and content hashes.
         $hash = hash('sha256', 'foo');
-        $this->assertEquals($hash, $request->getHeaderLine('x-amz-content-sha256'));
-        $this->assertEquals($hash, $request->getHeaderLine('x-amz-sha256-tree-hash'));
+        $this->assertSame($hash, $request->getHeaderLine('x-amz-content-sha256'));
+        $this->assertSame($hash, $request->getHeaderLine('x-amz-sha256-tree-hash'));
     }
 
     /**

--- a/tests/Glacier/MultipartUploaderTest.php
+++ b/tests/Glacier/MultipartUploaderTest.php
@@ -52,7 +52,7 @@ class MultipartUploaderTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals('buzz', $result['fizz']);
+        $this->assertSame('buzz', $result['fizz']);
     }
 
     public function getTestCases()
@@ -116,12 +116,12 @@ class MultipartUploaderTest extends TestCase
         $uploader = new MultipartUploader($client, $source, ['state' => $state]);
 
         $parts = $state->getUploadedParts();
-        $this->assertEquals(1048576, $parts[2]['size']);
-        $this->assertEquals($hashA, $parts[1]['checksum']);
-        $this->assertEquals($hashB, $parts[2]['checksum']);
+        $this->assertSame(1048576, $parts[2]['size']);
+        $this->assertSame($hashA, $parts[1]['checksum']);
+        $this->assertSame($hashB, $parts[2]['checksum']);
 
         $result = $uploader->upload();
         $this->assertTrue($state->isCompleted());
-        $this->assertEquals('buzz', $result['fizz']);
+        $this->assertSame('buzz', $result['fizz']);
     }
 }

--- a/tests/Glacier/TreeHashTest.php
+++ b/tests/Glacier/TreeHashTest.php
@@ -34,7 +34,7 @@ class TreeHashTest extends TestCase
         $leaf1 = hash('sha256', $leaf1 . $leaf2, true);
         $expectedTreeHash = hash('sha256', $leaf1 . $leaf3, true);
 
-        $this->assertEquals($expectedTreeHash, $hash->complete());
+        $this->assertSame($expectedTreeHash, $hash->complete());
     }
 
     /**
@@ -73,7 +73,7 @@ class TreeHashTest extends TestCase
         $hash->reset();
         $hash->update('foo');
 
-        $this->assertEquals(hash('sha256', 'foo', true), $hash->complete());
+        $this->assertSame(hash('sha256', 'foo', true), $hash->complete());
     }
 
     /**
@@ -83,7 +83,7 @@ class TreeHashTest extends TestCase
     {
         $hash = new TreeHash('sha256');
 
-        $this->assertEquals(TreeHash::EMPTY_HASH, bin2hex($hash->complete()));
+        $this->assertSame(TreeHash::EMPTY_HASH, bin2hex($hash->complete()));
     }
 
     /**
@@ -96,6 +96,6 @@ class TreeHashTest extends TestCase
         $hash = new TreeHash('sha256');
         $hash->update($data);
 
-        $this->assertEquals(hash('sha256', $data, true), $hash->complete());
+        $this->assertSame(hash('sha256', $data, true), $hash->complete());
     }
 }

--- a/tests/Handler/GuzzleV5/HandlerTest.php
+++ b/tests/Handler/GuzzleV5/HandlerTest.php
@@ -45,9 +45,9 @@ class HandlerTest extends TestCase
         /** @var $response PsrResponse */
         $response = $promise->wait();
         $this->assertInstanceOf(PsrResponse::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('foo', $response->getBody()->getContents());
-        $this->assertEquals('foo', (string) $sink);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getBody()->getContents());
+        $this->assertSame('foo', (string) $sink);
     }
 
     public function testHandlerWorksWithFailedRequest()
@@ -75,7 +75,7 @@ class HandlerTest extends TestCase
             $this->assertInstanceOf(ConnectException::class, $error['exception']);
             $this->assertTrue($error['connection_error']);
             $this->assertInstanceOf(PsrResponse::class, $error['response']);
-            $this->assertEquals(500, $error['response']->getStatusCode());
+            $this->assertSame(500, $error['response']->getStatusCode());
         }
 
         $this->assertTrue($wasRejected, 'Reject callback was not triggered.');
@@ -126,7 +126,7 @@ EOXML;
             $this->assertInstanceOf(RequestException::class, $error['exception']);
             $this->assertFalse($error['connection_error']);
             $this->assertInstanceOf(PsrResponse::class, $error['response']);
-            $this->assertEquals(404, $error['response']->getStatusCode());
+            $this->assertSame(404, $error['response']->getStatusCode());
             $this->assertEquals($xml, $error['response']->getBody());
             $this->assertStringEqualsFile($sink, $xml);
             unlink($sink);
@@ -165,7 +165,7 @@ EOXML;
             $this->assertInstanceOf(RequestException::class, $error['exception']);
             $this->assertFalse($error['connection_error']);
             $this->assertInstanceOf(PsrResponse::class, $error['response']);
-            $this->assertEquals(404, $error['response']->getStatusCode());
+            $this->assertSame(404, $error['response']->getStatusCode());
             $this->assertEquals($xml, (string)$error['response']->getBody());
             $this->assertEquals($xml, (string)$sink);
         }

--- a/tests/Handler/GuzzleV5/StreamTest.php
+++ b/tests/Handler/GuzzleV5/StreamTest.php
@@ -42,7 +42,7 @@ class StreamTest extends TestCase
         $stream->rewind();
         $str2 = $stream->getContents();
 
-        $this->assertEquals($expected, $str1);
-        $this->assertEquals($expected, $str2);
+        $this->assertSame($expected, $str1);
+        $this->assertSame($expected, $str2);
     }
 }

--- a/tests/Handler/GuzzleV6/HandlerTest.php
+++ b/tests/Handler/GuzzleV6/HandlerTest.php
@@ -37,8 +37,8 @@ class HandlerTest extends TestCase
         /** @var $response Response */
         $response = $promise->wait();
         $this->assertInstanceOf(Response::class, $response);
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('foo', $response->getBody()->getContents());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('foo', $response->getBody()->getContents());
     }
 
     public function testHandlerWorksWithFailedRequest()
@@ -66,7 +66,7 @@ class HandlerTest extends TestCase
             $this->assertInstanceOf(RequestException::class, $error['exception']);
             $this->assertFalse($error['connection_error']);
             $this->assertInstanceOf(Response::class, $error['response']);
-            $this->assertEquals(500, $error['response']->getStatusCode());
+            $this->assertSame(500, $error['response']->getStatusCode());
         }
 
         $this->assertTrue($wasRejected, 'Reject callback was not triggered.');

--- a/tests/HandlerListTest.php
+++ b/tests/HandlerListTest.php
@@ -103,7 +103,7 @@ class HandlerListTest extends TestCase
         }
         $built = $list->resolve();
         $cmd = new Command('foo');
-        $this->assertEquals('baz', $built($cmd));
+        $this->assertSame('baz', $built($cmd));
         $this->assertEquals($steps, $h);
     }
 
@@ -121,7 +121,7 @@ class HandlerListTest extends TestCase
         }
         $built = $list->resolve();
         $cmd = new Command('foo');
-        $this->assertEquals('baz', $built($cmd));
+        $this->assertSame('baz', $built($cmd));
         $this->assertEquals($steps, $h);
     }
 
@@ -136,9 +136,9 @@ class HandlerListTest extends TestCase
         $lines = explode("\n", (string) $list);
         $this->assertCount(6, $lines);
         $this->assertContains('0) Step: init, Name: foo, Function: callable(', $lines[0]);
-        $this->assertEquals("1) Step: init, Name: bar, Function: callable(['Aws\\Test\\HandlerListTest', 'bar'])", $lines[1]);
-        $this->assertEquals('2) Step: validate, Function: callable(Aws\Test\HandlerListTest::foo)', $lines[2]);
-        $this->assertEquals("3) Step: sign, Name: baz, Function: callable(['Aws\\Middleware', 'tap'])", $lines[3]);
+        $this->assertSame("1) Step: init, Name: bar, Function: callable(['Aws\\Test\\HandlerListTest', 'bar'])", $lines[1]);
+        $this->assertSame('2) Step: validate, Function: callable(Aws\Test\HandlerListTest::foo)', $lines[2]);
+        $this->assertSame("3) Step: sign, Name: baz, Function: callable(['Aws\\Middleware', 'tap'])", $lines[3]);
         $this->assertContains('4) Handler: callable(', $lines[4]);
     }
 

--- a/tests/HashingStreamTest.php
+++ b/tests/HashingStreamTest.php
@@ -16,7 +16,7 @@ class HashingStreamTest extends TestCase
         $source = Psr7\stream_for('foobar');
         $hash = new PhpHash('md5');
         (new HashingStream($source, $hash))->getContents();
-        $this->assertEquals(md5('foobar'), bin2hex($hash->complete()));
+        $this->assertSame(md5('foobar'), bin2hex($hash->complete()));
     }
 
     public function testCallbackTriggeredWhenComplete()
@@ -39,12 +39,12 @@ class HashingStreamTest extends TestCase
 
         // Reading works fine
         $bytes = $stream->read(3);
-        $this->assertEquals('foo', $bytes);
+        $this->assertSame('foo', $bytes);
 
         // Seeking to 0 is fine
         $stream->seek(0);
         $stream->getContents();
-        $this->assertEquals(md5('foobar'), bin2hex($hash->complete()));
+        $this->assertSame(md5('foobar'), bin2hex($hash->complete()));
 
         // Seeking arbitrarily is not fine
         $stream->seek(3);

--- a/tests/Integ/GuzzleV5HandlerTest.php
+++ b/tests/Integ/GuzzleV5HandlerTest.php
@@ -57,7 +57,7 @@ class GuzzleV5HandlerTest extends TestCase
 
         // Check the sink.
         $sink->seek(0);
-        $this->assertEquals($body, $sink->getContents());
+        $this->assertSame($body, $sink->getContents());
     }
 
     public function testProduceErrorData()

--- a/tests/Integ/GuzzleV6StreamHandlerTest.php
+++ b/tests/Integ/GuzzleV6StreamHandlerTest.php
@@ -66,6 +66,6 @@ class GuzzleV6StreamHandlerTest extends TestCase
             });
         /** @var \Aws\Result $result */
         $result = $promise->wait();
-        $this->assertEquals(204, $result['@metadata']['statusCode']);
+        $this->assertSame(204, $result['@metadata']['statusCode']);
     }
 }

--- a/tests/MachineLearning/MachineLearningClientTest.php
+++ b/tests/MachineLearning/MachineLearningClientTest.php
@@ -32,6 +32,6 @@ class MachineLearningClientTest extends TestCase
             'PredictEndpoint' => (string) $predictEndpoint
         ]);
 
-        $this->assertEquals($predictEndpoint->getHost(), $request->getUri()->getHost());
+        $this->assertSame($predictEndpoint->getHost(), $request->getUri()->getHost());
     }
 }

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -215,7 +215,7 @@ class MiddlewareTest extends TestCase
         $request = new Request('PUT', 'http://exmaple.com', [], $payload);
         $handler(new Command('Foo'), $request);
 
-        $this->assertEquals(
+        $this->assertSame(
             'image/png',
             $h->getLastRequest()->getHeaderLine('Content-Type')
         );
@@ -233,7 +233,7 @@ class MiddlewareTest extends TestCase
         $handler = $list->resolve();
         $request = new Request('GET', 'http://exmaple.com');
         $handler(new Command('Foo'), $request);
-        $this->assertEquals('test', $mock->getLastCommand()->offsetGet('Hi'));
+        $this->assertSame('test', $mock->getLastCommand()->offsetGet('Hi'));
     }
 
     public function testCanMapRequests()
@@ -262,7 +262,7 @@ class MiddlewareTest extends TestCase
         $handler = $list->resolve();
         $request = new Request('GET', 'http://exmaple.com');
         $result = $handler(new Command('Foo'), $request)->wait();
-        $this->assertEquals('hi', $result['Test']);
+        $this->assertSame('hi', $result['Test']);
     }
 
     public function testCanTimeSuccessfulHandlers()

--- a/tests/Multipart/AbstractUploaderTest.php
+++ b/tests/Multipart/AbstractUploaderTest.php
@@ -74,7 +74,7 @@ class AbstractUploaderTest extends TestCase
             new Result(), // Upload
             new Result(['test' => 'foo']) // Complete
         ], Psr7\stream_for('abcdef'));
-        $this->assertEquals('foo', $uploader->upload()['test']);
+        $this->assertSame('foo', $uploader->upload()['test']);
         $this->assertTrue($uploader->getState()->isCompleted());
     }
 
@@ -128,7 +128,7 @@ class AbstractUploaderTest extends TestCase
                 ]
             );
             $result = $secondChance->upload();
-            $this->assertEquals('bar', $result['foo']);
+            $this->assertSame('bar', $result['foo']);
         }
     }
 
@@ -157,7 +157,7 @@ class AbstractUploaderTest extends TestCase
         $promise = $uploader->promise();
         $this->assertSame($promise, $uploader->promise());
         $this->assertInstanceOf('Aws\Result', $promise->wait());
-        $this->assertEquals(6, $called);
+        $this->assertSame(6, $called);
     }
 
     /**

--- a/tests/Multipart/UploadStateTest.php
+++ b/tests/Multipart/UploadStateTest.php
@@ -35,7 +35,7 @@ class UploadStateTest extends TestCase
         $state = new UploadState([]);
         $this->assertNull($state->getPartSize());
         $state->setPartSize(50000000);
-        $this->assertEquals(50000000, $state->getPartSize());
+        $this->assertSame(50000000, $state->getPartSize());
     }
 
     public function testCanTrackUploadedParts()
@@ -65,7 +65,7 @@ class UploadStateTest extends TestCase
 
         /** @var UploadState $newState */
         $newState = unserialize($serializedState);
-        $this->assertEquals(5, $newState->getPartSize());
+        $this->assertSame(5, $newState->getPartSize());
         $this->assertArrayHasKey(1, $state->getUploadedParts());
         $this->assertTrue($newState->isInitiated());
         $this->assertArrayHasKey('foo', $newState->getId());

--- a/tests/PhpHashTest.php
+++ b/tests/PhpHashTest.php
@@ -15,7 +15,7 @@ class PhpHashTest extends TestCase
         $hash->update('foo');
         $hash->update('bar');
         $result = $hash->complete();
-        $this->assertEquals(md5('foobar', true), $result);
+        $this->assertSame(md5('foobar', true), $result);
     }
 
     public function testHashesDataAndBase64Encodes()
@@ -24,7 +24,7 @@ class PhpHashTest extends TestCase
         $hash->update('foo');
         $hash->update('bar');
         $result = $hash->complete();
-        $this->assertEquals(base64_encode(md5('foobar', true)), $result);
+        $this->assertSame(base64_encode(md5('foobar', true)), $result);
     }
 
     public function testCreatesNewHash()
@@ -35,7 +35,7 @@ class PhpHashTest extends TestCase
         $hash->update('foo');
         $hash->update('bar');
         $result = $hash->complete();
-        $this->assertEquals(base64_encode(md5('foobar', true)), $result);
+        $this->assertSame(base64_encode(md5('foobar', true)), $result);
         $this->assertSame($result, $hash->complete());
     }
 
@@ -45,6 +45,6 @@ class PhpHashTest extends TestCase
         $hash->update('foo');
         $hash->reset();
         $hash->update('bar');
-        $this->assertEquals(md5('bar'), bin2hex($hash->complete()));
+        $this->assertSame(md5('bar'), bin2hex($hash->complete()));
     }
 }

--- a/tests/Rds/RdsClientTest.php
+++ b/tests/Rds/RdsClientTest.php
@@ -22,7 +22,7 @@ class RdsClientTest extends TestCase
             function ($command, $request) {
                 $this->assertNotNull($command['PreSignedUrl']);
                 $this->assertContains('us-west-2', $command['PreSignedUrl']);
-                $this->assertEquals('us-east-1', $command['DestinationRegion']);
+                $this->assertSame('us-east-1', $command['DestinationRegion']);
                 return new Result();
             }
         ]);

--- a/tests/ResultPaginatorTest.php
+++ b/tests/ResultPaginatorTest.php
@@ -210,7 +210,7 @@ class ResultPaginatorTest extends TestCase
             $tableNames[] = $table;
         }
 
-        $this->assertEquals(4, $requestCount);
+        $this->assertSame(4, $requestCount);
         $this->assertEquals(['b2', 'a1', 'c3', 'd4'], $tableNames);
     }
 
@@ -276,12 +276,12 @@ class ResultPaginatorTest extends TestCase
 
         $promise->wait();
         $this->assertCount(4, $cmds);
-        $this->assertEquals('ListObjects', $cmds[0]->getName());
-        $this->assertEquals('HeadObject', $cmds[1]->getName());
-        $this->assertEquals('ListObjects', $cmds[2]->getName());
-        $this->assertEquals('HeadObject', $cmds[3]->getName());
-        $this->assertEquals('0.1', $cmds[1]['Key']);
-        $this->assertEquals('2.3', $cmds[3]['Key']);
+        $this->assertSame('ListObjects', $cmds[0]->getName());
+        $this->assertSame('HeadObject', $cmds[1]->getName());
+        $this->assertSame('ListObjects', $cmds[2]->getName());
+        $this->assertSame('HeadObject', $cmds[3]->getName());
+        $this->assertSame('0.1', $cmds[1]['Key']);
+        $this->assertSame('2.3', $cmds[3]['Key']);
     }
 
     public function testMarkerUpdated()
@@ -335,12 +335,12 @@ class ResultPaginatorTest extends TestCase
 
         $promise->wait();
         $this->assertCount(4, $cmds);
-        $this->assertEquals('ListObjects', $cmds[0]->getName());
-        $this->assertEquals('HeadObject', $cmds[1]->getName());
-        $this->assertEquals('ListObjects', $cmds[2]->getName());
-        $this->assertEquals('HeadObject', $cmds[3]->getName());
-        $this->assertEquals('2.3', $cmds[1]['Key']);
-        $this->assertEquals('4', $cmds[3]['Key']);
+        $this->assertSame('ListObjects', $cmds[0]->getName());
+        $this->assertSame('HeadObject', $cmds[1]->getName());
+        $this->assertSame('ListObjects', $cmds[2]->getName());
+        $this->assertSame('HeadObject', $cmds[3]->getName());
+        $this->assertSame('2.3', $cmds[1]['Key']);
+        $this->assertSame('4', $cmds[3]['Key']);
     }
 
     public function testDoesNotInsertMissingOutputTokensIntoNextRequest()

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -12,12 +12,12 @@ class ResultTest extends TestCase
     public function testHasData()
     {
         $c = new Result(['a' => 'b', 'c' => 'd']);
-        $this->assertEquals('b', $c['a']);
-        $this->assertEquals('d', $c['c']);
-        $this->assertEquals('d', $c->get('c'));
+        $this->assertSame('b', $c['a']);
+        $this->assertSame('d', $c['c']);
+        $this->assertSame('d', $c->get('c'));
         $this->assertTrue($c->hasKey('c'));
         $this->assertFalse($c->hasKey('f'));
-        $this->assertEquals('b', $c->search('a'));
+        $this->assertSame('b', $c->search('a'));
         $this->assertContains('Model Data', (string) $c);
     }
 
@@ -41,6 +41,6 @@ class ResultTest extends TestCase
     public function testCanGetByPath()
     {
         $r = new Result(['bar' => ['baz' => 'qux']]);
-        $this->assertEquals('qux', $r->getPath('bar/baz'));
+        $this->assertSame('qux', $r->getPath('bar/baz'));
     }
 }

--- a/tests/Retry/ConfigurationProviderTest.php
+++ b/tests/Retry/ConfigurationProviderTest.php
@@ -261,7 +261,7 @@ EOT;
         $ref = new \ReflectionClass('Aws\S3\UseArnRegion\ConfigurationProvider');
         $meth = $ref->getMethod('getHomeDir');
         $meth->setAccessible(true);
-        $this->assertEquals('C:\\My\\Home', $meth->invoke(null));
+        $this->assertSame('C:\\My\\Home', $meth->invoke(null));
     }
 
     public function testMemoizes()
@@ -274,9 +274,9 @@ EOT;
         };
         $p = ConfigurationProvider::memoize($f);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
     }
 
     public function testChainsConfiguration()
@@ -345,7 +345,7 @@ EOT;
                 ->wait();
         }
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
         $this->assertCount(1, $cache);
         $this->assertSame($expected->toArray(), $result->toArray());
     }

--- a/tests/Retry/QuotaManagerTest.php
+++ b/tests/Retry/QuotaManagerTest.php
@@ -88,7 +88,7 @@ class QuotaManagerTest extends TestCase
         ]);
 
         $quota->hasRetryQuota($exception);
-        $this->assertEquals(5, $quota->releaseToQuota($result));
+        $this->assertSame(5, $quota->releaseToQuota($result));
 
         // Verify that the available capacity is indeed set back to 10
         for ($i = 5; $i <= 10; $i += 5) {
@@ -131,12 +131,12 @@ class QuotaManagerTest extends TestCase
         $quota->hasRetryQuota($exception);
 
         // First call should return taken capacity
-        $this->assertEquals(5, $quota->releaseToQuota($result));
+        $this->assertSame(5, $quota->releaseToQuota($result));
 
         // Subsequent calls should return no_retry_incerement
-        $this->assertEquals(1, $quota->releaseToQuota($result));
-        $this->assertEquals(1, $quota->releaseToQuota($result));
-        $this->assertEquals(1, $quota->releaseToQuota($result));
+        $this->assertSame(1, $quota->releaseToQuota($result));
+        $this->assertSame(1, $quota->releaseToQuota($result));
+        $this->assertSame(1, $quota->releaseToQuota($result));
 
         // Verify that available capacity is now at 8
         for ($i = 2; $i <= 8; $i += 2) {

--- a/tests/Retry/RateLimiterTest.php
+++ b/tests/Retry/RateLimiterTest.php
@@ -46,10 +46,10 @@ class RateLimiterTest extends TestCase
         $refLastLastThrottleTime->setAccessible(true);
         $refLastLastThrottleTime->setValue($rateLimiter, 5);
 
-        $this->assertEquals(0, $rateLimiter->updateSendingRate(false));
-        $this->assertEquals(3.2, $rateLimiter->updateSendingRate(false));
-        $this->assertEquals(2.24, $rateLimiter->updateSendingRate(false));
-        $this->assertEquals(2.048, $rateLimiter->updateSendingRate(false));
+        $this->assertSame(0, $rateLimiter->updateSendingRate(false));
+        $this->assertSame(3.2, $rateLimiter->updateSendingRate(false));
+        $this->assertSame(2.24, $rateLimiter->updateSendingRate(false));
+        $this->assertSame(2.048, $rateLimiter->updateSendingRate(false));
     }
 
     public function cubicSuccessProvider()

--- a/tests/RetryMiddlewareV2Test.php
+++ b/tests/RetryMiddlewareV2Test.php
@@ -112,9 +112,9 @@ class RetryMiddlewareV2Test extends TestCase
                     $expected[$attempt - 1]['error']->getMessage(),
                     $e->getMessage()
                 );
-                $this->assertEquals(
+                $this->assertInstanceOf(
                     get_class($expected[$attempt - 1]['error']),
-                    get_class($e)
+                    $e
                 );
             } else {
                 throw $e;
@@ -126,7 +126,7 @@ class RetryMiddlewareV2Test extends TestCase
             throw $errors[0];
         }
 
-        $this->assertEquals($attempt, count($queue));
+        $this->assertCount($attempt, $queue);
     }
 
     function standardModeTestCases()
@@ -451,7 +451,7 @@ class RetryMiddlewareV2Test extends TestCase
             throw $errors[0];
         }
 
-        $this->assertEquals(count($expectedTimes), $attempt);
+        $this->assertCount($attempt, $expectedTimes);
     }
 
     public function testAddRetryHeader()
@@ -734,7 +734,7 @@ class RetryMiddlewareV2Test extends TestCase
         $attempts = 0;
         $handler = function ($command, $request) use (&$attempts) {
             if ($attempts > 0) {
-                $this->assertEquals(9999, $command['@http']['delay']);
+                $this->assertSame(9999, $command['@http']['delay']);
             }
             $attempts++;
             return \GuzzleHttp\Promise\rejection_for(
@@ -763,7 +763,7 @@ class RetryMiddlewareV2Test extends TestCase
             $wrapped($command, $request)->wait();
             $this->fail();
         } catch (AwsException $e) {
-            $this->assertEquals(3, $attempts);
+            $this->assertSame(3, $attempts);
             $this->assertContains('foo', $e->getMessage());
         }
     }

--- a/tests/Route53/RouteClient53Test.php
+++ b/tests/Route53/RouteClient53Test.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Aws\Route53\Route53Client
  */
-class Route53ClientTest extends TestCase
+class RouteClient53Test extends TestCase
 {
     public function testCleansIds()
     {

--- a/tests/S3/BatchDeleteTest.php
+++ b/tests/S3/BatchDeleteTest.php
@@ -90,9 +90,9 @@ class BatchDeleteTest extends TestCase
             $this->fail();
         } catch (DeleteMultipleObjectsException $e) {
             $this->assertCount(1, $e->getErrors());
-            $this->assertEquals('foo', $e->getErrors()[0]['Key']);
+            $this->assertSame('foo', $e->getErrors()[0]['Key']);
             $this->assertCount(1, $e->getDeleted());
-            $this->assertEquals('baz', $e->getDeleted()[0]['Key']);
+            $this->assertSame('baz', $e->getDeleted()[0]['Key']);
         }
     }
 
@@ -119,9 +119,9 @@ class BatchDeleteTest extends TestCase
             $this->fail();
         } catch (DeleteMultipleObjectsException $e) {
             $this->assertCount(1, $e->getErrors());
-            $this->assertEquals('foo', $e->getErrors()[0]['Key']);
+            $this->assertSame('foo', $e->getErrors()[0]['Key']);
             $this->assertCount(1, $e->getDeleted());
-            $this->assertEquals('baz', $e->getDeleted()[0]['Key']);
+            $this->assertSame('baz', $e->getDeleted()[0]['Key']);
         }
     }
 
@@ -143,9 +143,9 @@ class BatchDeleteTest extends TestCase
         $batch = BatchDelete::fromListObjects($client, $params);
         $batch->delete();
         $last = $mock->getLastCommand();
-        $this->assertEquals('DeleteObjects', $last->getName());
+        $this->assertSame('DeleteObjects', $last->getName());
         $this->assertCount(2, $last['Delete']['Objects']);
-        $this->assertEquals('foo', $last['Bucket']);
+        $this->assertSame('foo', $last['Bucket']);
     }
 
     public function testDeletesYieldedCommadnsWhenEachCallbackReturns()
@@ -206,8 +206,8 @@ class BatchDeleteTest extends TestCase
         $batch = BatchDelete::fromListObjects($client, $params);
         $batch->delete();
         $last = $mock->getLastCommand();
-        $this->assertEquals('ListObjects', $last->getName());
+        $this->assertSame('ListObjects', $last->getName());
         $this->assertFalse(isset($last['Delete']['Objects']));
-        $this->assertEquals('foo', $last['Bucket']);
+        $this->assertSame('foo', $last['Bucket']);
     }
 }

--- a/tests/S3/BucketEndpointArnMiddlewareTest.php
+++ b/tests/S3/BucketEndpointArnMiddlewareTest.php
@@ -59,7 +59,7 @@ class BucketEndpointArnMiddlewareTest extends TestCase
                     $endpoint,
                     $req->getUri()->getHost()
                 );
-                $this->assertEquals("/{$key}", $req->getRequestTarget());
+                $this->assertSame("/{$key}", $req->getRequestTarget());
                 $this->assertEquals(
                     $signingRegion,
                     $cmd['@context']['signing_region']
@@ -319,7 +319,7 @@ class BucketEndpointArnMiddlewareTest extends TestCase
             $this->fail('This was expected to fail with: ' . $expected->getMessage());
         } catch (\Exception $e) {
             $this->assertTrue($e instanceof $expected);
-            $this->assertEquals(
+            $this->assertSame(
                 $expected->getMessage(),
                 $e->getMessage()
             );
@@ -581,11 +581,11 @@ class BucketEndpointArnMiddlewareTest extends TestCase
             'region' => 'us-west-2',
             's3_use_arn_region' => true,
             'handler' => function(CommandInterface $cmd, RequestInterface $req) {
-                $this->assertEquals(
+                $this->assertSame(
                     'myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com',
                     $req->getUri()->getHost()
                 );
-                $this->assertEquals(
+                $this->assertSame(
                     'arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint/myobject',
                     $req->getHeader('x-amz-copy-source')[0]
                 );

--- a/tests/S3/BucketEndpointMiddlewareTest.php
+++ b/tests/S3/BucketEndpointMiddlewareTest.php
@@ -19,8 +19,8 @@ class BucketEndpointMiddlewareTest extends TestCase
         $command = $s3->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'Bar/Baz']);
         $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
-                $this->assertEquals('foo.s3.amazonaws.com', $req->getUri()->getHost());
-                $this->assertEquals('/Bar/Baz', $req->getRequestTarget());
+                $this->assertSame('foo.s3.amazonaws.com', $req->getUri()->getHost());
+                $this->assertSame('/Bar/Baz', $req->getRequestTarget());
             })
         );
         $s3->execute($command);
@@ -35,8 +35,8 @@ class BucketEndpointMiddlewareTest extends TestCase
         $command = $s3->getCommand('GetObject', ['Bucket' => 'foo', 'Key' => 'Bar/Baz']);
         $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
-                $this->assertEquals('s3.amazonaws.com', $req->getUri()->getHost());
-                $this->assertEquals('/foo/Bar/Baz', $req->getRequestTarget());
+                $this->assertSame('s3.amazonaws.com', $req->getUri()->getHost());
+                $this->assertSame('/foo/Bar/Baz', $req->getRequestTarget());
             })
         );
         $s3->execute($command);
@@ -49,8 +49,8 @@ class BucketEndpointMiddlewareTest extends TestCase
         $command = $s3->getCommand('GetBucketLocation', ['Bucket' => 'foo']);
         $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
-                $this->assertEquals('foo.s3.amazonaws.com', $req->getUri()->getHost());
-                $this->assertEquals('/?location', $req->getRequestTarget());
+                $this->assertSame('foo.s3.amazonaws.com', $req->getUri()->getHost());
+                $this->assertSame('/?location', $req->getRequestTarget());
             })
         );
         $s3->execute($command);
@@ -65,8 +65,8 @@ class BucketEndpointMiddlewareTest extends TestCase
         $command = $s3->getCommand('GetBucketLocation', ['Bucket' => 'foo']);
         $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
-                $this->assertEquals('s3.amazonaws.com', $req->getUri()->getHost());
-                $this->assertEquals('/foo?location', $req->getRequestTarget());
+                $this->assertSame('s3.amazonaws.com', $req->getUri()->getHost());
+                $this->assertSame('/foo?location', $req->getRequestTarget());
             })
         );
         $s3->execute($command);
@@ -85,8 +85,8 @@ class BucketEndpointMiddlewareTest extends TestCase
         ]);
         $command->getHandlerList()->appendSign(
             Middleware::tap(function ($cmd, $req) {
-                $this->assertEquals('test.domain.com', $req->getUri()->getHost());
-                $this->assertEquals('/key', $req->getRequestTarget());
+                $this->assertSame('test.domain.com', $req->getUri()->getHost());
+                $this->assertSame('/key', $req->getRequestTarget());
             })
         );
         $s3->execute($command);

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -616,7 +616,7 @@ EOXML;
         $list = $kms->getHandlerList();
         $list->setHandler(function($cmd, $req) {
             // Verify decryption command has correct parameters
-            $this->assertEquals('cek', $cmd['CiphertextBlob']);
+            $this->assertSame('cek', $cmd['CiphertextBlob']);
             $this->assertEquals(
                 [
                     'aws:x-amz-cek-alg' => 'AES/GCM/NoPadding'

--- a/tests/S3/Crypto/S3EncryptionClientV2Test.php
+++ b/tests/S3/Crypto/S3EncryptionClientV2Test.php
@@ -650,7 +650,7 @@ EOXML;
         $list = $kms->getHandlerList();
         $list->setHandler(function($cmd, $req) {
             // Verify decryption command has correct parameters
-            $this->assertEquals('cek', $cmd['CiphertextBlob']);
+            $this->assertSame('cek', $cmd['CiphertextBlob']);
             $this->assertEquals(
                 [
                     'kms_cmk_id' => '11111111-2222-3333-4444-555555555555'
@@ -698,7 +698,7 @@ EOXML;
         $list = $kms->getHandlerList();
         $list->setHandler(function($cmd, $req) {
             // Verify decryption command has correct parameters
-            $this->assertEquals('cek', $cmd['CiphertextBlob']);
+            $this->assertSame('cek', $cmd['CiphertextBlob']);
             $this->assertEquals(
                 [
                     'kms_cmk_id' => '11111111-2222-3333-4444-555555555555'
@@ -742,7 +742,7 @@ EOXML;
         $list = $kms->getHandlerList();
         $list->setHandler(function($cmd, $req) {
             // Verify decryption command has correct parameters
-            $this->assertEquals('cek', $cmd['CiphertextBlob']);
+            $this->assertSame('cek', $cmd['CiphertextBlob']);
             $this->assertEquals(
                 [
                     'aws:x-amz-cek-alg' => 'AES/GCM/NoPadding'
@@ -918,7 +918,7 @@ EOXML;
         $list = $kms->getHandlerList();
         $list->setHandler(function($cmd, $req) {
             // Verify decryption command has correct parameters
-            $this->assertEquals('cek', $cmd['CiphertextBlob']);
+            $this->assertSame('cek', $cmd['CiphertextBlob']);
             $this->assertEquals(
                 [
                     'kms_cmk_id' => '11111111-2222-3333-4444-555555555555'
@@ -965,7 +965,7 @@ EOXML;
         $list = $kms->getHandlerList();
         $list->setHandler(function($cmd, $req) {
             // Verify decryption command has correct parameters
-            $this->assertEquals('cek', $cmd['CiphertextBlob']);
+            $this->assertSame('cek', $cmd['CiphertextBlob']);
             $this->assertEquals(
                 [
                     'kms_cmk_id' => '11111111-2222-3333-4444-555555555555'

--- a/tests/S3/Crypto/S3EncryptionMultipartUploaderTest.php
+++ b/tests/S3/Crypto/S3EncryptionMultipartUploaderTest.php
@@ -90,7 +90,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -170,7 +170,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -242,7 +242,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -295,7 +295,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -346,7 +346,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     public function testPutObjectAppliesParams()
@@ -378,9 +378,9 @@ class S3EncryptionMultipartUploaderTest extends TestCase
                     'Cipher' => 'cbc',
                 ],
                 'before_initiate' => function($command) {
-                    $this->assertEquals('foo', $command['Bucket']);
-                    $this->assertEquals('bar', $command['Key']);
-                    $this->assertEquals(
+                    $this->assertSame('foo', $command['Bucket']);
+                    $this->assertSame('bar', $command['Key']);
+                    $this->assertSame(
                         'kms',
                         $command['Metadata']['x-amz-wrap-alg']
                     );
@@ -391,7 +391,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     public function testCanLoadStateFromService()
@@ -435,8 +435,8 @@ class S3EncryptionMultipartUploaderTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(4 * self::MB, $uploader->getState()->getPartSize());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame(4 * self::MB, $uploader->getState()->getPartSize());
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function testAddsCryptoUserAgent()

--- a/tests/S3/Crypto/S3EncryptionMultipartUploaderV2Test.php
+++ b/tests/S3/Crypto/S3EncryptionMultipartUploaderV2Test.php
@@ -98,7 +98,7 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -187,7 +187,7 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -268,7 +268,7 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -320,7 +320,7 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     /**
@@ -383,7 +383,7 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     public function testPutObjectAppliesParams()
@@ -421,9 +421,9 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
                 ],
                 '@KmsEncryptionContext' => [],
                 'before_initiate' => function($command) {
-                    $this->assertEquals('foo', $command['Bucket']);
-                    $this->assertEquals('bar', $command['Key']);
-                    $this->assertEquals(
+                    $this->assertSame('foo', $command['Bucket']);
+                    $this->assertSame('bar', $command['Key']);
+                    $this->assertSame(
                         'kms+context',
                         $command['Metadata']['x-amz-wrap-alg']
                     );
@@ -434,7 +434,7 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
 
         $this->assertTrue($this->mockQueueEmpty());
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(self::TEST_URL, $result['ObjectURL']);
+        $this->assertSame(self::TEST_URL, $result['ObjectURL']);
     }
 
     public function testCanLoadStateFromService()
@@ -484,8 +484,8 @@ class S3EncryptionMultipartUploaderV2Test extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(4 * self::MB, $uploader->getState()->getPartSize());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame(4 * self::MB, $uploader->getState()->getPartSize());
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function testAddsCryptoUserAgent()

--- a/tests/S3/Exception/S3MultipartUploadExceptionTest.php
+++ b/tests/S3/Exception/S3MultipartUploadExceptionTest.php
@@ -34,8 +34,8 @@ class S3MultipartUploadExceptionTest extends TestCase
         $exception = new S3MultipartUploadException($state, $failed, [
             'file_name' => $path
         ]);
-        $this->assertEquals('foo', $exception->getBucket());
-        $this->assertEquals('bar', $exception->getKey());
-        $this->assertEquals('php://temp', $exception->getSourceFileName());
+        $this->assertSame('foo', $exception->getBucket());
+        $this->assertSame('bar', $exception->getKey());
+        $this->assertSame('php://temp', $exception->getSourceFileName());
     }
 }

--- a/tests/S3/MultipartCopyTest.php
+++ b/tests/S3/MultipartCopyTest.php
@@ -42,7 +42,7 @@ class MultipartCopyTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function getTestCases()
@@ -83,8 +83,8 @@ class MultipartCopyTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(5 * self::MB, $uploader->getState()->getPartSize());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame(5 * self::MB, $uploader->getState()->getPartSize());
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function testCanUseCaseInsensitiveConfigKeys()
@@ -118,13 +118,13 @@ class MultipartCopyTest extends TestCase
             'source_metadata' => new Result(['ContentLength' => 11 * self::MB]),
             'params'          => ['RequestPayer' => 'test'],
             'before_initiate' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_upload'   => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_complete' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             }
         ];
         $url = 'http://foo.s3.amazonaws.com/bar';
@@ -141,6 +141,6 @@ class MultipartCopyTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 }

--- a/tests/S3/MultipartUploaderTest.php
+++ b/tests/S3/MultipartUploaderTest.php
@@ -56,7 +56,7 @@ class MultipartUploaderTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function getTestCases()
@@ -113,8 +113,8 @@ class MultipartUploaderTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals(4 * self::MB, $uploader->getState()->getPartSize());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame(4 * self::MB, $uploader->getState()->getPartSize());
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function testCanUseCaseInsensitiveConfigKeys()
@@ -169,14 +169,14 @@ class MultipartUploaderTest extends TestCase
                 'ContentLength' => $size
             ],
             'before_initiate' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_upload'   => function($command) use ($size) {
                 $this->assertLessThan($size, $command['ContentLength']);
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_complete' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             }
         ];
         $url = 'http://foo.s3.amazonaws.com/bar';
@@ -193,7 +193,7 @@ class MultipartUploaderTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function getContentTypeSettingTests()
@@ -262,7 +262,7 @@ class MultipartUploaderTest extends TestCase
         $result = $uploader->upload();
 
         $this->assertTrue($uploader->getState()->isCompleted());
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     /**

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -34,7 +34,7 @@ class ObjectCopierTest extends TestCase
             'private',
             $options
         ))->copy();
-        $this->assertEquals('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
+        $this->assertSame('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -57,7 +57,7 @@ class ObjectCopierTest extends TestCase
             'private',
             $options
         ))->copy();
-        $this->assertEquals('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
+        $this->assertSame('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -177,7 +177,7 @@ class ObjectCopierTest extends TestCase
         ))->promise();
         $this->assertFalse($this->mockQueueEmpty());
         $result = $promise->wait();
-        $this->assertEquals('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
+        $this->assertSame('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -202,7 +202,7 @@ class ObjectCopierTest extends TestCase
         ))->promise();
         $this->assertFalse($this->mockQueueEmpty());
         $result = $promise->wait();
-        $this->assertEquals('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
+        $this->assertSame('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -326,10 +326,10 @@ class ObjectCopierTest extends TestCase
         $copyOptions = [
             'params'          => ['RequestPayer' => 'test'],
             'before_lookup'   => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_upload'   => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
         ];
         $url = 'https://bucket.s3.amazonaws.com/key';
@@ -348,7 +348,7 @@ class ObjectCopierTest extends TestCase
         $this->assertFalse($this->mockQueueEmpty());
         $result = $uploader->copy();
 
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -360,16 +360,16 @@ class ObjectCopierTest extends TestCase
             'mup_threshold'   => MultipartUploader::PART_MIN_SIZE,
             'params'          => ['RequestPayer' => 'test'],
             'before_lookup'   => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_initiate' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_upload'   => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_complete' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             }
         ];
         $url = 'https://bucket.s3.amazonaws.com/key';
@@ -388,7 +388,7 @@ class ObjectCopierTest extends TestCase
         $this->assertFalse($this->mockQueueEmpty());
         $result = $uploader->copy();
 
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -414,7 +414,7 @@ class ObjectCopierTest extends TestCase
         $this->assertFalse($this->mockQueueEmpty());
         $result = $uploader->copy();
 
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function MultipartCopierProvider(){
@@ -449,7 +449,7 @@ class ObjectCopierTest extends TestCase
         $this->assertFalse($this->mockQueueEmpty());
         $result = $uploader->copy();
 
-        $this->assertEquals(
+        $this->assertSame(
             "https://bucket.s3.amazonaws.com/{$expectedOutput}",
             $result['ObjectURL']
         );

--- a/tests/S3/ObjectUploaderTest.php
+++ b/tests/S3/ObjectUploaderTest.php
@@ -31,7 +31,7 @@ class ObjectUploaderTest extends TestCase
         $this->addMockResults($client, $mockedResults);
         $result = (new ObjectUploader($client, 'bucket', 'key', $body, 'private', $options))
             ->upload();
-        $this->assertEquals('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
+        $this->assertSame('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -50,7 +50,7 @@ class ObjectUploaderTest extends TestCase
         $this->addMockResults($client, $mockedResults);
         $result = (new ObjectUploader($client, 'bucket', 'key', $body, 'private', $options))
             ->upload();
-        $this->assertEquals('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
+        $this->assertSame('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
         $this->assertTrue($this->mockQueueEmpty());
     }
 
@@ -68,11 +68,11 @@ class ObjectUploaderTest extends TestCase
         ]);
         $client->getHandlerList()->appendSign(Middleware::tap(
             function(CommandInterface $cmd, RequestInterface $req) {
-                $this->assertEquals(
+                $this->assertSame(
                     'mydest-123456789012.s3-accesspoint.us-west-2.amazonaws.com',
                     $req->getUri()->getHost()
                 );
-                $this->assertEquals(
+                $this->assertSame(
                     '/key',
                     $req->getUri()->getPath()
                 );
@@ -105,7 +105,7 @@ class ObjectUploaderTest extends TestCase
             ->promise();
         $this->assertFalse($this->mockQueueEmpty());
         $result = $promise->wait();
-        $this->assertEquals('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
+        $this->assertSame('https://bucket.s3.amazonaws.com/key', $result['ObjectURL']);
     }
 
     /**
@@ -125,7 +125,7 @@ class ObjectUploaderTest extends TestCase
             ->promise();
         $this->assertFalse($this->mockQueueEmpty());
         $result = $promise->wait();
-        $this->assertEquals('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
+        $this->assertSame('https://s3.amazonaws.com/bucket/key', $result['ObjectURL']);
     }
 
     public function getUploadTestCases()
@@ -241,7 +241,7 @@ class ObjectUploaderTest extends TestCase
         $uploadOptions = [
             'params'          => ['RequestPayer' => 'test'],
             'before_upload'   => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
         ];
         $url = 'https://foo.s3.amazonaws.com/bar';
@@ -265,7 +265,7 @@ class ObjectUploaderTest extends TestCase
             $uploadOptions);
         $result = $uploader->upload();
 
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 
     public function testS3ObjectUploaderMultipartParams()
@@ -276,13 +276,13 @@ class ObjectUploaderTest extends TestCase
             'mup_threshold'   => self::MB * 4,
             'params'          => ['RequestPayer' => 'test'],
             'before_initiate' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_upload'   => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             },
             'before_complete' => function($command) {
-                $this->assertEquals('test', $command['RequestPayer']);
+                $this->assertSame('test', $command['RequestPayer']);
             }
         ];
         $url = 'https://foo.s3.amazonaws.com/bar';
@@ -306,6 +306,6 @@ class ObjectUploaderTest extends TestCase
             $uploadOptions);
         $result = $uploader->upload();
 
-        $this->assertEquals($url, $result['ObjectURL']);
+        $this->assertSame($url, $result['ObjectURL']);
     }
 }

--- a/tests/S3/PermanentRedirectMiddlewareTest.php
+++ b/tests/S3/PermanentRedirectMiddlewareTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Aws\S3\PermanentRedirectMiddleware
  */
-class PermanentRedirectTest extends TestCase
+class PermanentRedirectMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/PostObjectTest.php
+++ b/tests/S3/PostObjectTest.php
@@ -44,8 +44,8 @@ class PostObjectTest extends TestCase
             'eyJleHBpcmF0aW9uIjoiMjAwNy0xMi0wMVQxMjowMDowMC4wMDBaIiwiY29uZGl0aW9ucyI6eyJhY2wiOiJwdWJsaWMtcmVhZCJ9fQ==',
             $a['policy']
         );
-        $this->assertEquals('ffajJbr1afVRb3qoFwdn9RK+qfM=', $a['signature']);
-        $this->assertEquals(
+        $this->assertSame('ffajJbr1afVRb3qoFwdn9RK+qfM=', $a['signature']);
+        $this->assertSame(
             '{"expiration":"2007-12-01T12:00:00.000Z","conditions":{"acl":"public-read"}}',
             $p->getJsonPolicy()
         );
@@ -57,17 +57,17 @@ class PostObjectTest extends TestCase
         $this->assertSame($this->client, $postObject->getClient());
         $this->assertSame('foo', $postObject->getBucket());
         $postObject->setFormInput('a', 'b');
-        $this->assertEquals('b', $postObject->getFormInputs()['a']);
+        $this->assertSame('b', $postObject->getFormInputs()['a']);
         $postObject->setFormAttribute('c', 'd');
-        $this->assertEquals('d', $postObject->getFormAttributes()['c']);
-        $this->assertEquals('', $postObject->getJsonPolicy());
+        $this->assertSame('d', $postObject->getFormAttributes()['c']);
+        $this->assertSame('', $postObject->getJsonPolicy());
     }
 
     public function testCanHandleDomainsWithDots()
     {
         $postObject = new PostObject($this->client, 'foo.bar', [], '');
         $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals(
+        $this->assertSame(
             'https://s3.amazonaws.com/foo.bar',
             $formAttrs['action']
         );
@@ -100,7 +100,7 @@ class PostObjectTest extends TestCase
         ];
         $postObject = new PostObject($s3, $bucket, [], $policy);
         $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals($expected, $formAttrs['action']);
+        $this->assertSame($expected, $formAttrs['action']);
     }
 
     public function pathStyleProvider()

--- a/tests/S3/PostObjectV4Test.php
+++ b/tests/S3/PostObjectV4Test.php
@@ -85,7 +85,7 @@ class PostObjectV4Test extends TestCase
         . 'bGdvcml0aG0iOiJBV1M0LUhNQUMtU0hBMjU2In1dfQ==';
         $this->assertSame($policy, $a['Policy']);
 
-        $this->assertEquals(
+        $this->assertSame(
             '683963a1575bb197c642490ac60f3f08cda08233cd3a163ad31b554e9327a3ff',
             $a['X-Amz-Signature']
         );
@@ -204,12 +204,12 @@ class PostObjectV4Test extends TestCase
 
         $this->assertSame($policy, $a['Policy']);
 
-        $this->assertEquals(
+        $this->assertSame(
             'ca86530c5c799e8fd3bf2013aaccc581bc34646d676c4b195d996b6723e2bb91',
             $a['X-Amz-Signature']
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'abJe44dFgDEXAMPLE',
             $a['X-Amz-Security-Token']
         );
@@ -221,16 +221,16 @@ class PostObjectV4Test extends TestCase
         $this->assertSame($this->client, $postObject->getClient());
         $this->assertSame('foo', $postObject->getBucket());
         $postObject->setFormInput('a', 'b');
-        $this->assertEquals('b', $postObject->getFormInputs()['a']);
+        $this->assertSame('b', $postObject->getFormInputs()['a']);
         $postObject->setFormAttribute('c', 'd');
-        $this->assertEquals('d', $postObject->getFormAttributes()['c']);
+        $this->assertSame('d', $postObject->getFormAttributes()['c']);
     }
 
     public function testCanHandleDomainsWithDots()
     {
         $postObject = new PostObjectV4($this->client, 'foo.bar', []);
         $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals(
+        $this->assertSame(
             'https://s3.amazonaws.com/foo.bar',
             $formAttrs['action']
         );
@@ -257,7 +257,7 @@ class PostObjectV4Test extends TestCase
         ]);
         $postObject = new PostObjectV4($s3, $bucket, []);
         $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals($expected, $formAttrs['action']);
+        $this->assertSame($expected, $formAttrs['action']);
     }
 
     public function virtualStyleProvider()
@@ -292,7 +292,7 @@ class PostObjectV4Test extends TestCase
         ]);
         $postObject = new PostObjectV4($s3, $bucket, []);
         $formAttrs = $postObject->getFormAttributes();
-        $this->assertEquals($expected, $formAttrs['action']);
+        $this->assertSame($expected, $formAttrs['action']);
     }
 
     public function pathStyleProvider()

--- a/tests/S3/PutObjectUrlMiddlewareTest.php
+++ b/tests/S3/PutObjectUrlMiddlewareTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Aws\S3\PutObjectUrlMiddleware
  */
-class PutObjectUrlTest extends TestCase
+class PutObjectUrlMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
 
@@ -22,7 +22,7 @@ class PutObjectUrlTest extends TestCase
             'Key'    => 'key',
             'Body'   => 'hi'
         ]);
-        $this->assertEquals('http://foo.com', $result['ObjectURL']);
+        $this->assertSame('http://foo.com', $result['ObjectURL']);
     }
 
     public function testAddsObjectUrlToCompleteMultipart()
@@ -41,7 +41,7 @@ class PutObjectUrlTest extends TestCase
             'Key'      => 'key',
             'UploadId' => '123'
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'https://test.s3.amazonaws.com/key',
             $result['ObjectURL']
         );

--- a/tests/S3/RegionalEndpoint/ConfigurationTest.php
+++ b/tests/S3/RegionalEndpoint/ConfigurationTest.php
@@ -13,13 +13,13 @@ class ConfigurationTest extends TestCase
     public function testGetsCorrectValues()
     {
         $config = new Configuration('regional');
-        $this->assertEquals('regional', $config->getEndpointsType());
+        $this->assertSame('regional', $config->getEndpointsType());
     }
 
     public function testAcceptsNonLowercase()
     {
         $config = new Configuration('rEgIoNaL');
-        $this->assertEquals('regional', $config->getEndpointsType());
+        $this->assertSame('regional', $config->getEndpointsType());
     }
 
     public function testToArray()

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -40,7 +40,7 @@ class S3ClientTest extends TestCase
             'endpoint'        => 'http://test.domain.com',
             'bucket_endpoint' => true
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'http://test.domain.com/key',
             $c->getObjectUrl('test', 'key')
         );
@@ -193,7 +193,7 @@ class S3ClientTest extends TestCase
             'Key'    => '+%.a'
         ]);
         $url = $client->createPresignedRequest($command, 1342138769)->getUri();
-        $this->assertEquals('/foobar.test.abc/%2B%25.a', $url->getPath());
+        $this->assertSame('/foobar.test.abc/%2B%25.a', $url->getPath());
         $query = Psr7\parse_query($url->getQuery());
         $this->assertArrayHasKey('X-Amz-Credential', $query);
         $this->assertArrayHasKey('X-Amz-Signature', $query);
@@ -212,7 +212,7 @@ class S3ClientTest extends TestCase
             'Key'    => '+%.a'
         ]);
         $url = $client->createPresignedRequest($command, 1342138769)->getUri();
-        $this->assertEquals('/foobar.test.abc/%2B%25.a', $url->getPath());
+        $this->assertSame('/foobar.test.abc/%2B%25.a', $url->getPath());
         $query = Psr7\parse_query($url->getQuery());
         $this->assertArrayHasKey('X-Amz-Credential', $query);
         $this->assertArrayHasKey('X-Amz-Signature', $query);
@@ -264,7 +264,7 @@ class S3ClientTest extends TestCase
                 $this->assertSame($exists, $s3->doesBucketExist($bucket));
             }
         } catch (\Exception $e) {
-            $this->assertEquals(-1, $exists);
+            $this->assertSame(-1, $exists);
         }
     }
 
@@ -274,7 +274,7 @@ class S3ClientTest extends TestCase
             'region'      => 'us-east-1',
             'credentials' => false
         ]);
-        $this->assertEquals('https://foo.s3.amazonaws.com/bar', $s3->getObjectUrl('foo', 'bar'));
+        $this->assertSame('https://foo.s3.amazonaws.com/bar', $s3->getObjectUrl('foo', 'bar'));
     }
 
     public function testReturnsObjectUrlWithPathStyleFallback()
@@ -283,7 +283,7 @@ class S3ClientTest extends TestCase
             'region'      => 'us-east-1',
             'credentials' => false,
         ]);
-        $this->assertEquals('https://s3.amazonaws.com/foo.baz/bar', $s3->getObjectUrl('foo.baz', 'bar'));
+        $this->assertSame('https://s3.amazonaws.com/foo.baz/bar', $s3->getObjectUrl('foo.baz', 'bar'));
     }
 
     public function testReturnsObjectUrlWithPathStyle()
@@ -293,7 +293,7 @@ class S3ClientTest extends TestCase
             'credentials' => false,
             'use_path_style_endpoint' => true
         ]);
-        $this->assertEquals('https://s3.amazonaws.com/foo/bar', $s3->getObjectUrl('foo', 'bar'));
+        $this->assertSame('https://s3.amazonaws.com/foo/bar', $s3->getObjectUrl('foo', 'bar'));
     }
 
     public function testReturnsObjectUrlViaPath()
@@ -303,7 +303,7 @@ class S3ClientTest extends TestCase
             'region'      => 'us-east-1',
             'credentials' => false
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'https://foo.s3.amazonaws.com/bar',
             $s3->getObjectUrl('foo', 'bar')
         );
@@ -316,7 +316,7 @@ class S3ClientTest extends TestCase
             'region'      => 'us-east-1',
             'credentials' => false
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'https://s3.amazonaws.com/foo.baz/bar',
             $s3->getObjectUrl('foo.baz', 'bar')
         );
@@ -330,7 +330,7 @@ class S3ClientTest extends TestCase
             'credentials' => false,
             'use_path_style_endpoint' => true
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             'https://s3.amazonaws.com/foo.baz/bar',
             $s3->getObjectUrl('foo.baz', 'bar')
         );
@@ -351,7 +351,7 @@ class S3ClientTest extends TestCase
         /** @var S3Client $client */
         $client = $this->getTestClient('S3');
         $client->getHandlerList()->setHandler(function ($c, $r) {
-            $this->assertEquals('bucket', $c['Bucket']);
+            $this->assertSame('bucket', $c['Bucket']);
             return Promise\promise_for(new Result([
                 'IsTruncated' => false,
                 'Marker' => '',
@@ -467,7 +467,7 @@ class S3ClientTest extends TestCase
             'SaveAs' => 'baz',
         ]);
 
-        $this->assertEquals('sink=baz', (string) $result['Body']);
+        $this->assertSame('sink=baz', (string) $result['Body']);
     }
 
     public function testRequestSucceedsWithColon()
@@ -521,7 +521,7 @@ class S3ClientTest extends TestCase
             'Bucket' => 'bucket',
         ]);
 
-        $this->assertEquals(0, $retries);
+        $this->assertSame(0, $retries);
     }
 
     public function clientRetrySettingsProvider()
@@ -582,7 +582,7 @@ class S3ClientTest extends TestCase
 
         $client->{$operation}($payload);
 
-        $this->assertEquals(0, $retries);
+        $this->assertSame(0, $retries);
     }
 
     public function successErrorResponseProvider()
@@ -864,7 +864,7 @@ EOXML;
             'Key' => 'key',
         ]);
 
-        $this->assertEquals(0, $retries);
+        $this->assertSame(0, $retries);
     }
 
     /**
@@ -906,7 +906,7 @@ EOXML;
             'UploadId' => 1,
         ]);
 
-        $this->assertEquals(0, $retries);
+        $this->assertSame(0, $retries);
     }
 
     /**
@@ -944,7 +944,7 @@ EOXML;
             'Key' => 'key',
         ]);
 
-        $this->assertEquals(0, $retries);
+        $this->assertSame(0, $retries);
     }
 
     public function testListObjectsAppliesUrlEncodingWhenNoneSupplied()
@@ -1410,11 +1410,11 @@ EOXML;
             'version' => 'latest',
             'use_arn_region' => $cache,
             'handler' => function (CommandInterface $cmd, RequestInterface $req) {
-                $this->assertEquals(
+                $this->assertSame(
                     'myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com',
                     $req->getUri()->getHost()
                 );
-                $this->assertEquals(
+                $this->assertSame(
                     '/Bar/Baz',
                     $req->getUri()->getPath()
                 );
@@ -1438,15 +1438,15 @@ EOXML;
             'region' => 'us-west-2',
             'version' => 'latest',
             'handler' => function (CommandInterface $cmd, RequestInterface $req) {
-                $this->assertEquals(
+                $this->assertSame(
                     'myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com',
                     $req->getUri()->getHost()
                 );
-                $this->assertEquals(
+                $this->assertSame(
                     '/copied-object',
                     $req->getUri()->getPath()
                 );
-                $this->assertEquals(
+                $this->assertSame(
                     'arn:aws:s3:us-west-2:1234567890123:accesspoint:my-my/finks-object',
                     $req->getHeader('x-amz-copy-source')[0]
                 );
@@ -1498,7 +1498,7 @@ EOXML;
             'region' => 'us-east-1',
         ]);
         $uri = new Uri($endpoint['endpoint']);
-        $this->assertEquals($uri->getHost(), $client->getEndpoint()->getHost());
+        $this->assertSame($uri->getHost(), $client->getEndpoint()->getHost());
     }
 
     /**
@@ -1655,6 +1655,6 @@ EOXML;
             'CopySource' => 'test-source/key'
         ]);
 
-        $this->assertEquals(3, $counter);
+        $this->assertSame(3, $counter);
     }
 }

--- a/tests/S3/SSECMiddlewareTest.php
+++ b/tests/S3/SSECMiddlewareTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Aws\S3\SSECMiddleware
  */
-class SseCpkListenerTest extends TestCase
+class SSECMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
 

--- a/tests/S3/StreamWrapperPathStyleTest.php
+++ b/tests/S3/StreamWrapperPathStyleTest.php
@@ -107,12 +107,12 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
 
         $s = fopen('s3://bucket/key', 'r');
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertFalse(feof($s));
-        $this->assertEquals('foo', fread($s, 4));
-        $this->assertEquals(3, ftell($s));
-        $this->assertEquals(-1, fseek($s, 0));
-        $this->assertEquals('', stream_get_contents($s));
+        $this->assertSame('foo', fread($s, 4));
+        $this->assertSame(3, ftell($s));
+        $this->assertSame(-1, fseek($s, 0));
+        $this->assertSame('', stream_get_contents($s));
         $this->assertTrue(feof($s));
         $this->assertTrue(fclose($s));
     }
@@ -133,12 +133,12 @@ class StreamWrapperPathStyleTest extends TestCase
             's3' => ['seekable' => true]
         ]));
 
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertFalse(feof($s));
-        $this->assertEquals('test', fread($s, 4));
-        $this->assertEquals(4, ftell($s));
-        $this->assertEquals(0, fseek($s, 0));
-        $this->assertEquals('testing 123', stream_get_contents($s));
+        $this->assertSame('test', fread($s, 4));
+        $this->assertSame(4, ftell($s));
+        $this->assertSame(0, fseek($s, 0));
+        $this->assertSame('testing 123', stream_get_contents($s));
         $this->assertTrue(feof($s));
         $this->assertTrue(fclose($s));
     }
@@ -152,7 +152,7 @@ class StreamWrapperPathStyleTest extends TestCase
         });
         file_put_contents('s3://foo/bar.xml', 'test');
         $this->assertCount(1, $h);
-        $this->assertEquals('application/xml', $h[0][1]->getHeaderLine('Content-Type'));
+        $this->assertSame('application/xml', $h[0][1]->getHeaderLine('Content-Type'));
     }
 
     public function testCanOpenWriteOnlyStreams()
@@ -161,16 +161,16 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result()]);
         $s = fopen('s3://bucket/key', 'w');
-        $this->assertEquals(4, fwrite($s, 'test'));
+        $this->assertSame(4, fwrite($s, 'test'));
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
         $this->assertCount(1, $history);
         $cmd = $history->getLastCommand();
-        $this->assertEquals('PutObject', $cmd->getName());
-        $this->assertEquals('bucket', $cmd['Bucket']);
-        $this->assertEquals('key', $cmd['Key']);
-        $this->assertEquals('test', (string) $cmd['Body']);
+        $this->assertSame('PutObject', $cmd->getName());
+        $this->assertSame('bucket', $cmd['Bucket']);
+        $this->assertSame('key', $cmd['Key']);
+        $this->assertSame('test', (string) $cmd['Body']);
     }
 
     /**
@@ -200,21 +200,21 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
 
         $s = fopen('s3://bucket/key', 'a');
-        $this->assertEquals(4, ftell($s));
-        $this->assertEquals(3, fwrite($s, 'ing'));
+        $this->assertSame(4, ftell($s));
+        $this->assertSame(3, fwrite($s, 'ing'));
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
         $this->assertCount(2, $history);
         $entries = $history->toArray();
         $c1 = $entries[0]['command'];
-        $this->assertEquals('GetObject', $c1->getName());
-        $this->assertEquals('bucket', $c1['Bucket']);
-        $this->assertEquals('key', $c1['Key']);
+        $this->assertSame('GetObject', $c1->getName());
+        $this->assertSame('bucket', $c1['Bucket']);
+        $this->assertSame('key', $c1['Key']);
         $c2 = $entries[1]['command'];
-        $this->assertEquals('PutObject', $c2->getName());
-        $this->assertEquals('key', $c2['Key']);
-        $this->assertEquals('testing', (string) $c2['Body']);
+        $this->assertSame('PutObject', $c2->getName());
+        $this->assertSame('key', $c2['Key']);
+        $this->assertSame('testing', (string) $c2['Body']);
     }
 
     public function testCanOpenAppendStreamsWithMissingFile()
@@ -225,7 +225,7 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
 
         $s = fopen('s3://bucket/key', 'a');
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertTrue(fclose($s));
     }
 
@@ -239,9 +239,9 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(unlink('s3://bucket/key'));
         $this->assertCount(1, $history);
         $entries = $history->toArray();
-        $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
-        $this->assertEquals('/bucket/key', $entries[0]['request']->getUri()->getPath());
-        $this->assertEquals('s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
+        $this->assertSame('DELETE', $entries[0]['request']->getMethod());
+        $this->assertSame('/bucket/key', $entries[0]['request']->getUri()->getPath());
+        $this->assertSame('s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
     }
 
     /**
@@ -302,16 +302,16 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertCount(6, $history);
         $entries = $history->toArray();
 
-        $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
-        $this->assertEquals('HEAD', $entries[2]['request']->getMethod());
-        $this->assertEquals('HEAD', $entries[4]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[0]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[2]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[4]['request']->getMethod());
 
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
-        $this->assertEquals('/bucket', $entries[1]['request']->getUri()->getPath());
-        $this->assertEquals('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertEquals('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertEquals('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertEquals('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('/bucket', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
+        $this->assertSame('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCreatesNestedSubfolder()
@@ -327,8 +327,8 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(mkdir('s3://bucket/key/', 0777));
         $this->assertCount(2, $history);
         $entries = $history->toArray();
-        $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[0]['request']->getMethod());
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
         $this->assertContains('public-read', $entries[1]['request']->getHeaderLine('x-amz-acl'));
     }
 
@@ -361,9 +361,9 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(rmdir('s3://bucket'));
         $this->assertCount(1, $history);
         $entries = $history->toArray();
-        $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
-        $this->assertEquals('/bucket', $entries[0]['request']->getUri()->getPath());
-        $this->assertEquals('s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
+        $this->assertSame('DELETE', $entries[0]['request']->getMethod());
+        $this->assertSame('/bucket', $entries[0]['request']->getUri()->getPath());
+        $this->assertSame('s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
     }
 
     public function rmdirProvider()
@@ -385,7 +385,7 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(rmdir($path));
         $this->assertCount(1, $history);
         $entries = $history->toArray();
-        $this->assertEquals('GET', $entries[0]['request']->getMethod());
+        $this->assertSame('GET', $entries[0]['request']->getMethod());
         $this->assertContains('prefix=object%2F', $entries[0]['request']->getUri()->getQuery());
     }
 
@@ -405,10 +405,10 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(rmdir('s3://foo/bar'));
         $this->assertCount(2, $history);
         $entries = $history->toArray();
-        $this->assertEquals('GET', $entries[0]['request']->getMethod());
+        $this->assertSame('GET', $entries[0]['request']->getMethod());
         $this->assertContains('prefix=bar%2F', $entries[0]['request']->getUri()->getQuery());
-        $this->assertEquals('DELETE', $entries[1]['request']->getMethod());
-        $this->assertEquals('/foo/bar/', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('DELETE', $entries[1]['request']->getMethod());
+        $this->assertSame('/foo/bar/', $entries[1]['request']->getUri()->getPath());
     }
 
     /**
@@ -454,22 +454,22 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertTrue(rename('s3://bucket/key', 's3://other/new_key'));
         $entries = $history->toArray();
         $this->assertCount(3, $entries);
-        $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
-        $this->assertEquals('/bucket/key', $entries[0]['request']->getUri()->getPath());
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
-        $this->assertEquals('/other/new_key', $entries[1]['request']->getUri()->getPath());
-        $this->assertEquals('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertEquals(
+        $this->assertSame('HEAD', $entries[0]['request']->getMethod());
+        $this->assertSame('/bucket/key', $entries[0]['request']->getUri()->getPath());
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('/other/new_key', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
+        $this->assertSame(
             '/bucket/key',
             $entries[1]['request']->getHeaderLine('x-amz-copy-source')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'COPY',
             $entries[1]['request']->getHeaderLine('x-amz-metadata-directive')
         );
-        $this->assertEquals('DELETE', $entries[2]['request']->getMethod());
-        $this->assertEquals('/bucket/key', $entries[2]['request']->getUri()->getPath());
-        $this->assertEquals('s3.amazonaws.com', $entries[2]['request']->getUri()->getHost());
+        $this->assertSame('DELETE', $entries[2]['request']->getMethod());
+        $this->assertSame('/bucket/key', $entries[2]['request']->getUri()->getPath());
+        $this->assertSame('s3.amazonaws.com', $entries[2]['request']->getUri()->getHost());
     }
 
     public function testCanRenameObjectsWithCustomSettings()
@@ -488,14 +488,14 @@ class StreamWrapperPathStyleTest extends TestCase
         ));
         $entries = $history->toArray();
         $this->assertCount(3, $entries);
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
-        $this->assertEquals('/other/new_key', $entries[1]['request']->getUri()->getPath());
-        $this->assertEquals('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertEquals(
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('/other/new_key', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
+        $this->assertSame(
             '/bucket/key',
             $entries[1]['request']->getHeaderLine('x-amz-copy-source')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'REPLACE',
             $entries[1]['request']->getHeaderLine('x-amz-metadata-directive')
         );
@@ -505,31 +505,31 @@ class StreamWrapperPathStyleTest extends TestCase
     {
         clearstatcache('s3://');
         $stat = stat('s3://');
-        $this->assertEquals(0040777, $stat['mode']);
+        $this->assertSame(0040777, $stat['mode']);
         $this->addMockResults($this->client, [
             new Result() // 200
         ]);
         clearstatcache('s3://bucket');
         $stat = stat('s3://bucket');
-        $this->assertEquals(0040777, $stat['mode']);
+        $this->assertSame(0040777, $stat['mode']);
     }
 
     public function testStatDataIsClearedOnWrite()
     {
         $this->cache->set('s3://foo/bar', ['size' => 123, 7 => 123]);
-        $this->assertEquals(123, filesize('s3://foo/bar'));
+        $this->assertSame(123, filesize('s3://foo/bar'));
         $this->addMockResults($this->client, [
             new Result,
             new Result(['ContentLength' => 124])
         ]);
         file_put_contents('s3://foo/bar', 'baz!');
-        $this->assertEquals(124, filesize('s3://foo/bar'));
+        $this->assertSame(124, filesize('s3://foo/bar'));
     }
 
     public function testCanPullStatDataFromCache()
     {
         $this->cache->set('s3://foo/bar', ['size' => 123, 7 => 123]);
-        $this->assertEquals(123, filesize('s3://foo/bar'));
+        $this->assertSame(123, filesize('s3://foo/bar'));
     }
 
     /**
@@ -571,10 +571,10 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
         clearstatcache('s3://bucket/key');
         $stat = stat('s3://bucket/key');
-        $this->assertEquals(0100777, $stat['mode']);
-        $this->assertEquals(5, $stat['size']);
-        $this->assertEquals($ts, $stat['mtime']);
-        $this->assertEquals($ts, $stat['ctime']);
+        $this->assertSame(0100777, $stat['mode']);
+        $this->assertSame(5, $stat['size']);
+        $this->assertSame($ts, $stat['mtime']);
+        $this->assertSame($ts, $stat['ctime']);
     }
 
     public function testCanStatPrefix()
@@ -591,7 +591,7 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
         clearstatcache('s3://bucket/prefix');
         $stat = stat('s3://bucket/prefix');
-        $this->assertEquals(0040777, $stat['mode']);
+        $this->assertSame(0040777, $stat['mode']);
     }
 
     /**
@@ -767,9 +767,9 @@ class StreamWrapperPathStyleTest extends TestCase
 
         $this->client->getHandlerList()->appendBuild(
             Middleware::tap(function (CommandInterface $c, $req) {
-                $this->assertEquals('bucket', $c['Bucket']);
-                $this->assertEquals('/', $c['Delimiter']);
-                $this->assertEquals('key/', $c['Prefix']);
+                $this->assertSame('bucket', $c['Bucket']);
+                $this->assertSame('/', $c['Delimiter']);
+                $this->assertSame('key/', $c['Prefix']);
             })
         );
 
@@ -809,9 +809,9 @@ class StreamWrapperPathStyleTest extends TestCase
 
         $this->client->getHandlerList()->appendBuild(
             Middleware::tap(function (CommandInterface $c, $req) {
-                $this->assertEquals('bucket', $c['Bucket']);
-                $this->assertEquals('', $c['Delimiter']);
-                $this->assertEquals('', $c['Prefix']);
+                $this->assertSame('bucket', $c['Bucket']);
+                $this->assertSame('', $c['Delimiter']);
+                $this->assertSame('', $c['Prefix']);
             })
         );
 
@@ -841,11 +841,11 @@ class StreamWrapperPathStyleTest extends TestCase
         $dir = 's3://bucket/key/';
         $r = opendir($dir);
         $file1 = readdir($r);
-        $this->assertEquals('e', $file1);
-        $this->assertEquals(1, filesize('s3://bucket/key/' . $file1));
+        $this->assertSame('e', $file1);
+        $this->assertSame(1, filesize('s3://bucket/key/' . $file1));
         $file2 = readdir($r);
-        $this->assertEquals('f', $file2);
-        $this->assertEquals(2, filesize('s3://bucket/key/' . $file2));
+        $this->assertSame('f', $file2);
+        $this->assertSame(2, filesize('s3://bucket/key/' . $file2));
         closedir($r);
     }
 
@@ -861,7 +861,7 @@ class StreamWrapperPathStyleTest extends TestCase
         ];
         $this->addMockResults($this->client, [$result]);
         $resource = fopen('s3://foo/bar', 'r');
-        $this->assertEquals(5, fstat($resource)['size']);
+        $this->assertSame(5, fstat($resource)['size']);
     }
 
     public function testCanUseCustomProtocol()
@@ -878,6 +878,6 @@ class StreamWrapperPathStyleTest extends TestCase
         ]);
 
         $s = fopen('foo://bucket/key', 'r');
-        $this->assertEquals('bar', fread($s, 4));
+        $this->assertSame('bar', fread($s, 4));
     }
 }

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -114,12 +114,12 @@ class StreamWrapperTest extends TestCase
         ]);
 
         $s = fopen('s3://bucket/key', 'r');
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertFalse(feof($s));
-        $this->assertEquals('foo', fread($s, 4));
-        $this->assertEquals(3, ftell($s));
-        $this->assertEquals(-1, fseek($s, 0));
-        $this->assertEquals('', stream_get_contents($s));
+        $this->assertSame('foo', fread($s, 4));
+        $this->assertSame(3, ftell($s));
+        $this->assertSame(-1, fseek($s, 0));
+        $this->assertSame('', stream_get_contents($s));
         $this->assertTrue(feof($s));
         $this->assertTrue(fclose($s));
     }
@@ -140,12 +140,12 @@ class StreamWrapperTest extends TestCase
             's3' => ['seekable' => true]
         ]));
 
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertFalse(feof($s));
-        $this->assertEquals('test', fread($s, 4));
-        $this->assertEquals(4, ftell($s));
-        $this->assertEquals(0, fseek($s, 0));
-        $this->assertEquals('testing 123', stream_get_contents($s));
+        $this->assertSame('test', fread($s, 4));
+        $this->assertSame(4, ftell($s));
+        $this->assertSame(0, fseek($s, 0));
+        $this->assertSame('testing 123', stream_get_contents($s));
         $this->assertTrue(feof($s));
         $this->assertTrue(fclose($s));
     }
@@ -159,11 +159,11 @@ class StreamWrapperTest extends TestCase
         $this->client->getHandlerList()->appendSign(
             Middleware::tap(
                 function (CommandInterface $cmd, RequestInterface $req) {
-                    $this->assertEquals(
+                    $this->assertSame(
                         'myaccess-123456789012.s3-accesspoint.us-east-1.amazonaws.com',
                         $req->getUri()->getHost()
                     );
-                    $this->assertEquals(
+                    $this->assertSame(
                         '/test_key',
                         $req->getUri()->getPath()
                     );
@@ -179,12 +179,12 @@ class StreamWrapperTest extends TestCase
         ]);
 
         $s = fopen('s3://arn:aws:s3:us-east-1:123456789012:accesspoint:myaccess/test_key', 'r');
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertFalse(feof($s));
-        $this->assertEquals('foo', fread($s, 4));
-        $this->assertEquals(3, ftell($s));
-        $this->assertEquals(-1, fseek($s, 0));
-        $this->assertEquals('', stream_get_contents($s));
+        $this->assertSame('foo', fread($s, 4));
+        $this->assertSame(3, ftell($s));
+        $this->assertSame(-1, fseek($s, 0));
+        $this->assertSame('', stream_get_contents($s));
         $this->assertTrue(feof($s));
         $this->assertTrue(fclose($s));
     }
@@ -198,11 +198,11 @@ class StreamWrapperTest extends TestCase
         $this->client->getHandlerList()->appendSign(
             Middleware::tap(
                 function (CommandInterface $cmd, RequestInterface $req) {
-                    $this->assertEquals(
+                    $this->assertSame(
                         'myaccess-123456789012.s3-accesspoint.us-east-1.amazonaws.com',
                         $req->getUri()->getHost()
                     );
-                    $this->assertEquals(
+                    $this->assertSame(
                         '/test_key',
                         $req->getUri()->getPath()
                     );
@@ -226,12 +226,12 @@ class StreamWrapperTest extends TestCase
             ])
         );
 
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertFalse(feof($s));
-        $this->assertEquals('test', fread($s, 4));
-        $this->assertEquals(4, ftell($s));
-        $this->assertEquals(0, fseek($s, 0));
-        $this->assertEquals('testing 123', stream_get_contents($s));
+        $this->assertSame('test', fread($s, 4));
+        $this->assertSame(4, ftell($s));
+        $this->assertSame(0, fseek($s, 0));
+        $this->assertSame('testing 123', stream_get_contents($s));
         $this->assertTrue(feof($s));
         $this->assertTrue(fclose($s));
     }
@@ -245,7 +245,7 @@ class StreamWrapperTest extends TestCase
         });
         file_put_contents('s3://foo/bar.xml', 'test');
         $this->assertCount(1, $h);
-        $this->assertEquals('application/xml', $h[0][1]->getHeaderLine('Content-Type'));
+        $this->assertSame('application/xml', $h[0][1]->getHeaderLine('Content-Type'));
     }
 
     public function testCanOpenWriteOnlyStreams()
@@ -254,16 +254,16 @@ class StreamWrapperTest extends TestCase
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result()]);
         $s = fopen('s3://bucket/key', 'w');
-        $this->assertEquals(4, fwrite($s, 'test'));
+        $this->assertSame(4, fwrite($s, 'test'));
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
         $this->assertCount(1, $history);
         $cmd = $history->getLastCommand();
-        $this->assertEquals('PutObject', $cmd->getName());
-        $this->assertEquals('bucket', $cmd['Bucket']);
-        $this->assertEquals('key', $cmd['Key']);
-        $this->assertEquals('test', (string) $cmd['Body']);
+        $this->assertSame('PutObject', $cmd->getName());
+        $this->assertSame('bucket', $cmd['Bucket']);
+        $this->assertSame('key', $cmd['Key']);
+        $this->assertSame('test', (string) $cmd['Body']);
     }
 
     public function testCanWriteEmptyFileToStream()
@@ -272,17 +272,17 @@ class StreamWrapperTest extends TestCase
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
         $this->addMockResults($this->client, [new Result()]);
         $s = fopen('s3://bucket/key', 'w');
-        $this->assertEquals(0, fwrite($s, ''));
+        $this->assertSame(0, fwrite($s, ''));
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed even with zero characters, and
         // that it only executed PutObject once.
         $this->assertCount(1, $history);
         $cmd = $history->getLastCommand();
-        $this->assertEquals('PutObject', $cmd->getName());
-        $this->assertEquals('bucket', $cmd['Bucket']);
-        $this->assertEquals('key', $cmd['Key']);
-        $this->assertEquals('', (string) $cmd['Body']);
+        $this->assertSame('PutObject', $cmd->getName());
+        $this->assertSame('bucket', $cmd['Bucket']);
+        $this->assertSame('key', $cmd['Key']);
+        $this->assertSame('', (string) $cmd['Body']);
     }
 
     /**
@@ -312,21 +312,21 @@ class StreamWrapperTest extends TestCase
         ]);
 
         $s = fopen('s3://bucket/key', 'a');
-        $this->assertEquals(4, ftell($s));
-        $this->assertEquals(3, fwrite($s, 'ing'));
+        $this->assertSame(4, ftell($s));
+        $this->assertSame(3, fwrite($s, 'ing'));
         $this->assertTrue(fclose($s));
 
         // Ensure that the stream was flushed and sent the upload
         $this->assertCount(2, $history);
         $entries = $history->toArray();
         $c1 = $entries[0]['command'];
-        $this->assertEquals('GetObject', $c1->getName());
-        $this->assertEquals('bucket', $c1['Bucket']);
-        $this->assertEquals('key', $c1['Key']);
+        $this->assertSame('GetObject', $c1->getName());
+        $this->assertSame('bucket', $c1['Bucket']);
+        $this->assertSame('key', $c1['Key']);
         $c2 = $entries[1]['command'];
-        $this->assertEquals('PutObject', $c2->getName());
-        $this->assertEquals('key', $c2['Key']);
-        $this->assertEquals('testing', (string) $c2['Body']);
+        $this->assertSame('PutObject', $c2->getName());
+        $this->assertSame('key', $c2['Key']);
+        $this->assertSame('testing', (string) $c2['Body']);
     }
 
     public function testCanOpenAppendStreamsWithMissingFile()
@@ -337,7 +337,7 @@ class StreamWrapperTest extends TestCase
         ]);
 
         $s = fopen('s3://bucket/key', 'a');
-        $this->assertEquals(0, ftell($s));
+        $this->assertSame(0, ftell($s));
         $this->assertTrue(fclose($s));
     }
 
@@ -351,9 +351,9 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(unlink('s3://bucket/key'));
         $this->assertCount(1, $history);
         $entries = $history->toArray();
-        $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
-        $this->assertEquals('/key', $entries[0]['request']->getUri()->getPath());
-        $this->assertEquals('bucket.s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
+        $this->assertSame('DELETE', $entries[0]['request']->getMethod());
+        $this->assertSame('/key', $entries[0]['request']->getUri()->getPath());
+        $this->assertSame('bucket.s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
     }
 
     /**
@@ -414,16 +414,16 @@ class StreamWrapperTest extends TestCase
         $this->assertCount(6, $history);
         $entries = $history->toArray();
 
-        $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
-        $this->assertEquals('HEAD', $entries[2]['request']->getMethod());
-        $this->assertEquals('HEAD', $entries[4]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[0]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[2]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[4]['request']->getMethod());
 
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
-        $this->assertEquals('/', $entries[1]['request']->getUri()->getPath());
-        $this->assertEquals('bucket.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertEquals('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertEquals('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertEquals('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('/', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('bucket.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
+        $this->assertSame('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCreatesNestedSubfolder()
@@ -439,8 +439,8 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(mkdir('s3://bucket/key/', 0777));
         $this->assertCount(2, $history);
         $entries = $history->toArray();
-        $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('HEAD', $entries[0]['request']->getMethod());
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
         $this->assertContains('public-read', $entries[1]['request']->getHeaderLine('x-amz-acl'));
     }
 
@@ -473,9 +473,9 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(rmdir('s3://bucket'));
         $this->assertCount(1, $history);
         $entries = $history->toArray();
-        $this->assertEquals('DELETE', $entries[0]['request']->getMethod());
-        $this->assertEquals('/', $entries[0]['request']->getUri()->getPath());
-        $this->assertEquals('bucket.s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
+        $this->assertSame('DELETE', $entries[0]['request']->getMethod());
+        $this->assertSame('/', $entries[0]['request']->getUri()->getPath());
+        $this->assertSame('bucket.s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
     }
 
     public function rmdirProvider()
@@ -497,7 +497,7 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(rmdir($path));
         $this->assertCount(1, $history);
         $entries = $history->toArray();
-        $this->assertEquals('GET', $entries[0]['request']->getMethod());
+        $this->assertSame('GET', $entries[0]['request']->getMethod());
         $this->assertContains('prefix=object%2F', $entries[0]['request']->getUri()->getQuery());
     }
 
@@ -517,10 +517,10 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(rmdir('s3://foo/bar'));
         $this->assertCount(2, $history);
         $entries = $history->toArray();
-        $this->assertEquals('GET', $entries[0]['request']->getMethod());
+        $this->assertSame('GET', $entries[0]['request']->getMethod());
         $this->assertContains('prefix=bar%2F', $entries[0]['request']->getUri()->getQuery());
-        $this->assertEquals('DELETE', $entries[1]['request']->getMethod());
-        $this->assertEquals('/bar/', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('DELETE', $entries[1]['request']->getMethod());
+        $this->assertSame('/bar/', $entries[1]['request']->getUri()->getPath());
         $this->assertContains('foo', $entries[1]['request']->getUri()->getHost());
     }
 
@@ -567,23 +567,23 @@ class StreamWrapperTest extends TestCase
         $this->assertTrue(rename('s3://bucket/key', 's3://other/new_key'));
         $entries = $history->toArray();
         $this->assertCount(3, $entries);
-        $this->assertEquals('HEAD', $entries[0]['request']->getMethod());
-        $this->assertEquals('/key', $entries[0]['request']->getUri()->getPath());
-        $this->assertEquals('bucket.s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
-        $this->assertEquals('/new_key', $entries[1]['request']->getUri()->getPath());
-        $this->assertEquals('other.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertEquals(
+        $this->assertSame('HEAD', $entries[0]['request']->getMethod());
+        $this->assertSame('/key', $entries[0]['request']->getUri()->getPath());
+        $this->assertSame('bucket.s3.amazonaws.com', $entries[0]['request']->getUri()->getHost());
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('/new_key', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('other.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
+        $this->assertSame(
             '/bucket/key',
             $entries[1]['request']->getHeaderLine('x-amz-copy-source')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'COPY',
             $entries[1]['request']->getHeaderLine('x-amz-metadata-directive')
         );
-        $this->assertEquals('DELETE', $entries[2]['request']->getMethod());
-        $this->assertEquals('/key', $entries[2]['request']->getUri()->getPath());
-        $this->assertEquals('bucket.s3.amazonaws.com', $entries[2]['request']->getUri()->getHost());
+        $this->assertSame('DELETE', $entries[2]['request']->getMethod());
+        $this->assertSame('/key', $entries[2]['request']->getUri()->getPath());
+        $this->assertSame('bucket.s3.amazonaws.com', $entries[2]['request']->getUri()->getHost());
     }
 
     public function testCanRenameObjectsWithCustomSettings()
@@ -602,14 +602,14 @@ class StreamWrapperTest extends TestCase
         ));
         $entries = $history->toArray();
         $this->assertCount(3, $entries);
-        $this->assertEquals('PUT', $entries[1]['request']->getMethod());
-        $this->assertEquals('/new_key', $entries[1]['request']->getUri()->getPath());
-        $this->assertEquals('other.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertEquals(
+        $this->assertSame('PUT', $entries[1]['request']->getMethod());
+        $this->assertSame('/new_key', $entries[1]['request']->getUri()->getPath());
+        $this->assertSame('other.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
+        $this->assertSame(
             '/bucket/key',
             $entries[1]['request']->getHeaderLine('x-amz-copy-source')
         );
-        $this->assertEquals(
+        $this->assertSame(
             'REPLACE',
             $entries[1]['request']->getHeaderLine('x-amz-metadata-directive')
         );
@@ -619,31 +619,31 @@ class StreamWrapperTest extends TestCase
     {
         clearstatcache('s3://');
         $stat = stat('s3://');
-        $this->assertEquals(0040777, $stat['mode']);
+        $this->assertSame(0040777, $stat['mode']);
         $this->addMockResults($this->client, [
             new Result() // 200
         ]);
         clearstatcache('s3://bucket');
         $stat = stat('s3://bucket');
-        $this->assertEquals(0040777, $stat['mode']);
+        $this->assertSame(0040777, $stat['mode']);
     }
 
     public function testStatDataIsClearedOnWrite()
     {
         $this->cache->set('s3://foo/bar', ['size' => 123, 7 => 123]);
-        $this->assertEquals(123, filesize('s3://foo/bar'));
+        $this->assertSame(123, filesize('s3://foo/bar'));
         $this->addMockResults($this->client, [
             new Result,
             new Result(['ContentLength' => 124])
         ]);
         file_put_contents('s3://foo/bar', 'baz!');
-        $this->assertEquals(124, filesize('s3://foo/bar'));
+        $this->assertSame(124, filesize('s3://foo/bar'));
     }
 
     public function testCanPullStatDataFromCache()
     {
         $this->cache->set('s3://foo/bar', ['size' => 123, 7 => 123]);
-        $this->assertEquals(123, filesize('s3://foo/bar'));
+        $this->assertSame(123, filesize('s3://foo/bar'));
     }
 
     /**
@@ -685,10 +685,10 @@ class StreamWrapperTest extends TestCase
         ]);
         clearstatcache('s3://bucket/key');
         $stat = stat('s3://bucket/key');
-        $this->assertEquals(0100777, $stat['mode']);
-        $this->assertEquals(5, $stat['size']);
-        $this->assertEquals($ts, $stat['mtime']);
-        $this->assertEquals($ts, $stat['ctime']);
+        $this->assertSame(0100777, $stat['mode']);
+        $this->assertSame(5, $stat['size']);
+        $this->assertSame($ts, $stat['mtime']);
+        $this->assertSame($ts, $stat['ctime']);
     }
 
     public function testCanStatPrefix()
@@ -705,7 +705,7 @@ class StreamWrapperTest extends TestCase
         ]);
         clearstatcache('s3://bucket/prefix');
         $stat = stat('s3://bucket/prefix');
-        $this->assertEquals(0040777, $stat['mode']);
+        $this->assertSame(0040777, $stat['mode']);
     }
 
     /**
@@ -881,9 +881,9 @@ class StreamWrapperTest extends TestCase
 
         $this->client->getHandlerList()->appendBuild(
             Middleware::tap(function (CommandInterface $c, $req) {
-                $this->assertEquals('bucket', $c['Bucket']);
-                $this->assertEquals('/', $c['Delimiter']);
-                $this->assertEquals('key/', $c['Prefix']);
+                $this->assertSame('bucket', $c['Bucket']);
+                $this->assertSame('/', $c['Delimiter']);
+                $this->assertSame('key/', $c['Prefix']);
             })
         );
 
@@ -923,9 +923,9 @@ class StreamWrapperTest extends TestCase
 
         $this->client->getHandlerList()->appendBuild(
             Middleware::tap(function (CommandInterface $c, $req) {
-                $this->assertEquals('bucket', $c['Bucket']);
-                $this->assertEquals('', $c['Delimiter']);
-                $this->assertEquals('', $c['Prefix']);
+                $this->assertSame('bucket', $c['Bucket']);
+                $this->assertSame('', $c['Delimiter']);
+                $this->assertSame('', $c['Prefix']);
             })
         );
 
@@ -955,11 +955,11 @@ class StreamWrapperTest extends TestCase
         $dir = 's3://bucket/key/';
         $r = opendir($dir);
         $file1 = readdir($r);
-        $this->assertEquals('e', $file1);
-        $this->assertEquals(1, filesize('s3://bucket/key/' . $file1));
+        $this->assertSame('e', $file1);
+        $this->assertSame(1, filesize('s3://bucket/key/' . $file1));
         $file2 = readdir($r);
-        $this->assertEquals('f', $file2);
-        $this->assertEquals(2, filesize('s3://bucket/key/' . $file2));
+        $this->assertSame('f', $file2);
+        $this->assertSame(2, filesize('s3://bucket/key/' . $file2));
         closedir($r);
     }
 
@@ -975,7 +975,7 @@ class StreamWrapperTest extends TestCase
         ];
         $this->addMockResults($this->client, [$result]);
         $resource = fopen('s3://foo/bar', 'r');
-        $this->assertEquals(5, fstat($resource)['size']);
+        $this->assertSame(5, fstat($resource)['size']);
     }
 
     public function testCanUseCustomProtocol()
@@ -992,7 +992,7 @@ class StreamWrapperTest extends TestCase
         ]);
 
         $s = fopen('foo://bucket/key', 'r');
-        $this->assertEquals('bar', fread($s, 4));
+        $this->assertSame('bar', fread($s, 4));
     }
 
     public function testStatDataIsClearedOnWriteUsingCustomProtocol()

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -120,8 +120,8 @@ class TransferTest extends TestCase
 
         /** @var CommandInterface $test */
         foreach ($c as $test) {
-            $this->assertEquals('PutObject', $test->getName());
-            $this->assertEquals('foo', $test['Bucket']);
+            $this->assertSame('PutObject', $test->getName());
+            $this->assertSame('foo', $test['Bucket']);
             $this->assertStringStartsWith('bar/', $test['Key']);
             $this->assertContains($test['SourceFile'] . ' -> s3://foo/bar', $output);
         }
@@ -258,7 +258,7 @@ class TransferTest extends TestCase
         $s3 = $this->getTestClient('s3');
         $s3->getHandlerList()->appendSign(Middleware::tap(
             function (CommandInterface $cmd, RequestInterface $req) {
-                $this->assertEquals(
+                $this->assertSame(
                     'myaccess-123456789012.s3-accesspoint.us-east-1.amazonaws.com',
                     $req->getUri()->getHost()
                 );

--- a/tests/S3/UseArnRegion/ConfigurationProviderTest.php
+++ b/tests/S3/UseArnRegion/ConfigurationProviderTest.php
@@ -252,7 +252,7 @@ EOT;
         $ref = new \ReflectionClass('Aws\S3\UseArnRegion\ConfigurationProvider');
         $meth = $ref->getMethod('getHomeDir');
         $meth->setAccessible(true);
-        $this->assertEquals('C:\\My\\Home', $meth->invoke(null));
+        $this->assertSame('C:\\My\\Home', $meth->invoke(null));
     }
 
     public function testMemoizes()
@@ -265,9 +265,9 @@ EOT;
         };
         $p = ConfigurationProvider::memoize($f);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
     }
 
     public function testChainsConfiguration()
@@ -335,7 +335,7 @@ EOT;
                 ->wait();
         }
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
         $this->assertCount(1, $cache);
         $this->assertSame($expected->toArray(), $result->toArray());
     }

--- a/tests/S3Control/EndpointArnMiddlewareTest.php
+++ b/tests/S3Control/EndpointArnMiddlewareTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aws\Test\S3;
+namespace Aws\Test\S3Control;
 
 use Aws\Arn\Exception\InvalidArnException;
 use Aws\CommandInterface;
@@ -57,7 +57,7 @@ class EndpointArnMiddlewareTest extends TestCase
                     $endpoint,
                     $req->getUri()->getHost()
                 );
-                $this->assertEquals("/{$target}", $req->getRequestTarget());
+                $this->assertSame("/{$target}", $req->getRequestTarget());
                 $this->assertContains(
                     "/{$signingRegion}/{$signingService}",
                     $req->getHeader('Authorization')[0]
@@ -405,8 +405,8 @@ class EndpointArnMiddlewareTest extends TestCase
             $this->fail('This test case should have failed with: '
                 . $expectedException->getMessage());
         } catch (\Exception $e) {
-            $this->assertEquals(get_class($expectedException), get_class($e));
-            $this->assertEquals($expectedException->getMessage(), $e->getMessage());
+            $this->assertInstanceOf(get_class($expectedException), $e);
+            $this->assertSame($expectedException->getMessage(), $e->getMessage());
         }
     }
 

--- a/tests/Signature/AnonymousSignatureTest.php
+++ b/tests/Signature/AnonymousSignatureTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @covers Aws\Signature\AnonymousSignature
  */
-class AnonymousTest extends TestCase
+class AnonymousSignatureTest extends TestCase
 {
     public function testDoesNotSignsRequests()
     {

--- a/tests/Signature/S3SignatureV4Test.php
+++ b/tests/Signature/S3SignatureV4Test.php
@@ -30,7 +30,7 @@ class S3SignatureV4Test extends TestCase
     {
         list($request, $credentials, $signature) = $this->getFixtures();
         $result = $signature->signRequest($request, $credentials);
-        $this->assertEquals(
+        $this->assertSame(
             hash('sha256', ''),
             $result->getHeaderLine('x-amz-content-sha256')
         );
@@ -42,7 +42,7 @@ class S3SignatureV4Test extends TestCase
         $credentials = new Credentials('foo', 'bar');
         $signature = new S3SignatureV4('service', 'region');
         $result = $signature->signRequest($request, $credentials);
-        $this->assertEquals(
+        $this->assertSame(
             hash('sha256', 'foo'),
             $result->getHeaderLine('x-amz-content-sha256')
         );

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -27,8 +27,8 @@ class SignatureV4Test extends TestCase
     public function testReturnsRegionAndService()
     {
         $s = new SignatureV4('foo', 'bar');
-        $this->assertEquals('foo', $this->readAttribute($s, 'service'));
-        $this->assertEquals('bar', $this->readAttribute($s, 'region'));
+        $this->assertSame('foo', $this->readAttribute($s, 'service'));
+        $this->assertSame('bar', $this->readAttribute($s, 'region'));
     }
 
     public function testAddsSecurityTokenIfPresent()
@@ -37,7 +37,7 @@ class SignatureV4Test extends TestCase
         $c = new Credentials('a', 'b', 'AddMe!');
         $r = new Request('GET', 'http://httpbin.org');
         $signed = $s->signRequest($r, $c);
-        $this->assertEquals('AddMe!', $signed->getHeaderLine('X-Amz-Security-Token'));
+        $this->assertSame('AddMe!', $signed->getHeaderLine('X-Amz-Security-Token'));
     }
 
     public function testSignsRequestsWithMultiValuedHeaders()
@@ -50,8 +50,8 @@ class SignatureV4Test extends TestCase
         $methB = new \ReflectionMethod($s, 'createContext');
         $methB->setAccessible(true);
         $result = $methB->invoke($s, $reqArray, '123');
-        $this->assertEquals('host;x-amz-foo', $result['headers']);
-        $this->assertEquals("GET\n/\n\nhost:httpbin.org\nx-amz-foo:bar,baz\n\nhost;x-amz-foo\n123", $result['creq']);
+        $this->assertSame('host;x-amz-foo', $result['headers']);
+        $this->assertSame("GET\n/\n\nhost:httpbin.org\nx-amz-foo:bar,baz\n\nhost;x-amz-foo\n123", $result['creq']);
     }
 
     public function testUsesExistingSha256HashIfPresent()
@@ -250,8 +250,8 @@ class SignatureV4Test extends TestCase
             'foo=bar&baz=bam'
         );
         $request = SignatureV4::convertPostToGet($request);
-        $this->assertEquals('GET', $request->getMethod());
-        $this->assertEquals('foo=bar&baz=bam', $request->getUri()->getQuery());
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('foo=bar&baz=bam', $request->getUri()->getQuery());
     }
 
     /**
@@ -404,7 +404,7 @@ class SignatureV4Test extends TestCase
         $payloadFn = new \ReflectionMethod($signature, 'getPayload');
         $payloadFn->setAccessible(true);
         $payload = $payloadFn->invoke($signature, $request);
-        $this->assertEquals('UNSIGNED-PAYLOAD',$payload);
+        $this->assertSame('UNSIGNED-PAYLOAD',$payload);
         $ctx = $contextFn->invoke($signature, $parsed, $payload);
         $this->assertEquals($creq, $ctx['creq']);
         $this->assertSame($sreq, Psr7\str($signature->signRequest($request, $credentials)));

--- a/tests/Sqs/SqsClientTest.php
+++ b/tests/Sqs/SqsClientTest.php
@@ -22,7 +22,7 @@ class SqsClientTest extends TestCase
             'region'  => 'us-east-1',
             'version' => 'latest'
         ]);
-        $this->assertEquals($arn, $sqs->getQueueArn($url));
+        $this->assertSame($arn, $sqs->getQueueArn($url));
     }
 
     public function testFifoQueueArn()
@@ -33,7 +33,7 @@ class SqsClientTest extends TestCase
             'region'  => 'us-east-1',
             'version' => 'latest'
         ]);
-        $this->assertEquals($arn, $sqs->getQueueArn($url));
+        $this->assertSame($arn, $sqs->getQueueArn($url));
     }
 
     /**
@@ -183,7 +183,7 @@ class SqsClientTest extends TestCase
         ]);
         $this->addMockResults($client, [[]]);
         $client->getHandlerList()->appendSign(Middleware::tap(function ($c, $r) use ($newUrl) {
-            $this->assertEquals($newUrl, $r->getUri());
+            $this->assertSame($newUrl, (string)$r->getUri());
         }));
         $client->receiveMessage(['QueueUrl' => $newUrl]);
     }

--- a/tests/Ssm/SsmClientTest.php
+++ b/tests/Ssm/SsmClientTest.php
@@ -47,7 +47,7 @@ class SsmClientTest extends TestCase
 
         $mock = new MockHandler([
             function ($command, $request) {
-                $this->assertEquals('foo', $command['ClientToken']);
+                $this->assertSame('foo', $command['ClientToken']);
                 return new Result();
             }
         ]);

--- a/tests/Sts/RegionalEndpoints/ConfigurationProviderTest.php
+++ b/tests/Sts/RegionalEndpoints/ConfigurationProviderTest.php
@@ -252,7 +252,7 @@ EOT;
         $ref = new \ReflectionClass('Aws\Sts\RegionalEndpoints\ConfigurationProvider');
         $meth = $ref->getMethod('getHomeDir');
         $meth->setAccessible(true);
-        $this->assertEquals('C:\\My\\Home', $meth->invoke(null));
+        $this->assertSame('C:\\My\\Home', $meth->invoke(null));
     }
 
     public function testMemoizes()
@@ -265,9 +265,9 @@ EOT;
         };
         $p = ConfigurationProvider::memoize($f);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertSame($expected, $p()->wait());
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
     }
 
     public function testChainsConfiguration()
@@ -335,7 +335,7 @@ EOT;
                 ->wait();
         }
 
-        $this->assertEquals(1, $timesCalled);
+        $this->assertSame(1, $timesCalled);
         $this->assertCount(1, $cache);
         $this->assertSame($expected->toArray(), $result->toArray());
     }

--- a/tests/Sts/RegionalEndpoints/ConfigurationTest.php
+++ b/tests/Sts/RegionalEndpoints/ConfigurationTest.php
@@ -13,7 +13,7 @@ class ConfigurationTest extends TestCase
     public function testGetsCorrectValues()
     {
         $config = new Configuration('regional');
-        $this->assertEquals('regional', $config->getEndpointsType());
+        $this->assertSame('regional', $config->getEndpointsType());
     }
 
     public function testToArray()

--- a/tests/Sts/StsClientTest.php
+++ b/tests/Sts/StsClientTest.php
@@ -33,9 +33,9 @@ class StsClientTest extends TestCase
             'Aws\Credentials\CredentialsInterface',
             $credentials
         );
-        $this->assertEquals('foo', $credentials->getAccessKeyId());
-        $this->assertEquals('bar', $credentials->getSecretKey());
-        $this->assertEquals('baz', $credentials->getSecurityToken());
+        $this->assertSame('foo', $credentials->getAccessKeyId());
+        $this->assertSame('bar', $credentials->getSecretKey());
+        $this->assertSame('baz', $credentials->getSecurityToken());
         $this->assertInternalType('int', $credentials->getExpiration());
         $this->assertFalse($credentials->isExpired());
     }
@@ -86,6 +86,6 @@ class StsClientTest extends TestCase
         ]);
         $uri = new Uri($endpoint['endpoint']);
 
-        $this->assertEquals($uri->getHost(), $client->getEndpoint()->getHost());
+        $this->assertSame($uri->getHost(), $client->getEndpoint()->getHost());
     }
 }

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -138,8 +138,8 @@ class WaiterTest extends TestCase
             ]
         );
 
-        $this->assertEquals(4, $iteration, 'Did not execute enough requests.');
-        $this->assertEquals(6000, $waitTime, 'Did not delay long enough.');
+        $this->assertSame(4, $iteration, 'Did not execute enough requests.');
+        $this->assertSame(6000, $waitTime, 'Did not delay long enough.');
     }
 
     /**
@@ -170,7 +170,7 @@ class WaiterTest extends TestCase
             $actualException = $e->getMessage();
         }
 
-        $this->assertEquals(count($results), $actualAttempt);
+        $this->assertCount($actualAttempt, $results);
         $this->assertEquals($expectedException, $actualException);
     }
 


### PR DESCRIPTION
*Description of changes:*

- Using the `assertSame` to make assert equals strict.
- Fix some class namespace and let their class name and file name have same naming.
- Fix correct namespace for some testing classes.
- Using the `PHPUnit\Framework\TestCase` namespace for all classes.
