### PR TITLE
EcsCredentialProvider - Replace getenv() with $_SERVER

### DIFF
--- a/.changes/nextrelease/bugfix-fix-empty-getenv-in-ecs-credentials-provider.json
+++ b/.changes/nextrelease/bugfix-fix-empty-getenv-in-ecs-credentials-provider.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Fix using ecs credentials provider on multi-threaded servers"
+  }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -105,7 +105,9 @@ class CredentialProvider
         $shouldUseEcsCredentialsProvider = getenv(EcsCredentialProvider::ENV_URI);
         // getenv() is not thread safe - fall back to $_SERVER
         if ($shouldUseEcsCredentialsProvider === false) {
-            $shouldUseEcsCredentialsProvider = isset($_SERVER[EcsCredentialProvider::ENV_URI]) ? $_SERVER[EcsCredentialProvider::ENV_URI] : false;
+            $shouldUseEcsCredentialsProvider = isset($_SERVER[EcsCredentialProvider::ENV_URI])
+                ? $_SERVER[EcsCredentialProvider::ENV_URI]
+                : false;
         }
 
         if (!empty($shouldUseEcsCredentialsProvider)) {

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -102,7 +102,13 @@ class CredentialProvider
             );
         }
 
-        if (!empty($_SERVER[EcsCredentialProvider::ENV_URI])) {
+        $shouldUseEcsCredentialsProvider = getenv(EcsCredentialProvider::ENV_URI);
+        // getenv() is not thread safe - fall back to $_SERVER
+        if ($shouldUseEcsCredentialsProvider === false) {
+            $shouldUseEcsCredentialsProvider = isset($_SERVER[EcsCredentialProvider::ENV_URI]) ? $_SERVER[EcsCredentialProvider::ENV_URI] : false;
+        }
+
+        if (!empty($shouldUseEcsCredentialsProvider)) {
             $defaultChain['ecs'] = self::ecsCredentials($config);
         }
         $defaultChain['process_credentials'] = self::process();

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -102,7 +102,7 @@ class CredentialProvider
             );
         }
 
-        if (!empty(getenv(EcsCredentialProvider::ENV_URI))) {
+        if (!empty($_SERVER[EcsCredentialProvider::ENV_URI])) {
             $defaultChain['ecs'] = self::ecsCredentials($config);
         }
         $defaultChain['process_credentials'] = self::process();

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -34,7 +34,9 @@ class EcsCredentialProvider
         $timeout = getenv(self::ENV_TIMEOUT);
 
         if (!$timeout) {
-            $timeout = isset($_SERVER[self::ENV_TIMEOUT]) ? $_SERVER[self::ENV_TIMEOUT] : (isset($config['timeout']) ? $config['timeout'] : 1.0);
+            $timeout = isset($_SERVER[self::ENV_TIMEOUT])
+                ? $_SERVER[self::ENV_TIMEOUT]
+                : (isset($config['timeout']) ? $config['timeout'] : 1.0);
         }
 
         $this->timeout = (float) $timeout;

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -76,7 +76,7 @@ class EcsCredentialProvider
      */
     private function getEcsUri()
     {
-        $creds_uri = $_SERVER[self::ENV_URI];
+        $creds_uri = isset($_SERVER[self::ENV_URI]) ? $_SERVER[self::ENV_URI] : '';
         return self::SERVER_URI . $creds_uri;
     }
 

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -34,7 +34,7 @@ class EcsCredentialProvider
         $timeout = getenv(self::ENV_TIMEOUT);
 
         if (!$timeout) {
-            $timeout = (isset($config['timeout']) ? $config['timeout'] : 1.0);
+            $timeout = isset($_SERVER[self::ENV_TIMEOUT]) ? $_SERVER[self::ENV_TIMEOUT] : (isset($config['timeout']) ? $config['timeout'] : 1.0);
         }
 
         $this->timeout = (float) $timeout;

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -31,7 +31,13 @@ class EcsCredentialProvider
      */
     public function __construct(array $config = [])
     {
-        $this->timeout = (float) (isset($_SERVER[self::ENV_TIMEOUT]) ? $_SERVER[self::ENV_TIMEOUT] : (isset($config['timeout']) ? $config['timeout'] : 1.0));
+        $timeout = getenv(self::ENV_TIMEOUT);
+
+        if (!$timeout) {
+            $timeout = (isset($config['timeout']) ? $config['timeout'] : 1.0);
+        }
+
+        $this->timeout = (float) $timeout;
         $this->client = isset($config['client'])
             ? $config['client']
             : \Aws\default_http_handler();
@@ -76,8 +82,13 @@ class EcsCredentialProvider
      */
     private function getEcsUri()
     {
-        $creds_uri = isset($_SERVER[self::ENV_URI]) ? $_SERVER[self::ENV_URI] : '';
-        return self::SERVER_URI . $creds_uri;
+        $credsUri = getenv(self::ENV_URI);
+
+        if ($credsUri === false) {
+            $credsUri = isset($_SERVER[self::ENV_URI]) ? $_SERVER[self::ENV_URI] : '';
+        }
+
+        return self::SERVER_URI . $credsUri;
     }
 
     private function decodeResult($response)

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -31,7 +31,7 @@ class EcsCredentialProvider
      */
     public function __construct(array $config = [])
     {
-        $this->timeout = (float) getenv(self::ENV_TIMEOUT) ?: (isset($config['timeout']) ? $config['timeout'] : 1.0);
+        $this->timeout = (float) (isset($_SERVER[self::ENV_TIMEOUT]) ? $_SERVER[self::ENV_TIMEOUT] : (isset($config['timeout']) ? $config['timeout'] : 1.0));
         $this->client = isset($config['client'])
             ? $config['client']
             : \Aws\default_http_handler();
@@ -76,7 +76,7 @@ class EcsCredentialProvider
      */
     private function getEcsUri()
     {
-        $creds_uri = getenv(self::ENV_URI);
+        $creds_uri = $_SERVER[self::ENV_URI];
         return self::SERVER_URI . $creds_uri;
     }
 

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1798,7 +1798,7 @@ EOT;
     public function testCachesCacheableInDefaultChain()
     {
         $this->clearEnv();
-        $_SERVER['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/latest';
+        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
         $cacheable = [
             'web_identity',
             'ecs',
@@ -1839,7 +1839,7 @@ EOT;
         $this->assertSame($instanceCredential->getAccessKeyId(), $credentials->getAccessKeyId());
         $this->assertSame($instanceCredential->getSecretKey(), $credentials->getSecretKey());
 
-        $_SERVER['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/latest';
+        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
         $credentials = call_user_func(CredentialProvider::defaultProvider([
             'credentials' => $cache,
         ]))

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -630,7 +630,7 @@ EOT;
             unlink($dir . '/credentials');
         }
     }
-    
+
     /**
      * @expectedException \Aws\Exception\CredentialsException
      * @expectedExceptionMessage Circular source_profile reference found.
@@ -1798,7 +1798,7 @@ EOT;
     public function testCachesCacheableInDefaultChain()
     {
         $this->clearEnv();
-        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
+        $_SERVER['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/latest';
         $cacheable = [
             'web_identity',
             'ecs',
@@ -1839,7 +1839,7 @@ EOT;
         $this->assertSame($instanceCredential->getAccessKeyId(), $credentials->getAccessKeyId());
         $this->assertSame($instanceCredential->getSecretKey(), $credentials->getSecretKey());
 
-        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
+        $_SERVER['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/latest';
         $credentials = call_user_func(CredentialProvider::defaultProvider([
             'credentials' => $cache,
         ]))


### PR DESCRIPTION
*Issue #2154 

*Description of changes:*
Changes how env variable is taken for `EcsCredentialProvider` (non-thread safe `getenv()` to `$_SERVER`)
This fixed the issue we had on PHP script triggered by a cronjob on ECS task where `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` was available only in `$_SERVER` and `$_ENV` but not by `getenv()`.
This resulted with a different CredentialsProvider being used and failing with an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
