### PR TITLE
Allow guzzlehttp/psr7 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
-        "guzzlehttp/psr7": "^1.7.0",
+        "guzzlehttp/psr7": "^1.7.0|^2.0",
         "guzzlehttp/promises": "^1.4.0",
         "mtdowling/jmespath.php": "^2.6",
         "ext-pcre": "*",


### PR DESCRIPTION
Issue https://github.com/aws/aws-sdk-php/issues/2300

# Changes
Allow guzzlehttp/psr7 2.0 to be installed if needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Closes https://github.com/aws/aws-sdk-php/issues/2300