### PR TITLE
feat: doesObjectExist and doesBucketExist v2

### DIFF
--- a/.changes/nextrelease/existence-methods.json
+++ b/.changes/nextrelease/existence-methods.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "S3",
+    "description": "New bucket and object existence helper methods."
+  }
+]

--- a/.changes/nextrelease/existence-methods.json
+++ b/.changes/nextrelease/existence-methods.json
@@ -2,6 +2,6 @@
   {
     "type": "feature",
     "category": "S3",
-    "description": "New bucket and object existence helper methods."
+    "description": "Adds DoesBucketExistV2 and DoesObjectExistV2 helper methods"
   }
 ]

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -41,6 +41,8 @@ interface S3ClientInterface extends AwsClientInterface
     public function getObjectUrl($bucket, $key);
 
     /**
+     * @deprecated Use doesBucketExistV2() instead
+     *
      * Determines whether or not a bucket exists by name.
      *
      * @param string $bucket  The name of the bucket
@@ -50,6 +52,8 @@ interface S3ClientInterface extends AwsClientInterface
     public function doesBucketExist($bucket);
 
     /**
+     * @deprecated
+     *
      * Determines whether or not a bucket exists by name. This method uses S3's
      * HeadBucket operation and requires the relevant bucket permissions in the
      * default case to avoid inaccuracies.
@@ -66,6 +70,8 @@ interface S3ClientInterface extends AwsClientInterface
     public function doesBucketExistV2($bucket, $accept403);
 
     /**
+     * @deprecated Use doesObjectExistV2() instead
+     *
      * Determines whether or not an object exists by name.
      *
      * @param string $bucket  The name of the bucket

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -52,8 +52,6 @@ interface S3ClientInterface extends AwsClientInterface
     public function doesBucketExist($bucket);
 
     /**
-     * @deprecated
-     *
      * Determines whether or not a bucket exists by name. This method uses S3's
      * HeadBucket operation and requires the relevant bucket permissions in the
      * default case to avoid inaccuracies.

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -52,8 +52,8 @@ interface S3ClientInterface extends AwsClientInterface
      * Determines whether or not a bucket exists by name.
      *
      * @param string $bucket  The name of the bucket
-     * @param bool $accept403 Changes behavior to return true in the case of a 403. Bucket
-     *                        permissions and credentials MUST be correct to avoid inaccuracies.
+     * @param bool $accept403 Changes behavior to return true in the case of a 403.
+     *                        credentials MUST be correct to avoid inaccuracies.
      *
      * @return bool
      */

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -4,6 +4,7 @@ namespace Aws\S3;
 use Aws\AwsClientInterface;
 use Aws\CommandInterface;
 use Aws\ResultInterface;
+use Aws\S3\Exception\S3Exception;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -49,13 +50,18 @@ interface S3ClientInterface extends AwsClientInterface
     public function doesBucketExist($bucket);
 
     /**
-     * Determines whether or not a bucket exists by name.
+     * Determines whether or not a bucket exists by name. This method uses S3's
+     * HeadBucket operation and requires the relevant bucket permissions in the
+     * default case to avoid inaccuracies.
      *
      * @param string $bucket  The name of the bucket
-     * @param bool $accept403 Changes behavior to return true in the case of a 403.
-     *                        credentials MUST be correct to avoid inaccuracies.
+     * @param bool $accept403 Set to true for this method to return true in the case of
+     *                        invalid bucket-level permissions. Credentials MUST be valid
+     *                        to avoid inaccuracies. Using the default value of false will
+     *                        cause an exception to be thrown instead.
      *
      * @return bool
+     * @throws S3Exception|Exception if there is an unhandled exception
      */
     public function doesBucketExistV2($bucket, $accept403);
 
@@ -72,16 +78,20 @@ interface S3ClientInterface extends AwsClientInterface
     public function doesObjectExist($bucket, $key, array $options = []);
 
     /**
-     * Determines whether or not an object exists by name.
+     * Determines whether or not an object exists by name. This method uses S3's HeadObject
+     * operation and requires the relevant bucket and object permissions to avoid inaccuracies.
      *
      * @param string $bucket The name of the bucket
      * @param string $key The key of the object
-     * @param bool $includeDeleteMarkers Optional flag that will consider delete markers
-     *                                   existing objects
+     * @param bool $includeDeleteMarkers Set to true to consider delete markers
+     *                                   existing objects. Using the default value
+     *                                   of false will ignore delete markers and
+     *                                   return false.
      * @param array $options Additional options available in the HeadObject
      *                        operation (e.g., VersionId).
      *
      * @return bool
+     * @throws S3Exception|Exception if there is an unhandled exception
      */
     public function doesObjectExistV2($bucket, $key, $includeDeleteMarkers, array $options = []);
 

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -54,7 +54,7 @@ interface S3ClientInterface extends AwsClientInterface
     /**
      * Determines whether or not a bucket exists by name. This method uses S3's
      * HeadBucket operation and requires the relevant bucket permissions in the
-     * default case to avoid inaccuracies.
+     * default case to prevent errors.
      *
      * @param string $bucket  The name of the bucket
      * @param bool $accept403 Set to true for this method to return true in the case of
@@ -83,7 +83,7 @@ interface S3ClientInterface extends AwsClientInterface
 
     /**
      * Determines whether or not an object exists by name. This method uses S3's HeadObject
-     * operation and requires the relevant bucket and object permissions to avoid inaccuracies.
+     * operation and requires the relevant bucket and object permissions to prevent errors.
      *
      * @param string $bucket The name of the bucket
      * @param string $key The key of the object

--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -49,6 +49,17 @@ interface S3ClientInterface extends AwsClientInterface
     public function doesBucketExist($bucket);
 
     /**
+     * Determines whether or not a bucket exists by name.
+     *
+     * @param string $bucket  The name of the bucket
+     * @param bool $accept403 Changes behavior to return true in the case of a 403. Bucket
+     *                        permissions and credentials MUST be correct to avoid inaccuracies.
+     *
+     * @return bool
+     */
+    public function doesBucketExistV2($bucket, $accept403);
+
+    /**
      * Determines whether or not an object exists by name.
      *
      * @param string $bucket  The name of the bucket
@@ -59,6 +70,20 @@ interface S3ClientInterface extends AwsClientInterface
      * @return bool
      */
     public function doesObjectExist($bucket, $key, array $options = []);
+
+    /**
+     * Determines whether or not an object exists by name.
+     *
+     * @param string $bucket The name of the bucket
+     * @param string $key The key of the object
+     * @param bool $includeDeleteMarkers Optional flag that will consider delete markers
+     *                                   existing objects
+     * @param array $options Additional options available in the HeadObject
+     *                        operation (e.g., VersionId).
+     *
+     * @return bool
+     */
+    public function doesObjectExistV2($bucket, $key, $includeDeleteMarkers, array $options = []);
 
     /**
      * Register the Amazon S3 stream wrapper with this client instance.

--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -272,8 +272,9 @@ trait S3ClientTrait
             $this->execute($command);
             return true;
         } catch (S3Exception $e) {
-            if ($accept403 && $e->getStatusCode() === 403
+            if ($accept403 && ($e->getStatusCode() === 403
                 || $e instanceof PermanentRedirectException)
+            )
             {
                 return true;
             }

--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -272,8 +272,8 @@ trait S3ClientTrait
             $this->execute($command);
             return true;
         } catch (S3Exception $e) {
-            if ($accept403 && ($e->getStatusCode() === 403
-                || $e instanceof PermanentRedirectException)
+            if (($accept403 && $e->getStatusCode() === 403)
+                || $e instanceof PermanentRedirectException
             )
             {
                 return true;

--- a/src/S3/S3ClientTrait.php
+++ b/src/S3/S3ClientTrait.php
@@ -275,8 +275,7 @@ trait S3ClientTrait
             if (
                 ($accept403 && $e->getStatusCode() === 403)
                 || $e instanceof PermanentRedirectException
-            )
-            {
+            ) {
                 return true;
             }
             if ($e->getStatusCode() === 404)  {

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -9,6 +9,7 @@ use Aws\LruArrayCache;
 use Aws\Endpoint\PartitionEndpointProvider;
 use Aws\Middleware;
 use Aws\Result;
+use Aws\S3\Exception\PermanentRedirectException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\RegionalEndpoint\Configuration;
 use Aws\S3\S3Client;
@@ -232,6 +233,13 @@ class S3ClientTest extends TestCase
 
     public function doesExistProvider()
     {
+        $redirectException = new PermanentRedirectException(
+            '',
+            new Command('mockCommand'),
+            ['response' => new Response(301)]
+        );
+        $deleteMarkerMock = $this->getS3ErrorMock('Foo', 404, true);
+
         return [
             ['foo', null, true, []],
             ['foo', 'bar', true, []],
@@ -241,14 +249,27 @@ class S3ClientTest extends TestCase
             ['foo', 'bar', false, $this->getS3ErrorMock('Foo', 401)],
             ['foo', null, -1, $this->getS3ErrorMock('Foo', 500)],
             ['foo', 'bar', -1, $this->getS3ErrorMock('Foo', 500)],
+            ['foo', null, true, [], true],
+            ['foo', 'bar', true, [] , true],
+            ['foo', null, false, $this->getS3ErrorMock('Foo', 404), true],
+            ['foo', 'bar', false, $this->getS3ErrorMock('Foo', 404), true],
+            ['foo', null, -1, $this->getS3ErrorMock('Forbidden', 403), true],
+            ['foo', 'bar', -1, $this->getS3ErrorMock('Forbidden', 403), true],
+            ['foo', null, true, $this->getS3ErrorMock('Forbidden', 403), true, true],
+            ['foo', 'bar', true, $deleteMarkerMock, true, false, true],
+            ['foo', 'bar', false, $deleteMarkerMock, true, false, false],
+            ['foo', null, true, $redirectException, true],
         ];
     }
 
-    private function getS3ErrorMock($errCode, $statusCode)
+    private function getS3ErrorMock($errCode, $statusCode, $deleteMarker = false)
     {
+        $response = new Response($statusCode);
+        $deleteMarker && $response = $response->withHeader('x-amz-delete-marker', true);
+
         $context = [
             'code' => $errCode,
-            'response' => new Response($statusCode),
+            'response' => $response,
         ];
         return new S3Exception('', new Command('mockCommand'), $context);
     }
@@ -256,16 +277,32 @@ class S3ClientTest extends TestCase
     /**
      * @dataProvider doesExistProvider
      */
-    public function testsIfExists($bucket, $key, $exists, $result)
+    public function testsIfExists(
+        $bucket,
+        $key,
+        $exists,
+        $result,
+        $V2 = false,
+        $accept403 = false,
+        $acceptDeleteMarkers = false
+    )
     {
         /** @var S3Client $s3 */
         $s3 = $this->getTestClient('S3', ['region' => 'us-east-1']);
         $this->addMockResults($s3, [$result]);
         try {
-            if ($key) {
-                $this->assertSame($exists, $s3->doesObjectExist($bucket, $key));
-            } else {
-                $this->assertSame($exists, $s3->doesBucketExist($bucket));
+            if ($V2) {
+                if ($key) {
+                    $this->assertSame($exists, $s3->doesObjectExistV2($bucket, $key, $acceptDeleteMarkers));
+                } else {
+                    $this->assertSame($exists, $s3->doesBucketExistV2($bucket, $accept403));
+                }
+            }else {
+                if ($key) {
+                    $this->assertSame($exists, $s3->doesObjectExist($bucket, $key));
+                } else {
+                    $this->assertSame($exists, $s3->doesBucketExist($bucket));
+                }
             }
         } catch (\Exception $e) {
             $this->assertSame(-1, $exists);
@@ -278,7 +315,10 @@ class S3ClientTest extends TestCase
             'region'      => 'us-east-1',
             'credentials' => false
         ]);
-        $this->assertSame('https://foo.s3.amazonaws.com/bar', $s3->getObjectUrl('foo', 'bar'));
+        $this->assertSame(
+            'https://foo.s3.amazonaws.com/bar',
+            $s3->getObjectUrl('foo', 'bar')
+        );
     }
 
     public function testReturnsObjectUrlWithPathStyleFallback()
@@ -287,7 +327,10 @@ class S3ClientTest extends TestCase
             'region'      => 'us-east-1',
             'credentials' => false,
         ]);
-        $this->assertSame('https://s3.amazonaws.com/foo.baz/bar', $s3->getObjectUrl('foo.baz', 'bar'));
+        $this->assertSame(
+            'https://s3.amazonaws.com/foo.baz/bar',
+            $s3->getObjectUrl('foo.baz', 'bar')
+        );
     }
 
     public function testReturnsObjectUrlWithPathStyle()
@@ -297,7 +340,10 @@ class S3ClientTest extends TestCase
             'credentials' => false,
             'use_path_style_endpoint' => true
         ]);
-        $this->assertSame('https://s3.amazonaws.com/foo/bar', $s3->getObjectUrl('foo', 'bar'));
+        $this->assertSame(
+            'https://s3.amazonaws.com/foo/bar',
+            $s3->getObjectUrl('foo', 'bar')
+        );
     }
 
     public function testReturnsObjectUrlViaPath()

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -262,10 +262,17 @@ class S3ClientTest extends TestCase
         ];
     }
 
-    private function getS3ErrorMock($errCode, $statusCode, $deleteMarker = false)
+    private function getS3ErrorMock(
+        $errCode,
+        $statusCode,
+        $deleteMarker = false
+    )
     {
         $response = new Response($statusCode);
-        $deleteMarker && $response = $response->withHeader('x-amz-delete-marker', true);
+        $deleteMarker && $response = $response->withHeader(
+            'x-amz-delete-marker',
+            'true'
+        );
 
         $context = [
             'code' => $errCode,


### PR DESCRIPTION
*Issue #, if available:*
Implements #1561, closes #2342 

*Description of changes:*

New object/bucket existence helper methods with changed exception handling behavior.  Previously, `false` was returned any time an exception was thrown by the underlying S3 APIs (`headObject` and `headBucket`) unless the exception's status code was >= `500` (then exception was thrown) or the exception's error code was `AccessDenied` (`true` was returned).  This was problematic because `false` could be returned in the cases of an unresolvable endpoint, expired credentials, invalid credentials, or if bucket permissions were not granted to the calling entity and resources did in fact exist.

This implementation makes fewer assumptions in cases where status codes are ambiguous, namely `403` status codes. a `403` status code can signify bad credentials or incorrect bucket-level permissions— this causes issues with `headObject`/`doesObjectExist` calls in particular because a 403 will be returned whether or not an object exists. In this implementation, exceptions will be thrown in all cases when an exception is thrown by the underlying API, unless the exception has a  `404` status code (returns false) or in the case of `DoesBucketExist`, a user can specify if they want to accept `403` status codes, as a 403 will be thrown if a bucket exists, but an entity doesn't have correct bucket-level permissions.

Other changes include accepting bucket redirects (incorrectly specified region) as a `true` case for `DoesBucketExist`, the `$accept403` flag for `doesBucketExist` and the `$includeDeleteMarkers` flag for `doesObjectExist`, which counts a `404` response with the presence of a delete marker header as a `true` case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
