### PR TITLE
Update to later releases of guzzle and jmespath

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
-        "guzzlehttp/psr7": "^1.4.1",
-        "guzzlehttp/promises": "^1.0",
-        "mtdowling/jmespath.php": "^2.5",
+        "guzzlehttp/psr7": "^1.7.0",
+        "guzzlehttp/promises": "^1.4.0",
+        "mtdowling/jmespath.php": "^2.6",
         "ext-pcre": "*",
         "ext-json": "*",
         "ext-simplexml": "*"


### PR DESCRIPTION
The later releases of guzzle and jmespath have had PHP7.4 compatibility issues resolved.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
