### PR TITLE
Suppress error for potential empty token

### DIFF
--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -99,7 +99,7 @@ class AssumeRoleWithWebIdentityCredentialProvider
             while ($result == null) {
                 try {
                     $token = is_readable($this->tokenFile)
-                        ? file_get_contents($this->tokenFile)
+                        ? @file_get_contents($this->tokenFile)
                         : false;
                     if (false === $token) {
                         clearstatcache(true, dirname($this->tokenFile) . "/" . readlink($this->tokenFile));
@@ -110,7 +110,7 @@ class AssumeRoleWithWebIdentityCredentialProvider
                                 "Unreadable tokenfile at location {$this->tokenFile}"
                             );
                         }
-                        $token = file_get_contents($this->tokenFile);
+                        $token = @file_get_contents($this->tokenFile);
                     }
                     if (empty($token)) {
                         if ($this->tokenFileReadAttempts < $this->retries) {


### PR DESCRIPTION
*Description of changes:*
An empty token is expected and handled so there is no need to log the warning errors the we get from `file_get_contents`

Currently, every time the token is refreshed the following gets logged
```
ERROR - 2021-05-11 14:48:06 --> {"description":"Severity: Warning --> file_get_contents(\/var\/run\/secrets\/eks.amazonaws.com\/serviceaccount\/token): failed to open stream: No such file or directory \/var\/www\/test\/vendor\/aws\/aws-sdk-php\/src\/Credentials\/AssumeRoleWithWebIdentityCredentialProvider.php 102"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
