### PR TITLE
Update RestSerializer.php

### DIFF
--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -217,7 +217,7 @@ abstract class RestSerializer
         // If endpoint has path, remove leading '/' to preserve URI resolution.
         $path = $this->endpoint->getPath();
         if ($path && $relative[0] === '/') {
-            $relative = substr($relative, 1);
+            $relative = substr($path.$relative, 1);
         }
 
         // Expand path place holders using Amazon's slightly different URI


### PR DESCRIPTION
Hello,

When I use the class "ApiGatewayManagementApiClient" with the URL generated by api gateway (ex.: https://xxxxxxxxx.execute-api.us-east-2.amazonaws.com/dev) the response is "(client) Forbidden",

I'm using the postToConnection() method and I noticed that the url generated by the aws sdk was stripping the "stage" from the like "https://ixe7e2mjfl.execute-api.us-east-2.amazonaws.com/@connections/OBZeGcyKCYcCGng=" where the correct would be  "https://ixe7e2mjfl.execute-api.us-east-2.amazonaws.com/dev/@connections/OBZeGcyKCYcCGng=".. debugging the aws sdk i find the solution proposed in Pull-Request.