### PR TITLE
chore: IMDS extensibility refresh window

### DIFF
--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -100,7 +100,7 @@ class Credentials implements CredentialsInterface, \Serializable
     }
 
     public function extendExpiration() {
-        $extension = mt_rand(5, 15);
+        $extension = mt_rand(5, 10);
         $this->expires = time() + $extension * 60;
 
         $message = <<<EOT


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Shortening IMDS credential extensibility refresh window due to the possibility of overshooting the TTL for STS credentials proxied through a faux-IMDS endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
