### PR TITLE
Implements `__serialize()` and `__unserialize()` PHP 8.1 magic methods

### DIFF
--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -76,10 +76,20 @@ class Credentials implements CredentialsInterface, \Serializable
 
     public function serialize()
     {
-        return json_encode($this->toArray());
+        return $this->__serialize();
     }
 
     public function unserialize($serialized)
+    {
+        $this->__unserialize($serialized);
+    }
+
+    public function __serialize()
+    {
+        return json_encode($this->toArray());
+    }
+
+    public function __unserialize($serialized)
     {
         $data = json_decode($serialized, true);
 


### PR DESCRIPTION
This pull request addresses the issue https://github.com/aws/aws-sdk-php/issues/2307, by implementing the missing PHP 8.1  `__serialize()` and `__unserialize()` methods.