### PR TITLE
Add missing PHPDoc annotations for `ArrayAccess` and `Countable` implementations

### DIFF
--- a/.changes/nextrelease/enhancement-add-missing-phpdoc-annotations
+++ b/.changes/nextrelease/enhancement-add-missing-phpdoc-annotations
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Add missing PHPDoc annotations for ArrayAccess and Countable implementations."
+    }
+]

--- a/src/Api/AbstractModel.php
+++ b/src/Api/AbstractModel.php
@@ -27,6 +27,9 @@ abstract class AbstractModel implements \ArrayAccess
         return $this->definition;
     }
 
+    /**
+     * @return mixed|null
+     */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
@@ -34,18 +37,27 @@ abstract class AbstractModel implements \ArrayAccess
             ? $this->definition[$offset] : null;
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->definition[$offset] = $value;
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->definition[$offset]);
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {

--- a/src/Crypto/MetadataEnvelope.php
+++ b/src/Crypto/MetadataEnvelope.php
@@ -38,6 +38,7 @@ class MetadataEnvelope implements ArrayAccess, IteratorAggregate, JsonSerializab
         return array_keys(self::$constants);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {
         $constants = self::getConstantValues();

--- a/src/Crypto/MetadataEnvelope.php
+++ b/src/Crypto/MetadataEnvelope.php
@@ -38,6 +38,9 @@ class MetadataEnvelope implements ArrayAccess, IteratorAggregate, JsonSerializab
         return array_keys(self::$constants);
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetSet($name, $value)
     {

--- a/src/DynamoDb/SetValue.php
+++ b/src/DynamoDb/SetValue.php
@@ -27,6 +27,9 @@ class SetValue implements \JsonSerializable, \Countable, \IteratorAggregate
         return $this->values;
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {

--- a/src/HandlerList.php
+++ b/src/HandlerList.php
@@ -305,6 +305,9 @@ class HandlerList implements \Countable
         return $prev;
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {

--- a/src/HasDataTrait.php
+++ b/src/HasDataTrait.php
@@ -10,6 +10,9 @@ trait HasDataTrait
     /** @var array */
     private $data = [];
 
+    /**
+     * @return \Traversable
+     */
     #[\ReturnTypeWillChange]
     public function getIterator()
     {
@@ -35,18 +38,27 @@ trait HasDataTrait
         return $value;
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->data[$offset] = $value;
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
@@ -58,6 +70,9 @@ trait HasDataTrait
         return $this->data;
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {

--- a/src/History.php
+++ b/src/History.php
@@ -21,6 +21,9 @@ class History implements \Countable, \IteratorAggregate
         $this->maxEntries = $maxEntries;
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {

--- a/src/LruArrayCache.php
+++ b/src/LruArrayCache.php
@@ -72,6 +72,9 @@ class LruArrayCache implements CacheInterface, \Countable
         unset($this->items[$key]);
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {


### PR DESCRIPTION
While upgrading to Symfony 5.4 I noticed the follow reported deprecations:

* Method `ArrayAccess::offsetExists()` might add `bool` as a native return type declaration in the future. Do the same in implementation `Aws\Api\AbstractModel` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* Method `ArrayAccess::offsetExists()` might add `bool` as a native return type declaration in the future. Do the same in implementation `Aws\Endpoint\Partition` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* Method `ArrayAccess::offsetGet()` might add `mixed` as a native return type declaration in the future. Do the same in implementation `Aws\Api\AbstractModel` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* Method `ArrayAccess::offsetSet()` might add `void` as a native return type declaration in the future. Do the same in implementation `Aws\Api\AbstractModel` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* Method `ArrayAccess::offsetSet()` might add `void` as a native return type declaration in the future. Do the same in implementation `Aws\Endpoint\Partition` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* Method `ArrayAccess::offsetUnset()` might add `void` as a native return type declaration in the future. Do the same in implementation `Aws\Api\AbstractModel` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* Method `ArrayAccess::offsetUnset()` might add `void` as a native return type declaration in the future. Do the same in implementation `Aws\Endpoint\Partition` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* Method `Countable::count()` might add `int` as a native return type declaration in the future. Do the same in implementation `Aws\HandlerList` now to avoid errors or add an explicit `@return` annotation to suppress this message.