### PR TITLE
Support DateTimeImmutable in Timestamp API Fields

### DIFF
--- a/src/Api/TimestampShape.php
+++ b/src/Api/TimestampShape.php
@@ -24,7 +24,7 @@ class TimestampShape extends Shape
      */
     public static function format($value, $format)
     {
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             $value = $value->getTimestamp();
         } elseif (is_string($value)) {
             $value = strtotime($value);

--- a/tests/Api/TimestampShapeTest.php
+++ b/tests/Api/TimestampShapeTest.php
@@ -22,7 +22,10 @@ class TimestampShapeTest extends TestCase
             [$t, 'rfc822', 'Tue, 05 Jan 1999 00:00:00 GMT'],
             [new \DateTime('january 5, 1999'), 'unixTimestamp', '915494400'],
             [new \DateTime('january 5, 1999'), 'iso8601', '1999-01-05T00:00:00Z'],
-            [new \DateTime('january 5, 1999'), 'rfc822', 'Tue, 05 Jan 1999 00:00:00 GMT']
+            [new \DateTime('january 5, 1999'), 'rfc822', 'Tue, 05 Jan 1999 00:00:00 GMT'],
+            [new \DateTimeImmutable('january 5, 1999'), 'unixTimestamp', '915494400'],
+            [new \DateTimeImmutable('january 5, 1999'), 'iso8601', '1999-01-05T00:00:00Z'],
+            [new \DateTimeImmutable('january 5, 1999'), 'rfc822', 'Tue, 05 Jan 1999 00:00:00 GMT']
         ];
     }
 


### PR DESCRIPTION
*Description of changes:*

By checking `DateTimeInterface` instead of `DateTime`.

DateTimeInterface was added in PHP 5.5, which is the minimum PHP version
the SDK supports.

*Issue #, if available:*

I couldn't find any, but there are a few closed PRs around this https://github.com/aws/aws-sdk-php/pull/422


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
