### PR TITLE
Allows Cloudshell to acquire perm from AWS_CONTAINER_CREDENTIALS_FULL v2

### DIFF
--- a/.changes/nextrelease/ecsenvvars.json
+++ b/.changes/nextrelease/ecsenvvars.json
@@ -2,7 +2,7 @@
   {
     "type": "feature",
     "category": "Credentials",
-    "description": "Add support for full uri and auth token environment variables"
+    "description": "Add support for ECS full uri and auth token environment variables"
   }
 ]
 

--- a/.changes/nextrelease/ecsenvvars.json
+++ b/.changes/nextrelease/ecsenvvars.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "feature",
+    "category": "Credentials",
+    "description": "Add support for full uri and auth token environment variables"
+  }
+]
+

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -7,7 +7,6 @@ use Aws\CacheInterface;
 use Aws\Exception\CredentialsException;
 use Aws\Sts\StsClient;
 use GuzzleHttp\Promise;
-
 /**
  * Credential providers are functions that accept no arguments and return a
  * promise that is fulfilled with an {@see \Aws\Credentials\CredentialsInterface}
@@ -112,26 +111,7 @@ class CredentialProvider
             );
         }
 
-        $shouldUseEcsCredentialsProvider = getenv(EcsCredentialProvider::ENV_URI);
-        // getenv() is not thread safe - fall back to $_SERVER
-        if ($shouldUseEcsCredentialsProvider === false) {
-            $shouldUseEcsCredentialsProvider = isset($_SERVER[EcsCredentialProvider::ENV_URI])
-                ? $_SERVER[EcsCredentialProvider::ENV_URI]
-                : false;
-        }
-        
-        if($shouldUseEcsCredentialsProvider === false){
-            //check along ENV_FULL_URI
-            $shouldUseEcsCredentialsProvider = getenv(EcsCredentialProvider::ENV_FULL_URI);
-            // getenv() is not thread safe - fall back to $_SERVER
-            if ($shouldUseEcsCredentialsProvider === false) {
-                $shouldUseEcsCredentialsProvider = isset($_SERVER[EcsCredentialProvider::ENV_FULL_URI])
-                    ? $_SERVER[EcsCredentialProvider::ENV_FULL_URI]
-                    : false;
-            }
-        }
-
-        if (!empty($shouldUseEcsCredentialsProvider)) {
+        if (self::shouldUseEcs()) {
             $defaultChain['ecs'] = self::ecsCredentials($config);
         } else {
             $defaultChain['instance'] = self::instanceProfile($config);
@@ -905,6 +885,19 @@ class CredentialProvider
                 (self::getHomeDir() . '/.aws/credentials');
         }
         return $filename;
+    }
+
+    /**
+     * @return boolean
+     */
+    private static function shouldUseEcs()
+    {
+        //Check for relative uri. if not, then full uri.
+        //fall back to server for each as getenv is not thread-safe.
+        return !empty(getenv(EcsCredentialProvider::ENV_URI))
+        || !empty($_SERVER[EcsCredentialProvider::ENV_URI])
+        || !empty(getenv(EcsCredentialProvider::ENV_FULL_URI))
+        || !empty($_SERVER[EcsCredentialProvider::ENV_FULL_URI]);
     }
 }
 

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -890,7 +890,7 @@ class CredentialProvider
     /**
      * @return boolean
      */
-    private static function shouldUseEcs()
+    public static function shouldUseEcs()
     {
         //Check for relative uri. if not, then full uri.
         //fall back to server for each as getenv is not thread-safe.

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -111,6 +111,10 @@ class EcsCredentialProvider
 
         if(empty($credsUri)){
             $credFullUri = getenv(self::ENV_FULL_URI);
+            if($credFullUri === false){
+                $credFullUri = isset($_SERVER[self::ENV_FULL_URI]) ? $_SERVER[self::ENV_FULL_URI] : '';
+            }
+
             if(!empty($credFullUri))
                 return $credFullUri;
         }

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -57,11 +57,7 @@ class EcsCredentialProvider
         $client = $this->client;
         $request = new Request('GET', self::getEcsUri());
         
-        $authToken = self::getEcsAuthToken();
-        $headers = [];
-        if(!empty($authToken))
-            $headers = ['Authorization' => $authToken];
-        
+        $headers = $this->setHeaderForAuthToken();
         return $client(
             $request,
             [
@@ -89,6 +85,15 @@ class EcsCredentialProvider
     private function getEcsAuthToken()
     {
         return getenv(self::ENV_AUTH_TOKEN);
+    }
+
+    public function setHeaderForAuthToken(){
+        $authToken = self::getEcsAuthToken();
+        $headers = [];
+        if(!empty($authToken))
+            $headers = ['Authorization' => $authToken];
+
+        return $headers;
     }
 
     /**

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -103,14 +103,16 @@ class EcsCredentialProvider
      */
     private function getEcsUri()
     {
-        $credFullUri = getenv(self::ENV_FULL_URI);
-        if(!empty($credFullUri))
-            return $credFullUri;
-        
         $credsUri = getenv(self::ENV_URI);
 
         if ($credsUri === false) {
             $credsUri = isset($_SERVER[self::ENV_URI]) ? $_SERVER[self::ENV_URI] : '';
+        }
+
+        if(empty($credsUri)){
+            $credFullUri = getenv(self::ENV_FULL_URI);
+            if(!empty($credFullUri))
+                return $credFullUri;
         }
         
         return self::SERVER_URI . $credsUri;

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1817,7 +1817,6 @@ EOT;
             'process_credentials',
             'process_config',
             'ecs',
-            'ecs_cloudshell',
             'instance'
         ];
 
@@ -1826,11 +1825,6 @@ EOT;
             $this->clearEnv();
 
             if ($provider == 'ecs') putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=/latest');
-            else if ($provider == 'ecs_cloudshell'){
-                putenv('AWS_CONTAINER_CREDENTIALS_FULL_URI=http://localhost/test/metadata');
-                putenv('AWS_CONTAINER_AUTHORIZATION_TOKEN=1AAA+BBBBB=');
-                $provider = 'ecs';
-            }
             $cache = new LruArrayCache;
             $cache->set('aws_cached_' . $provider . '_credentials', $credsForCache);
             $credentials = call_user_func(CredentialProvider::defaultProvider([

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1922,4 +1922,37 @@ EOT;
         unlink($dir . '/config');
         $this->assertSame('configFoo', $creds->getAccessKeyId());
     }
+
+    /**
+     * @dataProvider shouldUseEcsProvider
+     *
+     * @param string $relative
+     * @param string $serverRelative
+     * @param string $full
+     * @param string $serverFull
+     * @param bool $expected
+     */
+    public function testShouldUseEcs(
+        $relative, $serverRelative, $full, $serverFull, $expected
+    )
+    {
+        $this->clearEnv();
+        putenv('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' . $relative);
+        $_SERVER['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = $serverRelative;
+        putenv('AWS_CONTAINER_CREDENTIALS_FULL_URI' . $full);
+        $_SERVER['AWS_CONTAINER_CREDENTIALS_FULL_URI'] = $serverFull;
+        $result = CredentialProvider::shouldUseEcs();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function shouldUseEcsProvider()
+    {
+        return [
+            ['=foo', '', '', '', true],
+            ['', 'foo', '', '', true],
+            ['', '', '=bar', '', true],
+            ['', '', '', 'bar', true],
+            ['', '', '', '', false]
+        ];
+    }
 }

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -86,6 +86,20 @@ class EcsCredentialProviderTest extends TestCase
         new EcsCredentialProvider();
     }
 
+    public function testRequestHeaderWithAuthorisationKey(){
+        $this->clearEnv();
+        $provider = new EcsCredentialProvider();
+
+        $TOKEN_VALUE = "GA%24102391AAA+BBBBB4==";
+        $AUTH_KEYNAME = 'Authorization';
+        putenv(EcsCredentialProvider::ENV_FULL_URI . '=http://localhost/test/metadata');
+        putenv(EcsCredentialProvider::ENV_AUTH_TOKEN . '=' . $TOKEN_VALUE);
+
+        $header = $provider->setHeaderForAuthToken();
+        $this->assertArrayHasKey($AUTH_KEYNAME, $header);
+        $this->assertSame($TOKEN_VALUE, $header[$AUTH_KEYNAME]);
+    }
+
     private function getCredentialArray(
         $key, $secret, $token = null, $time = null, $success = true
     ){


### PR DESCRIPTION
*Issue #2323 , if available:*

*Description of changes:*
Added supports for AWS_CONTAINER_CREDENTIALS_FULL_URI in EcsCredentialProvider.php, this will allows aws-php-sdk to works with CloudShell correctly. Permission in Cloudshell to follow IAM User.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
