### PR TITLE
Fix DateTimeResult on PHP 8.1

### DIFF
--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -3,6 +3,8 @@
 namespace Aws\Api;
 
 use Aws\Api\Parser\Exception\ParserException;
+use DateTime;
+use DateTimeZone;
 use Exception;
 
 /**
@@ -16,19 +18,34 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
      * The Unix epoch (or Unix time or POSIX time or Unix
      * timestamp) is the number of seconds that have elapsed since
      * January 1, 1970 (midnight UTC/GMT).
-     * @param $unixTimestamp
      *
      * @return DateTimeResult
      * @throws Exception
      */
     public static function fromEpoch($unixTimestamp)
     {
-        return new self(gmdate('c', $unixTimestamp));
+        if (!is_numeric($unixTimestamp)) {
+            throw new ParserException('Invalid timestamp value passed to DateTimeResult::fromEpoch');
+        }
+
+        // PHP 5.5 does not support sub-second precision
+        if (\PHP_VERSION_ID < 56000) {
+            return new self(gmdate('c', $unixTimestamp));
+        }
+
+        $dateTime = DateTime::createFromFormat('U.u', sprintf('%0.6f', $unixTimestamp), new DateTimeZone('UTC'));
+
+        if (false === $dateTime) {
+            throw new ParserException('Invalid timestamp value passed to DateTimeResult::fromEpoch');
+        }
+
+        return new self(
+            $dateTime->format('Y-m-d H:i:s.u'),
+            new DateTimeZone('UTC')
+        );
     }
 
     /**
-     * @param $iso8601Timestamp
-     *
      * @return DateTimeResult
      */
     public static function fromISO8601($iso8601Timestamp)
@@ -36,16 +53,15 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
         if (is_numeric($iso8601Timestamp) || !is_string($iso8601Timestamp)) {
             throw new ParserException('Invalid timestamp value passed to DateTimeResult::fromISO8601');
         }
+
         return new DateTimeResult($iso8601Timestamp);
     }
 
     /**
      * Create a new DateTimeResult from an unknown timestamp.
      *
-     * @param $timestamp
-     *
      * @return DateTimeResult
-     * @throws ParserException|Exception
+     * @throws Exception
      */
     public static function fromTimestamp($timestamp, $expectedFormat = null)
     {
@@ -92,7 +108,7 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
     /**
      * Serialize the date as an ISO 8601 date when serializing as JSON.
      *
-     * @return mixed|string
+     * @return string
      */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()

--- a/tests/Api/DateTimeResultTest.php
+++ b/tests/Api/DateTimeResultTest.php
@@ -13,7 +13,15 @@ class DateTimeResultTest extends TestCase
     {
         $t = time();
         $d = DateTimeResult::fromEpoch($t);
-        $this->assertSame((string)$t, $d->format('U'));
+        $this->assertSame((string) $t, $d->format('U'));
+    }
+
+    public function testCreatesFromEpochFloat()
+    {
+        $t = 16344171.123432;
+        $d = DateTimeResult::fromEpoch($t);
+        $this->assertSame('16344171', $d->format('U'));
+        $this->assertSame(\PHP_VERSION_ID < 56000 ? '16344171.000000' : '16344171.123432', $d->format('U.u'));
     }
 
     public function testCastToIso8601String()


### PR DESCRIPTION
Fixes #2327. Replaces #2331.