### PR TITLE
fixed "hash_init(): Passing null to parameter #3 ($key) of type string is deprecated

### DIFF
--- a/src/PhpHash.php
+++ b/src/PhpHash.php
@@ -68,7 +68,7 @@ class PhpHash implements HashInterface
     private function getContext()
     {
         if (!$this->context) {
-            $key = isset($this->options['key']) ? $this->options['key'] : null;
+            $key = isset($this->options['key']) ? $this->options['key'] : '';
             $this->context = hash_init(
                 $this->algo,
                 $key ? HASH_HMAC : 0,


### PR DESCRIPTION
… in PhpHash::getContext()

*Description of changes:*

The signature of `hash_init` is defined as `hash_init(string $algo, int $flags = 0, string $key = "", array $options = []): HashContext`

So if no key is needed the argument should either be skipped or an empty string but not `NULL`.
Passing `NULL` is deprecated since PHP 8.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
