### PR TITLE
Fixes usage of `http_build_query` on PHP 8.1

### DIFF
--- a/src/Api/Serializer/QuerySerializer.php
+++ b/src/Api/Serializer/QuerySerializer.php
@@ -54,7 +54,7 @@ class QuerySerializer
             );
         }
 
-        $body = http_build_query($body, null, '&', PHP_QUERY_RFC3986);
+        $body = http_build_query($body, '', '&', PHP_QUERY_RFC3986);
 
         return new Request(
             'POST',

--- a/src/CloudFront/UrlSigner.php
+++ b/src/CloudFront/UrlSigner.php
@@ -64,7 +64,7 @@ class UrlSigner
             $policy
         );
         $uri = $uri->withQuery(
-            http_build_query($query + $signature, null, '&', PHP_QUERY_RFC3986)
+            http_build_query($query + $signature, '', '&', PHP_QUERY_RFC3986)
         );
 
         return $scheme === 'rtmp'


### PR DESCRIPTION
This pull request addresses the error `Passing null to parameter #2 ($numeric_prefix) of type string is deprecated` that gets thrown when using this library with PHP 8.1.