### PR TITLE
Fix: warning when passing null as parameter to ucfirst() in Ec2ParamB…

### DIFF
--- a/src/Api/Serializer/Ec2ParamBuilder.php
+++ b/src/Api/Serializer/Ec2ParamBuilder.php
@@ -12,7 +12,7 @@ class Ec2ParamBuilder extends QueryParamBuilder
     protected function queryName(Shape $shape, $default = null)
     {
         return ($shape['queryName']
-            ?: ucfirst($shape['locationName']))
+                    ?: ( isset($shape['locationName']) ? ucfirst($shape['locationName']) : null) )
                 ?: $default;
     }
 


### PR DESCRIPTION
…uilder.php

From src/Api\Serializer/Ec2ParamBuilder.php ucfirst() function is being call with the posibility of passing null as parameter, which could cause a warning if using PHP>=8.1 due that passing null to a function parameter not declared nullable throws a deprecation warning in this php version. To prevent this warning from happening, what I did was to make sure that when calling ucfirst() the variable has value in it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
