### PR TITLE
removes a bad smoke test

### DIFF
--- a/.changes/nextrelease/remove-bad-smoke-test.json
+++ b/.changes/nextrelease/remove-bad-smoke-test.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Removes a broken smoke test for device farms"
+  }
+]

--- a/features/smoke/devicefarm.feature
+++ b/features/smoke/devicefarm.feature
@@ -5,8 +5,3 @@ Feature: AWS Device Farm
   Scenario: Making a request
     When I call the "ListDevices" API
     Then the value at "devices" should be a list
-
-  Scenario: Handling errors
-    When I attempt to call the "GetDevice" API with:
-    | arn | arn:aws:devicefarm:us-west-2::device:000000000000000000000000fake-arn |
-    Then I expect the response error code to be "NotFoundException"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes a broken smoke test from device farm

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
