### PR TITLE
Added missed endpoint options

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -380,7 +380,9 @@ class S3Client extends AwsClient implements S3ClientInterface
                         'dual_stack' => $this->getConfig('use_dual_stack_endpoint'),
                         'accelerate' => $this->getConfig('use_accelerate_endpoint'),
                         'path_style' => $this->getConfig('use_path_style_endpoint'),
-
+                        'endpoint' => isset($args['endpoint'])
+                            ? $args['endpoint']
+                            : null,
                     ]
                 ),
                 's3.endpoint_middleware'


### PR DESCRIPTION
While I was trying to use aws s3 stream wrapper, it was not working with the path style where I am using a different endpoint for s3 service. 
Looking into S3EndpointMiddleware endpoint used, but it was not passed from s3Client, so I added it.

*Issue #, if available:* None

*Description of changes:*
The endpoint option is not used while creating wrap for S3EndpointMiddleware. This creates an issue when a developer wants to use a custom endpoint for s3. There is no way I can create an endpoint like http://localhost/bucketname/object/key

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
