### PR TITLE
MockHandler exceptions fix

### DIFF
--- a/.changes/nextrelease/enhancement-make-tests-more-strict.json
+++ b/.changes/nextrelease/enhancement-make-tests-more-strict.json
@@ -3,10 +3,5 @@
     "type": "enhancement",
     "category": "",
     "description": "Use the assertSame to make assert equals strict, test namespace improvements"
-  },
-  {
-    "type": "enhancement",
-    "category": "",
-    "description": "Code changes to mock exceptions correctly in mockhandler"
   }
 ]

--- a/.changes/nextrelease/enhancement-make-tests-more-strict.json
+++ b/.changes/nextrelease/enhancement-make-tests-more-strict.json
@@ -3,5 +3,10 @@
     "type": "enhancement",
     "category": "",
     "description": "Use the assertSame to make assert equals strict, test namespace improvements"
+  },
+  {
+    "type": "enhancement",
+    "category": "",
+    "description": "Code changes to mock exceptions correctly in mockhandler"
   }
 ]

--- a/.changes/nextrelease/mockhandlerExcpetionFix.json
+++ b/.changes/nextrelease/mockhandlerExcpetionFix.json
@@ -1,0 +1,5 @@
+{
+    "type": "enhancement",
+    "category": "",
+    "description": "Code changes to mock exceptions correctly in mockhandler"
+  }

--- a/.changes/nextrelease/mockhandlerExcpetionFix.json
+++ b/.changes/nextrelease/mockhandlerExcpetionFix.json
@@ -1,5 +1,7 @@
-{
+[
+  {
     "type": "enhancement",
     "category": "",
     "description": "Code changes to mock exceptions correctly in mockhandler"
   }
+]

--- a/src/MockHandler.php
+++ b/src/MockHandler.php
@@ -5,6 +5,7 @@ use Aws\Exception\AwsException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\RejectedPromise;
 use Psr\Http\Message\RequestInterface;
+use Exception;
 
 /**
  * Returns promises that are rejected or fulfilled using a queue of
@@ -53,7 +54,7 @@ class MockHandler implements \Countable
             ) {
                 $this->queue[] = $value;
             } else {
-                throw new \InvalidArgumentException('Expected an Aws\ResultInterface or Aws\Exception.');
+                throw new \InvalidArgumentException('Expected an Aws\ResultInterface or Exception.');
             }
         }
     }

--- a/src/MockHandler.php
+++ b/src/MockHandler.php
@@ -48,12 +48,12 @@ class MockHandler implements \Countable
     {
         foreach (func_get_args() as $value) {
             if ($value instanceof ResultInterface
-                || $value instanceof AwsException
+                || $value instanceof Exception
                 || is_callable($value)
             ) {
                 $this->queue[] = $value;
             } else {
-                throw new \InvalidArgumentException('Expected an Aws\ResultInterface or Aws\Exception\AwsException.');
+                throw new \InvalidArgumentException('Expected an Aws\ResultInterface or Aws\Exception.');
             }
         }
     }

--- a/tests/MockHandlerTest.php
+++ b/tests/MockHandlerTest.php
@@ -18,7 +18,7 @@ class MockHandlerTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected an Aws\ResultInterface or Aws\Exception
+     * @expectedExceptionMessage Expected an Aws\ResultInterface or Exception
      */
     public function testValidatesEachResult()
     {

--- a/tests/MockHandlerTest.php
+++ b/tests/MockHandlerTest.php
@@ -18,7 +18,7 @@ class MockHandlerTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Expected an Aws\ResultInterface or Aws\Exception\AwsException
+     * @expectedExceptionMessage Expected an Aws\ResultInterface or Aws\Exception
      */
     public function testValidatesEachResult()
     {


### PR DESCRIPTION
*Issue #2143, 

*Description of changes:*

Code changes to mock exceptions, for example `S3MultipartUploadException` which extends from Exception and not `AwsException`, using the previous code will throw an exception like: `InvalidArgumentException: Expected an Aws\ResultInterface or Aws\Exception\AwsException.`




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
