### PR TITLE
Fix `Implicit conversion from float` warning PHP

### DIFF
--- a/src/Retry/RateLimiter.php
+++ b/src/Retry/RateLimiter.php
@@ -101,7 +101,7 @@ class RateLimiter
         $this->refillTokenBucket();
 
         if ($amount > $this->currentCapacity) {
-            usleep(1000000 * ($amount - $this->currentCapacity) / $this->fillRate);
+            usleep((int) (1000000 * ($amount - $this->currentCapacity) / $this->fillRate));
         }
 
         $this->currentCapacity -= $amount;


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:*
Fix a warning in PHP8. `Implicit conversion from float 1785690.2054377967 to int loses precision in ...`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
