### PR TITLE
fix: don't attempt flushHttpDebug when disabled

### DIFF
--- a/src/TraceMiddleware.php
+++ b/src/TraceMiddleware.php
@@ -285,7 +285,7 @@ class TraceMiddleware
 
     private function flushHttpDebug(CommandInterface $command)
     {
-        if ($res = $command['@http']['debug']) {
+        if ($this->config['http'] && $res = $command['@http']['debug']) {
             rewind($res);
             $this->write(stream_get_contents($res));
             fclose($res);


### PR DESCRIPTION
When TraceMiddleware is configured with http=false, createHttpDebug does not create a debug resource.  This fix ensures that flushHttpDebug does not try to use the non-existent debug resource.

Fixes:

```
Notice: Undefined index: debug

  at vendor/aws/aws-sdk-php/src/TraceMiddleware.php:288
  at Aws\TraceMiddleware->flushHttpDebug(object(Command))
     (vendor/aws/aws-sdk-php/src/TraceMiddleware.php:111)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
