### PR TITLE
Fixes for PHP 8.1 compatibility

### DIFF
--- a/build/docs/classes/ShapeIterator.php
+++ b/build/docs/classes/ShapeIterator.php
@@ -49,26 +49,31 @@ class ShapeIterator implements \Iterator
         $this->rewind();
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->shapes[$this->index];
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->index++;
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->index;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->shapes[$this->index]);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->index = 0;

--- a/src/Api/Parser/DecodingEventStreamIterator.php
+++ b/src/Api/Parser/DecodingEventStreamIterator.php
@@ -172,6 +172,7 @@ class DecodingEventStreamIterator implements Iterator
     /**
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->currentEvent;
@@ -180,11 +181,13 @@ class DecodingEventStreamIterator implements Iterator
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->key;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->currentPosition = $this->stream->tell();
@@ -194,6 +197,7 @@ class DecodingEventStreamIterator implements Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->stream->rewind();
@@ -205,6 +209,7 @@ class DecodingEventStreamIterator implements Iterator
     /**
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->currentPosition < $this->stream->getSize();

--- a/src/Api/Parser/EventParsingIterator.php
+++ b/src/Api/Parser/EventParsingIterator.php
@@ -33,26 +33,31 @@ class EventParsingIterator implements Iterator
         $this->parser = $parser;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->parseEvent($this->decodingIterator->current());
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->decodingIterator->key();
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->decodingIterator->next();
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->decodingIterator->rewind();
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->decodingIterator->valid();

--- a/src/CloudTrail/LogFileIterator.php
+++ b/src/CloudTrail/LogFileIterator.php
@@ -127,6 +127,7 @@ class LogFileIterator extends \IteratorIterator
      *
      * @return array|bool
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($object = parent::current()) {

--- a/src/ResultPaginator.php
+++ b/src/ResultPaginator.php
@@ -101,21 +101,25 @@ class ResultPaginator implements \Iterator
     /**
      * @return Result
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->valid() ? $this->result : false;
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->valid() ? $this->requestCount - 1 : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->result = null;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if ($this->result) {
@@ -134,6 +138,7 @@ class ResultPaginator implements \Iterator
         return false;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->requestCount = 0;

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -324,11 +324,11 @@ class SignatureV4 implements SignatureInterface
         ksort($query);
         foreach ($query as $k => $v) {
             if (!is_array($v)) {
-                $qs .= rawurlencode($k) . '=' . rawurlencode($v) . '&';
+                $qs .= rawurlencode($k ?? '') . '=' . rawurlencode($v ?? '') . '&';
             } else {
                 sort($v);
                 foreach ($v as $value) {
-                    $qs .= rawurlencode($k) . '=' . rawurlencode($value) . '&';
+                    $qs .= rawurlencode($k ?? '') . '=' . rawurlencode($value ?? '') . '&';
                 }
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds several fixes for PHP 8.1. compatibility.

1.
In PHP 8.1, >> non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation.
RFC: https://wiki.php.net/rfc/internal_method_return_types

Because of this, we receive multiple deprecation notices when running our code with PHP8.1.

This PR adds #[ReturnTypeWillChange] attribute where it is needed, in order to avoid the described problem and keep backward compatibility.

2.
In 8.1 it's [deprecated](https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg) to pass `null` to non-nullable arguments of internal functions.
We're receiving such a warning in our logs:
`aws/aws-sdk-php/src/Signature/SignatureV4.php:327 rawurlencode(): Passing null to parameter #1 ($string) of type string is deprecated`

This PR adds an additional checking for null in a problematic place.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
