### PR TITLE
chore: re-enable sessionhandler unit test

### DIFF
--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -23,9 +23,9 @@ class DynamoDbClientTest extends TestCase
     public function testRegisterSessionHandlerReturnsHandler()
     {
         $client = $this->getTestSdk()->createDynamoDb();
-        @$sh = $client->registerSessionHandler();
+        @$sh = $client->registerSessionHandler(['locking' => true]);
         $this->assertAttributeInstanceOf(
-            'Aws\DynamoDb\StandardSessionConnection',
+            'Aws\DynamoDb\LockingSessionConnection',
             'connection', $sh
         );
     }

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -23,11 +23,7 @@ class DynamoDbClientTest extends TestCase
 
     public function testRegisterSessionHandlerReturnsHandler()
     {
-        $client = $this->getMockBuilder('Aws\DynamoDb\DynamoDbClient')
-            ->setMethodsExcept(['registerSessionHandler'])
-            ->disableOriginalConstructor()
-            ->getMock();
-
+        $client = $this->getTestSdk()->createDynamoDb();
         @$sh = $client->registerSessionHandler();
         $this->assertAttributeInstanceOf(
             'Aws\DynamoDb\StandardSessionConnection',

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -12,7 +12,6 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_Error_Warning;
 
 /**
  * @covers \Aws\DynamoDb\DynamoDbClient

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -21,7 +21,6 @@ class DynamoDbClientTest extends TestCase
     use UsesServiceTrait;
 
     /**
-     * @preserveGlobalState disabled
      * @runInSeparateProcess
      */
     public function testRegisterSessionHandlerReturnsHandler()

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_Error_Warning;
 
 /**
  * @covers \Aws\DynamoDb\DynamoDbClient
@@ -20,16 +21,17 @@ class DynamoDbClientTest extends TestCase
 {
     use UsesServiceTrait;
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testRegisterSessionHandlerReturnsHandler()
     {
-        $client = $this->getTestSdk()->createDynamoDb();
-        $sh = $client->registerSessionHandler(['locking' => true]);
-        $this->assertInstanceOf(
-            'Aws\DynamoDb\LockingSessionConnection',
-            $this->readAttribute($sh, 'connection')
+        $client = $this->getMockBuilder('Aws\DynamoDb\DynamoDbClient')
+            ->setMethodsExcept(['registerSessionHandler'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        @$sh = $client->registerSessionHandler();
+        $this->assertAttributeInstanceOf(
+            'Aws\DynamoDb\StandardSessionConnection',
+            'connection', $sh
         );
     }
 

--- a/tests/DynamoDb/DynamoDbClientTest.php
+++ b/tests/DynamoDb/DynamoDbClientTest.php
@@ -20,9 +20,12 @@ class DynamoDbClientTest extends TestCase
 {
     use UsesServiceTrait;
 
+    /**
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     */
     public function testRegisterSessionHandlerReturnsHandler()
     {
-        $this->markTestSkipped();
         $client = $this->getTestSdk()->createDynamoDb();
         $sh = $client->registerSessionHandler(['locking' => true]);
         $this->assertInstanceOf(


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Because global state is preserved by default when running a test in a separate process, added annotation to disable this behavior for testing purposes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
