### PR TITLE
Add `guzzlehttp/psr7=^1.7|^2.0` to composer

### DIFF
--- a/.changes/nextrelease/2264-guzzlehttp-psr7-v2-compat.json
+++ b/.changes/nextrelease/2264-guzzlehttp-psr7-v2-compat.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Allow `guzzlehttp/psr7=^2.0` next to (previously existing) `^1.7`."
+    }
+]

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
-        "guzzlehttp/psr7": "^1.7.0",
+        "guzzlehttp/psr7": "^1.7|^2.0",
         "guzzlehttp/promises": "^1.4.0",
         "mtdowling/jmespath.php": "^2.6",
         "ext-pcre": "*",


### PR DESCRIPTION
*Issue #2264, if available:* #2264

*Description of changes:* Declare compatibility with `guzzlehttp/psr7` version 2.0, while still allowing version 1.7


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
