### PR TITLE
Add ReturnTypeWillChange attribute

### DIFF
--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -4,6 +4,7 @@ namespace Aws\Api;
 
 use Aws\Api\Parser\Exception\ParserException;
 use Exception;
+use \ReturnTypeWillChange;
 
 /**
  * DateTime overrides that make DateTime work more seamlessly as a string,
@@ -94,6 +95,7 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
      *
      * @return mixed|string
      */
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return (string) $this;

--- a/src/Crypto/MetadataEnvelope.php
+++ b/src/Crypto/MetadataEnvelope.php
@@ -6,6 +6,7 @@ use \ArrayAccess;
 use \IteratorAggregate;
 use \InvalidArgumentException;
 use \JsonSerializable;
+use \ReturnTypeWillChange;
 
 /**
  * Stores encryption metadata for reading and writing.
@@ -49,6 +50,7 @@ class MetadataEnvelope implements ArrayAccess, IteratorAggregate, JsonSerializab
         $this->data[$name] = $value;
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->data;

--- a/src/DynamoDb/BinaryValue.php
+++ b/src/DynamoDb/BinaryValue.php
@@ -2,6 +2,7 @@
 namespace Aws\DynamoDb;
 
 use GuzzleHttp\Psr7;
+use \ReturnTypeWillChange;
 
 /**
  * Special object to represent a DynamoDB binary (B) value.
@@ -24,6 +25,7 @@ class BinaryValue implements \JsonSerializable
         $this->value = (string) $value;
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->value;

--- a/src/DynamoDb/NumberValue.php
+++ b/src/DynamoDb/NumberValue.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\DynamoDb;
 
+use \ReturnTypeWillChange;
+
 /**
  * Special object to represent a DynamoDB Number (N) value.
  */
@@ -17,6 +19,7 @@ class NumberValue implements \JsonSerializable
         $this->value = (string) $value;
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->value;

--- a/src/DynamoDb/SessionHandler.php
+++ b/src/DynamoDb/SessionHandler.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\DynamoDb;
 
+use \ReturnTypeWillChange;
+
 /**
  * Provides an interface for using Amazon DynamoDB as a session store by hooking
  * into PHP's session handler hooks. Once registered, You may use the native
@@ -101,6 +103,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Whether or not the operation succeeded.
      */
+     #[ReturnTypeWillChange]
     public function open($savePath, $sessionName)
     {
         $this->savePath = $savePath;
@@ -114,6 +117,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Success
      */
+     #[ReturnTypeWillChange]
     public function close()
     {
         $id = session_id();
@@ -134,6 +138,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return string Session data.
      */
+     #[ReturnTypeWillChange]
     public function read($id)
     {
         $this->openSessionId = $id;
@@ -167,6 +172,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Whether or not the operation succeeded.
      */
+     #[ReturnTypeWillChange]
     public function write($id, $data)
     {
         $changed = $id !== $this->openSessionId
@@ -187,6 +193,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Whether or not the operation succeeded.
      */
+     #[ReturnTypeWillChange]
     public function destroy($id)
     {
         $this->openSessionId = $id;
@@ -206,6 +213,7 @@ class SessionHandler implements \SessionHandlerInterface
      * @return bool Whether or not the operation succeeded.
      * @codeCoverageIgnore
      */
+     #[ReturnTypeWillChange]
     public function gc($maxLifetime)
     {
         // Garbage collection for a DynamoDB table must be triggered manually.

--- a/src/DynamoDb/SetValue.php
+++ b/src/DynamoDb/SetValue.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\DynamoDb;
 
+use \ReturnTypeWillChange;
+
 /**
  * Special object to represent a DynamoDB set (SS/NS/BS) value.
  */
@@ -37,6 +39,7 @@ class SetValue implements \JsonSerializable, \Countable, \IteratorAggregate
         return new \ArrayIterator($this->values);
     }
 
+    #[ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();


### PR DESCRIPTION
This PR adds the new `ReturnTypeWillChange` attribute from PHP 8.1 to several internal method overrides so these are compatible with PHP 8.1. This is similarly to how we've done it in the Laravel framework: https://github.com/laravel/framework/pull/37838

At the moment the PHP 8.1 build for the Laravel framework is failing because AWS is not yet compatible with it (understandable because it's still a while out). By merging this PR, the AWS PHP SDK will be one step closer to PHP 8.1 compatibility and we can run our own build to prepare Laravel. Now with the recent PHP 8.1 Alpha 3 being out it's a good time to start testing: https://www.php.net/archive/2021.php#2021-07-08-1

See the failing build on `laravel/framework` here: https://github.com/laravel/framework/runs/3022524466#step:7:61

PS.: [I tried to add a PHP 8.0 build](https://github.com/aws/aws-sdk-php/pull/2268) (and was planning on a 8.1 after it) but there seems to be much more work involved as the current test suite has greatly aged. I suggest doing a new 4.0 major release and dropping a few older PHP versions and maintain parallel 3.x and 4.x branches so you can at least modernize the codebase and upgrade to a newer PHPUnit version.