### PR TITLE
bugfix-breaking-LCK-test

### DIFF
--- a/tests/S3/S3EndpointMiddlewareTest.php
+++ b/tests/S3/S3EndpointMiddlewareTest.php
@@ -549,6 +549,10 @@ class S3EndpointMiddlewareTest extends TestCase
         $endpointUrl,
         $expectedEndpoint)
     {
+        $isMvpRegion = getenv('AIRGAPPED_REGION') == 'LCK';
+        if ($isMvpRegion) {
+            $this->markTestSkipped();
+        }
         //additional flags is not used yet, will be in the future if dualstack support is added
         $clientConfig = [
             'region' => $clientRegion,

--- a/tests/S3/S3EndpointMiddlewareTest.php
+++ b/tests/S3/S3EndpointMiddlewareTest.php
@@ -591,7 +591,7 @@ class S3EndpointMiddlewareTest extends TestCase
             ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "s3-external-1", "none", true, null, "mybanner-123456789012.s3-object-lambda.us-east-1.amazonaws.com"],
             ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "s3-external-1", "none", false, null, "mybanner-123456789012.s3-object-lambda.s3-external-1.amazonaws.com"],
             ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "aws-global", "none", true, null, "mybanner-123456789012.s3-object-lambda.us-east-1.amazonaws.com"],
-            ["arn:aws:s3-object-lambda:us-east-2:123456789012:accesspoint/mybanner", "aws-global", "none", false, null, "mybanner-123456789012.s3-object-lambda.aws-global.amazonaws.com"],
+            ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "aws-global", "none", false, null, "mybanner-123456789012.s3-object-lambda.aws-global.amazonaws.com"],
             ["arn:aws-cn:s3-object-lambda:cn-north-1:123456789012:accesspoint/mybanner", "cn-north-1", "none", true, null, "mybanner-123456789012.s3-object-lambda.cn-north-1.amazonaws.com.cn"],
             ["arn:aws-cn:s3-object-lambda:cn-north-1:123456789012:accesspoint/mybanner", "cn-north-1", "none", false, null, "mybanner-123456789012.s3-object-lambda.cn-north-1.amazonaws.com.cn"],
             ["arn:aws-cn:s3-object-lambda:cn-northwest-1:123456789012:accesspoint/mybanner", "cn-north-1", "none", true, null, "mybanner-123456789012.s3-object-lambda.cn-northwest-1.amazonaws.com.cn"],

--- a/tests/S3/S3EndpointMiddlewareTest.php
+++ b/tests/S3/S3EndpointMiddlewareTest.php
@@ -591,7 +591,7 @@ class S3EndpointMiddlewareTest extends TestCase
             ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "s3-external-1", "none", true, null, "mybanner-123456789012.s3-object-lambda.us-east-1.amazonaws.com"],
             ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "s3-external-1", "none", false, null, "mybanner-123456789012.s3-object-lambda.s3-external-1.amazonaws.com"],
             ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "aws-global", "none", true, null, "mybanner-123456789012.s3-object-lambda.us-east-1.amazonaws.com"],
-            ["arn:aws:s3-object-lambda:us-east-1:123456789012:accesspoint/mybanner", "aws-global", "none", false, null, "mybanner-123456789012.s3-object-lambda.aws-global.amazonaws.com"],
+            ["arn:aws:s3-object-lambda:us-east-2:123456789012:accesspoint/mybanner", "aws-global", "none", false, null, "mybanner-123456789012.s3-object-lambda.aws-global.amazonaws.com"],
             ["arn:aws-cn:s3-object-lambda:cn-north-1:123456789012:accesspoint/mybanner", "cn-north-1", "none", true, null, "mybanner-123456789012.s3-object-lambda.cn-north-1.amazonaws.com.cn"],
             ["arn:aws-cn:s3-object-lambda:cn-north-1:123456789012:accesspoint/mybanner", "cn-north-1", "none", false, null, "mybanner-123456789012.s3-object-lambda.cn-north-1.amazonaws.com.cn"],
             ["arn:aws-cn:s3-object-lambda:cn-northwest-1:123456789012:accesspoint/mybanner", "cn-north-1", "none", true, null, "mybanner-123456789012.s3-object-lambda.cn-northwest-1.amazonaws.com.cn"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Test is breaking in LCK region due to customization on us-east-1 as a legacy global endpoint.  This PR marks this test as skipped in the LCK region

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
