### PR TITLE
Fix issue with s3 request uri generation

### DIFF
--- a/.changes/nextrelease/s3-endpoint-middleware-bugfix
+++ b/.changes/nextrelease/s3-endpoint-middleware-bugfix
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "S3",
+        "description": "Fix issue with s3 request uri generation"
+    }
+]

--- a/src/S3/BucketEndpointArnMiddleware.php
+++ b/src/S3/BucketEndpointArnMiddleware.php
@@ -13,6 +13,7 @@ use Aws\Endpoint\PartitionEndpointProvider;
 use Aws\Exception\InvalidRegionException;
 use Aws\Exception\UnresolvedEndpointException;
 use Aws\S3\Exception\S3Exception;
+use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 
 /**

--- a/src/S3/S3EndpointMiddleware.php
+++ b/src/S3/S3EndpointMiddleware.php
@@ -46,6 +46,8 @@ class S3EndpointMiddleware
     private $endpointProvider;
     /** @var callable */
     private $nextHandler;
+    /** @var string */
+    private $endpoint;
 
     /**
      * Create a middleware wrapper function
@@ -278,11 +280,17 @@ class S3EndpointMiddleware
                 $command,
                 $this->endpoint
             );
-        $uri = new Uri();
-        //The host contains s3-outposts here, that's where it gets added
-        $request = $request->withUri(
-            $uri->withHost($host)
-        );
+        $uri = new Uri($host);
+        $scheme = $uri->getScheme();
+        if(empty($scheme)){
+            //The host contains s3-outposts here, that's where it gets added
+            $request = $request->withUri(
+                $uri->withHost($host)
+            );
+        } else {
+            $request = $request->withUri($uri);
+        }
+
         return $request;
     }
 

--- a/src/S3Control/S3ControlEndpointMiddleware.php
+++ b/src/S3Control/S3ControlEndpointMiddleware.php
@@ -22,6 +22,8 @@ class S3ControlEndpointMiddleware
     private $region;
     /** @var callable */
     private $nextHandler;
+    /** @var string|null */
+    private $endpoint;
 
     /**
      * Create a middleware wrapper function


### PR DESCRIPTION
When the endpoint option is set the way the Uri was being generated resulted in a Uri with a blank scheme, and the scheme included in the host value.

*Issue #, if available: 2189
https://github.com/aws/aws-sdk-php/issues/2189

*Description of changes: Changed to pass host to Uri via constructor rather than generating new Uri using the withHost method.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
