### PR TITLE
bugfix to update content type in lexmodelsv2

### DIFF
--- a/.changes/nextrelease/bugfix-content-type-in-lexmodelsv2.json
+++ b/.changes/nextrelease/bugfix-content-type-in-lexmodelsv2.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "LexModelsV2",
+    "description": "Fixed bug where incorrect Content-Type header was being sent to the LexModelsV2 service"
+  }
+]

--- a/src/LexModelsV2/LexModelsV2Client.php
+++ b/src/LexModelsV2/LexModelsV2Client.php
@@ -99,7 +99,7 @@ class LexModelsV2Client extends AwsClient {
     }
 
     /**
-     * Creates a middleware that fixes the Content-Type header when it is present
+     * Creates a middleware that updates the Content-Type header when it is present
      *
      * @return callable
      */

--- a/src/LexModelsV2/LexModelsV2Client.php
+++ b/src/LexModelsV2/LexModelsV2Client.php
@@ -99,7 +99,10 @@ class LexModelsV2Client extends AwsClient {
     }
 
     /**
-     * Creates a middleware that updates the Content-Type header when it is present
+     * Creates a middleware that updates the Content-Type header when it is present;
+     * this is necessary because the service protocol is rest-json which by default
+     * sets the content-type to 'application/json', but interacting with the service
+     * requires it to be set to x-amz-json-1.1
      *
      * @return callable
      */

--- a/src/LexModelsV2/LexModelsV2Client.php
+++ b/src/LexModelsV2/LexModelsV2Client.php
@@ -99,7 +99,7 @@ class LexModelsV2Client extends AwsClient {
     }
 
     /**
-     * Creates a middleware that updates the Content-Type header for all requests with bodies.
+     * Creates a middleware that fixes the Content-Type header when it is present
      *
      * @return callable
      */

--- a/src/LexModelsV2/LexModelsV2Client.php
+++ b/src/LexModelsV2/LexModelsV2Client.php
@@ -2,6 +2,8 @@
 namespace Aws\LexModelsV2;
 
 use Aws\AwsClient;
+use Aws\CommandInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * This client is used to interact with the **Amazon Lex Model Building V2** service.
@@ -86,4 +88,37 @@ use Aws\AwsClient;
  * @method \Aws\Result updateSlotType(array $args = [])
  * @method \GuzzleHttp\Promise\Promise updateSlotTypeAsync(array $args = [])
  */
-class LexModelsV2Client extends AwsClient {}
+class LexModelsV2Client extends AwsClient {
+    public function __construct(array $args)
+    {
+        parent::__construct($args);
+
+        // Setup middleware.
+        $stack = $this->getHandlerList();
+        $stack->appendBuild($this->updateContentType(), 'models.lex.v2.updateContentType');
+    }
+
+    /**
+     * Creates a middleware that updates the Content-Type header for all requests with bodies.
+     *
+     * @return callable
+     */
+    private function updateContentType()
+    {
+        return function (callable $handler) {
+            return function (
+                CommandInterface $command,
+                RequestInterface $request = null
+            ) use ($handler) {
+                $contentType = $request->getHeader('Content-Type');
+                if (!empty($contentType) && $contentType[0] == 'application/json') {
+                    return $handler($command, $request->withHeader(
+                        'Content-Type',
+                        'application/x-amz-json-1.1'
+                    ));
+                }
+                return $handler($command, $request);
+            };
+        };
+    }
+}

--- a/tests/LexModelsV2/LexModelsV2ClientTest.php
+++ b/tests/LexModelsV2/LexModelsV2ClientTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace Aws\Test\LexModelsV2;
+
+use Aws\Exception\CouldNotCreateChecksumException;
+use Aws\Glacier\GlacierClient;
+use Aws\LexModelsV2\LexModelsV2Client;
+use Aws\Test\UsesServiceTrait;
+use GuzzleHttp\Psr7\NoSeekStream;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Aws\LexModelsV2\LexModelsV2Client
+ */
+class LexModelsV2ClientTest extends TestCase
+{
+    use UsesServiceTrait;
+
+    public function testUpdatesContentTypeWithBody()
+    {
+        $client = new LexModelsV2Client([
+            'region'  => 'us-west-2',
+            'version' => 'latest'
+        ]);
+
+        $command = $client->getCommand('ListBots', [
+            'filters' => [
+                [
+                    'name' => 'BotName',
+                    'operator' => 'CO',
+                    'values' => ['foo' => 'bar'],
+                ],
+            ]
+        ]);
+        $request = \Aws\serialize($command);
+
+        // Corrected the header in a post request
+        $contentType = $request->getHeader('Content-Type');
+        $this->assertNotEmpty($contentType);
+        $this->assertSame('application/x-amz-json-1.1', $contentType[0]);
+    }
+
+    public function testNoContentTypeWithoutBody()
+    {
+        $client = new LexModelsV2Client([
+            'region'  => 'us-west-2',
+            'version' => 'latest'
+        ]);
+        $command = $client->getCommand('DeleteBot', [
+            'botId' => '0123456789'
+        ]);
+        $request = \Aws\serialize($command);
+
+        // Corrected the header in a post request
+        $contentType = $request->getHeader('Content-Type');
+        $this->assertEmpty($contentType);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added handler to update the content type of the LexModelsV2 client to 'application/x-amz-json-1.1'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
