### PR TITLE
Resolves #2171: Honor 'use_aws_shared_config_files' for process…

### DIFF
--- a/.changes/nextrelease/credential-resolver-ordering-update
+++ b/.changes/nextrelease/credential-resolver-ordering-update
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Credentials",
+        "description": "Aligns the credential resolver to the documentation and other SDK behaviors."
+    }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -56,6 +56,7 @@ class CredentialProvider
     /**
      * Create a default credential provider that
      * first checks for environment variables,
+     * then checks for assumed role via web identity,
      * then checks for cached SSO credentials from the CLI,
      * then check for credential_process in the "default" profile in ~/.aws/credentials,
      * then checks for the "default" profile in ~/.aws/credentials,

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -109,9 +109,9 @@ class CredentialProvider
 
         if (!empty(getenv(EcsCredentialProvider::ENV_URI))) {
             $defaultChain['ecs'] = self::ecsCredentials($config);
+        } else {
+            $defaultChain['instance'] = self::instanceProfile($config);
         }
-
-        $defaultChain['instance'] = self::instanceProfile($config);
 
         if (isset($config['credentials'])
             && $config['credentials'] instanceof CacheInterface

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -76,9 +76,9 @@ class CredentialProvider
         $cacheable = [
             'web_identity',
             'sso',
-            'ecs',
             'process_credentials',
             'process_config',
+            'ecs',
             'instance'
         ];
 
@@ -100,23 +100,17 @@ class CredentialProvider
                 'profile default',
                 self::getHomeDir() . '/.aws/config'
             );
-        }
-
-        if (!empty(getenv(EcsCredentialProvider::ENV_URI))) {
-            $defaultChain['ecs'] = self::ecsCredentials($config);
-        }
-        
-        if (
-            !isset($config['use_aws_shared_config_files'])
-            || $config['use_aws_shared_config_files'] !== false
-        ) {
             $defaultChain['process_credentials'] = self::process();
             $defaultChain['process_config'] = self::process(
                 'profile default',
                 self::getHomeDir() . '/.aws/config'
             );
         }
-        
+
+        if (!empty(getenv(EcsCredentialProvider::ENV_URI))) {
+            $defaultChain['ecs'] = self::ecsCredentials($config);
+        }
+
         $defaultChain['instance'] = self::instanceProfile($config);
 
         if (isset($config['credentials'])

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -54,13 +54,14 @@ class CredentialProvider
     const ENV_SHARED_CREDENTIALS_FILE = 'AWS_SHARED_CREDENTIALS_FILE';
 
     /**
-     * Create a default credential provider that first checks for
-     * environment variables,
-     * then checks for the "default" profile in ~/.aws/credentials,
+     * Create a default credential provider that
+     * first checks for environment variables,
+     * then check for role-based auth in ~/.aws/config,
      * then check for credential_process in the "default" profile in ~/.aws/credentials,
+     * then checks for the "default" profile in ~/.aws/credentials,
+     * then for credential_process in the "default profile" profile in ~/.aws/config,
      * then checks for "profile default" profile in ~/.aws/config (which is
      * the default profile of AWS CLI),
-     * then for credential_process in the "default profile" profile in ~/.aws/config,
      * then tries to make a GET Request to fetch credentials if ECS environment variable is presented,
      * finally checks for EC2 instance profile credentials.
      *
@@ -96,13 +97,13 @@ class CredentialProvider
                 self::getHomeDir() . '/.aws/config',
                 $config
             );
-            $defaultChain['ini'] = self::ini();
             $defaultChain['process_credentials'] = self::process();
-            $defaultChain['ini_config'] = self::ini(
+            $defaultChain['ini'] = self::ini();
+            $defaultChain['process_config'] = self::process(
                 'profile default',
                 self::getHomeDir() . '/.aws/config'
             );
-            $defaultChain['process_config'] = self::process(
+            $defaultChain['ini_config'] = self::ini(
                 'profile default',
                 self::getHomeDir() . '/.aws/config'
             );

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -54,14 +54,15 @@ class CredentialProvider
     const ENV_SHARED_CREDENTIALS_FILE = 'AWS_SHARED_CREDENTIALS_FILE';
 
     /**
-     * Create a default credential provider that first checks for environment
-     * variables, then checks for the "default" profile in ~/.aws/credentials,
+     * Create a default credential provider that first checks for
+     * environment variables,
+     * then checks for the "default" profile in ~/.aws/credentials,
+     * then check for credential_process in the "default" profile in ~/.aws/credentials,
      * then checks for "profile default" profile in ~/.aws/config (which is
-     * the default profile of AWS CLI), then tries to make a GET Request to
-     * fetch credentials if Ecs environment variable is presented, then checks
-     * for credential_process in the "default" profile in ~/.aws/credentials,
-     * then for credential_process in the "default profile" profile in
-     * ~/.aws/config, and finally checks for EC2 instance profile credentials.
+     * the default profile of AWS CLI),
+     * then for credential_process in the "default profile" profile in ~/.aws/config,
+     * then tries to make a GET Request to fetch credentials if ECS environment variable is presented,
+     * finally checks for EC2 instance profile credentials.
      *
      * This provider is automatically wrapped in a memoize function that caches
      * previously provided credentials.
@@ -96,11 +97,11 @@ class CredentialProvider
                 $config
             );
             $defaultChain['ini'] = self::ini();
+            $defaultChain['process_credentials'] = self::process();
             $defaultChain['ini_config'] = self::ini(
                 'profile default',
                 self::getHomeDir() . '/.aws/config'
             );
-            $defaultChain['process_credentials'] = self::process();
             $defaultChain['process_config'] = self::process(
                 'profile default',
                 self::getHomeDir() . '/.aws/config'

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -56,7 +56,7 @@ class CredentialProvider
     /**
      * Create a default credential provider that
      * first checks for environment variables,
-     * then check for role-based auth in ~/.aws/config,
+     * then checks for cached SSO credentials from the CLI,
      * then check for credential_process in the "default" profile in ~/.aws/credentials,
      * then checks for the "default" profile in ~/.aws/credentials,
      * then for credential_process in the "default profile" profile in ~/.aws/config,

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -105,11 +105,18 @@ class CredentialProvider
         if (!empty(getenv(EcsCredentialProvider::ENV_URI))) {
             $defaultChain['ecs'] = self::ecsCredentials($config);
         }
-        $defaultChain['process_credentials'] = self::process();
-        $defaultChain['process_config'] = self::process(
-            'profile default',
-            self::getHomeDir() . '/.aws/config'
-        );
+        
+        if (
+            !isset($config['use_aws_shared_config_files'])
+            || $config['use_aws_shared_config_files'] !== false
+        ) {
+            $defaultChain['process_credentials'] = self::process();
+            $defaultChain['process_config'] = self::process(
+                'profile default',
+                self::getHomeDir() . '/.aws/config'
+            );
+        }
+        
         $defaultChain['instance'] = self::instanceProfile($config);
 
         if (isset($config['credentials'])

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1797,19 +1797,19 @@ EOT;
 
     public function testCachesCacheableInDefaultChain()
     {
-        $this->clearEnv();
-        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
         $cacheable = [
             'web_identity',
-            'ecs',
+            'sso',
             'process_credentials',
             'process_config',
-            'sso',
+            'ecs',
             'instance'
         ];
 
         $credsForCache = new Credentials('foo', 'bar', 'baz', PHP_INT_MAX);
         foreach ($cacheable as $provider) {
+            $this->clearEnv();
+            if ($provider == 'ecs') putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
             $cache = new LruArrayCache;
             $cache->set('aws_cached_' . $provider . '_credentials', $credsForCache);
             $credentials = call_user_func(CredentialProvider::defaultProvider([


### PR DESCRIPTION
…-based CredentialProvider

*Issue #, if available:*

Resolves #2171 

For the credential resolver whereby the default ~/.aws/config and ~/.aws/credentials are evaluated for access credentials, the config variable 'use_aws_shared_config_files' is considered. However, for the process-based credential resolver, checking the same $HOME directory shared config files, it is not. This adds the same conditional check to ensure those files are not considered for either method where configuration is explicitly supplied indicating they should not be.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
