### PR TITLE
XML encoding update

### DIFF
--- a/.changes/nextrelease/bugfix-xml-encoding.json
+++ b/.changes/nextrelease/bugfix-xml-encoding.json
@@ -1,0 +1,8 @@
+[
+  {
+  "type": "bugfix",
+  "category": "Api",
+  "description": "Fixed a bug where certain characters weren't escaped in the XML encoding"
+  }
+]
+

--- a/src/Api/Serializer/RestXmlSerializer.php
+++ b/src/Api/Serializer/RestXmlSerializer.php
@@ -29,6 +29,20 @@ class RestXmlSerializer extends RestSerializer
     protected function payload(StructureShape $member, array $value, array &$opts)
     {
         $opts['headers']['Content-Type'] = 'application/xml';
-        $opts['body'] = (string) $this->xmlBody->build($member, $value);
+        $opts['body'] = $this->getXmlBody($member, $value);
+    }
+
+    /**
+     * @param StructureShape $member
+     * @param array $value
+     * @return string
+     */
+    private function getXmlBody(StructureShape $member, array $value)
+    {
+        $xmlBody = (string)$this->xmlBody->build($member, $value);
+        $xmlBody = str_replace("'", "&apos;", $xmlBody);
+        $xmlBody = str_replace('\r', "&#13;", $xmlBody);
+        $xmlBody = str_replace('\n', "&#10;", $xmlBody);
+        return $xmlBody;
     }
 }

--- a/tests/Api/Serializer/RestXmlSerializerTest.php
+++ b/tests/Api/Serializer/RestXmlSerializerTest.php
@@ -31,6 +31,23 @@ class RestXmlSerializerTest extends TestCase
         $this->assertSame('abc', $request->getHeaderLine('Content-Type'));
     }
 
+    public function testEscapesAllXMLCharacters()
+    {
+        $request = $this->getRequest('DeleteObjects', [
+            'Bucket' => 'foo',
+            'Delete' => ['Objects' =>
+                [
+                    ['Key' => '/@/#/=/;/:/ /,/?/\'/"/</>/&/\r/\n/']
+                ]
+            ],
+        ]);
+        $contents = $request->getBody()->getContents();
+        $this->assertContains(
+            "<Key>/@/#/=/;/:/ /,/?/&apos;/&quot;/&lt;/&gt;/&amp;/&#13;/&#10;/",
+            $contents
+        );
+    }
+
     public function testPreparesRequestsWithNoContentType()
     {
         $request = $this->getRequest('PutObject', [


### PR DESCRIPTION
XML encoding now encodes new line characters, apostrophes, and carriage returns

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
