### PR TITLE
Fix PHP 7.4+ deprecation in src/S3/ApplyChecksumMiddleware.php

### DIFF
--- a/src/S3/ApplyChecksumMiddleware.php
+++ b/src/S3/ApplyChecksumMiddleware.php
@@ -83,7 +83,7 @@ class ApplyChecksumMiddleware
                 throw new InvalidArgumentException(
                     "Unsupported algorithm supplied for input variable {$checksumMemberName}."
                     . "  Supported checksums for this operation include: "
-                    . implode($supportedAlgorithms, ", ") . "."
+                    . implode(", ", $supportedAlgorithms) . "."
                 );
             }
             return $next($command, $request);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* fix PHP 7.4+ deprecation - "Passing the $glue and $pieces parameters in reverse order to implode has been deprecated since PHP 7.4"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
