### PR TITLE
[PHP 8.1] fixed "hash_init(): Passing null to parameter #3 ($key) of type string is deprecated

### DIFF
--- a/.changes/nextrelease/bugfix-php81-hash_init
+++ b/.changes/nextrelease/bugfix-php81-hash_init
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "",
+        "description": "Passing null to hash_init is deprecated on PHP 8.1."
+    }
+]

--- a/src/PhpHash.php
+++ b/src/PhpHash.php
@@ -68,7 +68,7 @@ class PhpHash implements HashInterface
     private function getContext()
     {
         if (!$this->context) {
-            $key = isset($this->options['key']) ? $this->options['key'] : null;
+            $key = isset($this->options['key']) ? $this->options['key'] : '';
             $this->context = hash_init(
                 $this->algo,
                 $key ? HASH_HMAC : 0,


### PR DESCRIPTION
Retry of #2365 that includes required changelog document