### PR TITLE
Add missing PHPDoc annotation for `PromiseInterface` implementations

### DIFF
--- a/.changes/nextrelease/enhancement-add-missing-phpdoc-annotation
+++ b/.changes/nextrelease/enhancement-add-missing-phpdoc-annotation
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Add missing PHPDoc annotation for PromiseInterface implementations."
+    }
+]

--- a/src/CommandPool.php
+++ b/src/CommandPool.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
 use GuzzleHttp\Promise\EachPromise;
 
@@ -72,7 +73,7 @@ class CommandPool implements PromisorInterface
     }
 
     /**
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @return PromiseInterface
      */
     public function promise()
     {

--- a/src/S3/BatchDelete.php
+++ b/src/S3/BatchDelete.php
@@ -112,6 +112,9 @@ class BatchDelete implements PromisorInterface
         return new self($client, $bucket, $fn, $options);
     }
 
+    /**
+     * @return PromiseInterface
+     */
     public function promise()
     {
         if (!$this->cachedPromise) {

--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -6,6 +6,7 @@ use Aws\Arn\S3\AccessPointArn;
 use Aws\Exception\MultipartUploadException;
 use Aws\Result;
 use Aws\S3\Exception\S3Exception;
+use GuzzleHttp\Promise\Coroutine;
 use GuzzleHttp\Promise\PromisorInterface;
 use InvalidArgumentException;
 
@@ -78,7 +79,7 @@ class ObjectCopier implements PromisorInterface
      */
     public function promise()
     {
-        return \GuzzleHttp\Promise\Coroutine::of(function () {
+        return Coroutine::of(function () {
             $headObjectCommand = $this->client->getCommand(
                 'HeadObject',
                 $this->options['params'] + $this->source

--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -76,6 +76,8 @@ class ObjectCopier implements PromisorInterface
      * Perform the configured copy asynchronously. Returns a promise that is
      * fulfilled with the result of the CompleteMultipartUpload or CopyObject
      * operation or rejected with an exception.
+     *
+     * @return Coroutine
      */
     public function promise()
     {

--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\S3;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
@@ -60,6 +61,9 @@ class ObjectUploader implements PromisorInterface
         $this->options = $options + self::$defaults;
     }
 
+    /**
+     * @return PromiseInterface
+     */
     public function promise()
     {
         /** @var int $mup_threshold */

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -5,6 +5,7 @@ use Aws;
 use Aws\CommandInterface;
 use Aws\Exception\AwsException;
 use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
 use Iterator;
 
@@ -137,6 +138,8 @@ class Transfer implements PromisorInterface
 
     /**
      * Transfers the files.
+     *
+     * @return PromiseInterface
      */
     public function promise()
     {

--- a/src/Waiter.php
+++ b/src/Waiter.php
@@ -2,6 +2,7 @@
 namespace Aws;
 
 use Aws\Exception\AwsException;
+use GuzzleHttp\Promise\Coroutine;
 use GuzzleHttp\Promise\PromisorInterface;
 use GuzzleHttp\Promise\RejectedPromise;
 
@@ -85,6 +86,9 @@ class Waiter implements PromisorInterface
         }
     }
 
+    /**
+     * @return Coroutine
+     */
     public function promise()
     {
         return Coroutine::of(function () {

--- a/src/Waiter.php
+++ b/src/Waiter.php
@@ -2,7 +2,6 @@
 namespace Aws;
 
 use Aws\Exception\AwsException;
-use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromisorInterface;
 use GuzzleHttp\Promise\RejectedPromise;
 
@@ -88,7 +87,7 @@ class Waiter implements PromisorInterface
 
     public function promise()
     {
-        return Promise\Coroutine::of(function () {
+        return Coroutine::of(function () {
             $name = $this->config['operation'];
             for ($state = 'retry', $attempt = 1; $state === 'retry'; $attempt++) {
                 // Execute the operation.


### PR DESCRIPTION
*Issue #2353*

*Description of changes:*
This fixes the following deprecation produced by the Symfony PHPUnit Bridge:

```
Method "GuzzleHttp\Promise\PromisorInterface::promise()" might add "PromiseInterface" as a
native return type declaration in the future. Do the same in implementation "Aws\S3\ObjectUploader"
now to avoid errors or add an explicit @return annotation to suppress this message.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
