### PR TITLE
Wrap calls to openssl_pkey_free for PHP 8 compatibility

### DIFF
--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -45,7 +45,11 @@ class Signer
 
     public function __destruct()
     {
-        $this->pkHandle && openssl_pkey_free($this->pkHandle);
+        if (PHP_MAJOR_VERSION < 8) {
+            $this->pkHandle && openssl_pkey_free($this->pkHandle);
+        } else {
+            $this->pkHandle;
+        }
     }
 
     /**


### PR DESCRIPTION
The openssl_pkey_free() function, used in PHPMailer::DKIM_Sign(), is deprecated since PHP 8.0 and may start throwing notices.

https://github.com/aws/aws-sdk-php/issues/2152

*Description of changes:*
Wrap calls to openssl_pkey_free to prevent notices throw.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
