### PR TITLE
Fix issue where a float could be passed to gmdate, throwing an exception in PHP 8.1

### DIFF
--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -23,7 +23,11 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
      */
     public static function fromEpoch($unixTimestamp)
     {
-        return new self(gmdate('c', is_numeric($unixTimestamp) ? (int) $unixTimestamp : $unixTimestamp));
+        if (!is_numeric($unixTimestamp)) {
+            throw new ParserException('Invalid timestamp value passed to DateTimeResult::fromEpoch');
+        }
+
+        return new self(gmdate('c', (int) $unixTimestamp));
     }
 
     /**


### PR DESCRIPTION
Fixes #2327

Adds a coercion to int, which would have been the internal behaviour of the function pre-8.1. The test suite expects the code should fail when passed a string like "this text is not a date", therefore the `is_numeric` test and exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
