### PR TITLE
PHPDoc update on signature

### DIFF
--- a/src/Signature/AnonymousSignature.php
+++ b/src/Signature/AnonymousSignature.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\RequestInterface;
  */
 class AnonymousSignature implements SignatureInterface
 {
+    /**
+     * /** {@inheritdoc}
+     */
     public function signRequest(
         RequestInterface $request,
         CredentialsInterface $credentials
@@ -16,6 +19,9 @@ class AnonymousSignature implements SignatureInterface
         return $request;
     }
 
+    /**
+     * /** {@inheritdoc}
+     */
     public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,

--- a/src/Signature/S3SignatureV4.php
+++ b/src/Signature/S3SignatureV4.php
@@ -9,13 +9,10 @@ use Psr\Http\Message\RequestInterface;
  */
 class S3SignatureV4 extends SignatureV4
 {
-
     /**
      * S3-specific signing logic
      *
-     * @param RequestInterface $request
-     * @param CredentialsInterface $credentials
-     * @return \GuzzleHttp\Psr7\Request|RequestInterface
+     * {@inheritdoc}
      */
     public function signRequest(
         RequestInterface $request,
@@ -34,6 +31,8 @@ class S3SignatureV4 extends SignatureV4
 
     /**
      * Always add a x-amz-content-sha-256 for data integrity.
+     *
+     * {@inheritdoc}
      */
     public function presign(
         RequestInterface $request,

--- a/src/Signature/SignatureInterface.php
+++ b/src/Signature/SignatureInterface.php
@@ -28,9 +28,9 @@ interface SignatureInterface
     /**
      * Create a pre-signed request.
      *
-     * @param RequestInterface     $request     Request to sign
-     * @param CredentialsInterface $credentials Credentials used to sign
-     * @param int|string|\DateTime $expires The time at which the URL should
+     * @param RequestInterface              $request     Request to sign
+     * @param CredentialsInterface          $credentials Credentials used to sign
+     * @param int|string|\DateTimeInterface $expires The time at which the URL should
      *     expire. This can be a Unix timestamp, a PHP DateTime object, or a
      *     string that can be evaluated by strtotime.
      *

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -75,6 +75,9 @@ class SignatureV4 implements SignatureInterface
         $this->unsigned = isset($options['unsigned-body']) ? $options['unsigned-body'] : false;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function signRequest(
         RequestInterface $request,
         CredentialsInterface $credentials
@@ -134,6 +137,9 @@ class SignatureV4 implements SignatureInterface
         return $presignHeaders;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function presign(
         RequestInterface $request,
         CredentialsInterface $credentials,


### PR DESCRIPTION
Updated PHPDoc about the signatures.
The change concerns more particularly the "presign" method which can take a larger object than a simple DateTime.

Edit : I am using a DateTimeImmutable and my PHPStan detect an error on this

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
