### PR TITLE
Implement more ReturnTypeWillChange attributes

### DIFF
--- a/src/Api/AbstractModel.php
+++ b/src/Api/AbstractModel.php
@@ -27,22 +27,26 @@ abstract class AbstractModel implements \ArrayAccess
         return $this->definition;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->definition[$offset])
             ? $this->definition[$offset] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->definition[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->definition[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->definition[$offset]);

--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -4,7 +4,6 @@ namespace Aws\Api;
 
 use Aws\Api\Parser\Exception\ParserException;
 use Exception;
-use \ReturnTypeWillChange;
 
 /**
  * DateTime overrides that make DateTime work more seamlessly as a string,
@@ -95,10 +94,9 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
      *
      * @return mixed|string
      */
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return (string) $this;
     }
 }
-

--- a/src/CloudTrail/LogRecordIterator.php
+++ b/src/CloudTrail/LogRecordIterator.php
@@ -110,11 +110,13 @@ class LogRecordIterator implements \OuterIterator
      *
      * @return array|false
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->valid() ? $this->records[$this->recordIndex] : false;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->recordIndex++;
@@ -131,6 +133,7 @@ class LogRecordIterator implements \OuterIterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         if ($logFile = $this->logFileIterator->current()) {
@@ -140,17 +143,20 @@ class LogRecordIterator implements \OuterIterator
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->records[$this->recordIndex]);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->logFileIterator->rewind();
         $this->loadRecordsFromCurrentLogFile();
     }
 
+    #[\ReturnTypeWillChange]
     public function getInnerIterator()
     {
         return $this->logFileIterator;

--- a/src/Crypto/MetadataEnvelope.php
+++ b/src/Crypto/MetadataEnvelope.php
@@ -6,7 +6,6 @@ use \ArrayAccess;
 use \IteratorAggregate;
 use \InvalidArgumentException;
 use \JsonSerializable;
-use \ReturnTypeWillChange;
 
 /**
  * Stores encryption metadata for reading and writing.
@@ -50,7 +49,7 @@ class MetadataEnvelope implements ArrayAccess, IteratorAggregate, JsonSerializab
         $this->data[$name] = $value;
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->data;

--- a/src/DynamoDb/BinaryValue.php
+++ b/src/DynamoDb/BinaryValue.php
@@ -2,7 +2,6 @@
 namespace Aws\DynamoDb;
 
 use GuzzleHttp\Psr7;
-use \ReturnTypeWillChange;
 
 /**
  * Special object to represent a DynamoDB binary (B) value.
@@ -25,7 +24,7 @@ class BinaryValue implements \JsonSerializable
         $this->value = (string) $value;
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->value;

--- a/src/DynamoDb/NumberValue.php
+++ b/src/DynamoDb/NumberValue.php
@@ -1,8 +1,6 @@
 <?php
 namespace Aws\DynamoDb;
 
-use \ReturnTypeWillChange;
-
 /**
  * Special object to represent a DynamoDB Number (N) value.
  */
@@ -19,7 +17,7 @@ class NumberValue implements \JsonSerializable
         $this->value = (string) $value;
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->value;

--- a/src/DynamoDb/SessionHandler.php
+++ b/src/DynamoDb/SessionHandler.php
@@ -1,8 +1,6 @@
 <?php
 namespace Aws\DynamoDb;
 
-use \ReturnTypeWillChange;
-
 /**
  * Provides an interface for using Amazon DynamoDB as a session store by hooking
  * into PHP's session handler hooks. Once registered, You may use the native
@@ -103,7 +101,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Whether or not the operation succeeded.
      */
-     #[ReturnTypeWillChange]
+     #[\ReturnTypeWillChange]
     public function open($savePath, $sessionName)
     {
         $this->savePath = $savePath;
@@ -117,7 +115,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Success
      */
-     #[ReturnTypeWillChange]
+     #[\ReturnTypeWillChange]
     public function close()
     {
         $id = session_id();
@@ -138,7 +136,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return string Session data.
      */
-     #[ReturnTypeWillChange]
+     #[\ReturnTypeWillChange]
     public function read($id)
     {
         $this->openSessionId = $id;
@@ -172,7 +170,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Whether or not the operation succeeded.
      */
-     #[ReturnTypeWillChange]
+     #[\ReturnTypeWillChange]
     public function write($id, $data)
     {
         $changed = $id !== $this->openSessionId
@@ -193,7 +191,7 @@ class SessionHandler implements \SessionHandlerInterface
      *
      * @return bool Whether or not the operation succeeded.
      */
-     #[ReturnTypeWillChange]
+     #[\ReturnTypeWillChange]
     public function destroy($id)
     {
         $this->openSessionId = $id;
@@ -213,7 +211,7 @@ class SessionHandler implements \SessionHandlerInterface
      * @return bool Whether or not the operation succeeded.
      * @codeCoverageIgnore
      */
-     #[ReturnTypeWillChange]
+     #[\ReturnTypeWillChange]
     public function gc($maxLifetime)
     {
         // Garbage collection for a DynamoDB table must be triggered manually.

--- a/src/DynamoDb/SetValue.php
+++ b/src/DynamoDb/SetValue.php
@@ -29,6 +29,7 @@ class SetValue implements \JsonSerializable, \Countable, \IteratorAggregate
         return $this->values;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->values);

--- a/src/DynamoDb/SetValue.php
+++ b/src/DynamoDb/SetValue.php
@@ -35,6 +35,7 @@ class SetValue implements \JsonSerializable, \Countable, \IteratorAggregate
         return count($this->values);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->values);

--- a/src/DynamoDb/SetValue.php
+++ b/src/DynamoDb/SetValue.php
@@ -1,8 +1,6 @@
 <?php
 namespace Aws\DynamoDb;
 
-use \ReturnTypeWillChange;
-
 /**
  * Special object to represent a DynamoDB set (SS/NS/BS) value.
  */
@@ -41,7 +39,7 @@ class SetValue implements \JsonSerializable, \Countable, \IteratorAggregate
         return new \ArrayIterator($this->values);
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->toArray();

--- a/src/HandlerList.php
+++ b/src/HandlerList.php
@@ -305,6 +305,7 @@ class HandlerList implements \Countable
         return $prev;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->steps[self::INIT])

--- a/src/HasDataTrait.php
+++ b/src/HasDataTrait.php
@@ -24,6 +24,7 @@ trait HasDataTrait
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function & offsetGet($offset)
     {
         if (isset($this->data[$offset])) {
@@ -34,16 +35,19 @@ trait HasDataTrait
         return $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->data[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);

--- a/src/HasDataTrait.php
+++ b/src/HasDataTrait.php
@@ -10,6 +10,7 @@ trait HasDataTrait
     /** @var array */
     private $data = [];
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->data);

--- a/src/HasDataTrait.php
+++ b/src/HasDataTrait.php
@@ -53,6 +53,7 @@ trait HasDataTrait
         return $this->data;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);

--- a/src/History.php
+++ b/src/History.php
@@ -21,6 +21,7 @@ class History implements \Countable, \IteratorAggregate
         $this->maxEntries = $maxEntries;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->entries);

--- a/src/History.php
+++ b/src/History.php
@@ -27,6 +27,7 @@ class History implements \Countable, \IteratorAggregate
         return count($this->entries);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator(array_values($this->entries));

--- a/src/LruArrayCache.php
+++ b/src/LruArrayCache.php
@@ -72,6 +72,7 @@ class LruArrayCache implements CacheInterface, \Countable
         unset($this->items[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);

--- a/src/MockHandler.php
+++ b/src/MockHandler.php
@@ -139,6 +139,7 @@ class MockHandler implements \Countable
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->queue);


### PR DESCRIPTION
This PR implements more ReturnTypeWillChange attributes where type hints were added in PHP 8.1. 

I've also moved all use imports to the more easy to use inline usage so they can be more easily removed in a future version. I should have done that in my original PR as well. This will also be consistent with Laravel and Symfony.
