### PR TITLE
nitpicking, remove useless else{}

### DIFF
--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -47,8 +47,6 @@ class Signer
     {
         if (PHP_MAJOR_VERSION < 8) {
             $this->pkHandle && openssl_pkey_free($this->pkHandle);
-        } else {
-            $this->pkHandle;
         }
     }
 


### PR DESCRIPTION
it's not like we're using some evil __get() magic to actually do something when pkHandle is fetched?
this else looks useless.

*Issue #, if available:*

*Description of changes:*

nitpicking

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
