### PR TITLE
Add serializer and parser tests

### DIFF
--- a/tests/Api/ServiceTest.php
+++ b/tests/Api/ServiceTest.php
@@ -180,9 +180,14 @@ class ServiceTest extends TestCase
     /**
      * @dataProvider serializerDataProvider
      */
-    public function testCreatesSerializer($type, $parser)
+    public function testCreatesSerializer($type, $cl)
     {
-
+        $service = new Service(
+            ['metadata' => ['protocol' => $type]],
+            function () { return []; }
+        );
+        $serializer = Service::createSerializer($service, $type);
+        $this->assertInstanceOf($cl, $serializer);
     }
 
     public function parserDataProvider()
@@ -191,16 +196,21 @@ class ServiceTest extends TestCase
             ['json', 'Aws\Api\Parser\JsonRpcParser'],
             ['rest-json', 'Aws\Api\Parser\RestJsonParser'],
             ['rest-xml', 'Aws\Api\Parser\RestXmlParser'],
-            ['query', 'Aws\Api\Parser\XmlParser'],
-            ['ec2', 'Aws\Api\Parser\XmlParser'],
+            ['query', 'Aws\Api\Parser\QueryParser'],
+            ['ec2', 'Aws\Api\Parser\QueryParser'],
         ];
     }
 
     /**
      * @dataProvider parserDataProvider
      */
-    public function testCreatesParsers($type, $parser)
+    public function testCreatesParsers($type, $cl)
     {
-
+        $service = new Service(
+            ['metadata' => ['protocol' => $type]],
+            function () { return []; }
+        );
+        $parser = Service::createParser($service);
+        $this->assertInstanceOf($cl, $parser);
     }
 }

--- a/tests/Api/ServiceTest.php
+++ b/tests/Api/ServiceTest.php
@@ -6,6 +6,7 @@ use Aws\Api\StructureShape;
 use Aws\Test\TestServiceTrait;
 use Aws\Test\UsesServiceTrait;
 use PHPUnit\Framework\TestCase;
+use Aws\Api\Parser\QueryParser;
 
 /**
  * @covers \Aws\Api\Service
@@ -212,5 +213,11 @@ class ServiceTest extends TestCase
         );
         $parser = Service::createParser($service);
         $this->assertInstanceOf($cl, $parser);
+
+        if ($parser instanceof QueryParser) {
+            $this->assertAttributeInstanceOf(
+                'Aws\Api\Parser\XmlParser', 'parser', $parser
+            );
+        }
     }
 }

--- a/tests/Api/ServiceTest.php
+++ b/tests/Api/ServiceTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace Aws\Test\Api;
 
+use Aws\Api\Parser\QueryParser;
 use Aws\Api\Service;
 use Aws\Api\StructureShape;
 use Aws\Test\TestServiceTrait;
 use Aws\Test\UsesServiceTrait;
 use PHPUnit\Framework\TestCase;
-use Aws\Api\Parser\QueryParser;
 
 /**
  * @covers \Aws\Api\Service


### PR DESCRIPTION
*Description of changes:*
Adds missing serializer and parser creation tests for `Aws\Api\Service`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
