### PR TITLE
Actually set the key formInput for PostObjectV4

### DIFF
--- a/src/S3/PostObjectV4.php
+++ b/src/S3/PostObjectV4.php
@@ -67,7 +67,7 @@ class PostObjectV4
         ];
 
         // setup basic formInputs
-        $this->formInputs = $formInputs + ['key' => '${filename}'];
+        $this->formInputs = $formInputs + ['key' => $filename];
 
         // finalize policy and signature
 


### PR DESCRIPTION
*Description of changes:* The variable syntax will not work inside of singular quote marks, so just direct set the variable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
