### PR TITLE
Update WrappedHttpHandler.php by remove deprecated  method

### DIFF
--- a/src/WrappedHttpHandler.php
+++ b/src/WrappedHttpHandler.php
@@ -5,6 +5,7 @@ use Aws\Api\Parser\Exception\ParserException;
 use GuzzleHttp\Promise;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Promise\Create;
 
 /**
  * Converts an HTTP handler into a Command HTTP handler.
@@ -84,7 +85,7 @@ class WrappedHttpHandler
                 . ' receiver to Aws\WrappedHttpHandler is not supported.');
         }
 
-        return Promise\promise_for($fn($request, $options))
+        return Create::promiseFor($fn($request, $options))
             ->then(
                 function (
                     ResponseInterface $res


### PR DESCRIPTION
Creates a promise for a value if the value is not a promise.

 
function promise_for($value) { }
@deprecated promise_for
will be removed in guzzlehttp/promises:2.0. Use Create::promiseFor instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
