### PR TITLE
Implements `__serialize()` and `__unserialize()` PHP 8.1 magic methods on `Aws\Credentials\Credentials` class

### DIFF
--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -76,13 +76,23 @@ class Credentials implements CredentialsInterface, \Serializable
 
     public function serialize()
     {
-        return json_encode($this->toArray());
+        return json_encode($this->__serialize());
     }
 
     public function unserialize($serialized)
     {
         $data = json_decode($serialized, true);
 
+        $this->__unserialize($data);
+    }
+
+    public function __serialize()
+    {
+        return $this->toArray();
+    }
+
+    public function __unserialize($data)
+    {
         $this->key = $data['key'];
         $this->secret = $data['secret'];
         $this->token = $data['token'];

--- a/tests/Credentials/CredentialsTest.php
+++ b/tests/Credentials/CredentialsTest.php
@@ -35,4 +35,26 @@ class CredentialsTest extends TestCase
             (new Credentials('foo', 'baz', 'tok', time() - 1000))->isExpired()
         );
     }
+
+    public function testSerialization()
+    {
+        $credentials = new Credentials('key-value', 'secret-value');
+        $actual = unserialize(serialize($credentials))->toArray();
+        $this->assertEquals([
+            'key'     => 'key-value',
+            'secret'  => 'secret-value',
+            'token'   => null,
+            'expires' => null,
+        ], $actual);
+
+        $credentials = new Credentials('key-value', 'secret-value', 'token-value', 10);
+        $actual = unserialize(serialize($credentials))->toArray();
+
+        $this->assertEquals([
+            'key'     => 'key-value',
+            'secret'  => 'secret-value',
+            'token'   => 'token-value',
+            'expires' => 10,
+        ], $actual);
+    }
 }


### PR DESCRIPTION
This pull request implements `__serialize()` and `__unserialize()` PHP 8.1 magic methods on `Aws\Credentials\Credentials` class. I've also added a few tests regarding serialization.