### PR TITLE
fix: Copy file fails when bucket is an access point arn

### DIFF
--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -144,20 +144,22 @@ class ObjectCopier implements PromisorInterface
 
     private function getSourcePath()
     {
+        $path = "/{$this->source['Bucket']}/";
         if (ArnParser::isArn($this->source['Bucket'])) {
             try {
                 new AccessPointArn($this->source['Bucket']);
+                $path = "{$this->source['Bucket']}/object/";
             } catch (\Exception $e) {
                 throw new \InvalidArgumentException(
                     'Provided ARN was a not a valid S3 access point ARN ('
-                        . $e->getMessage() . ')',
+                    . $e->getMessage() . ')',
                     0,
                     $e
                 );
             }
         }
-        $sourcePath = "/{$this->source['Bucket']}/" . rawurlencode($this->source['Key']);
 
+        $sourcePath = $path . rawurlencode($this->source['Key']);
         if (isset($this->source['VersionId'])) {
             $sourcePath .= "?versionId={$this->source['VersionId']}";
         }

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -78,6 +78,7 @@ class ObjectCopierTest extends TestCase
             function (CommandInterface $cmd, RequestInterface $req) {
 
                 switch($cmd->getName()) {
+                    case 'UploadPartCopy':
                     case 'CopyObject':
                         $this->assertEquals(
                             'mydest-123456789012.s3-accesspoint.us-west-2.amazonaws.com',
@@ -89,12 +90,12 @@ class ObjectCopierTest extends TestCase
                             $cmd['Bucket']
                         );
                         $this->assertEquals(
-                            '/arn:aws:s3:us-west-2:123456789012:accesspoint:mysource/sourceKey',
+                            'arn:aws:s3:us-west-2:123456789012:accesspoint:mysource/object/sourceKey',
                             $cmd['CopySource']
                         );
                         $this->assertEquals(
-                            '/arn:aws:s3:us-west-2:123456789012:accesspoint:mysource/sourceKey',
-                            $req->getHeader('x-amz-copy-source')[0]
+                                'arn:aws:s3:us-west-2:123456789012:accesspoint:mysource/object/sourceKey',
+                                $req->getHeader('x-amz-copy-source')[0]
                         );
                         break;
 
@@ -108,26 +109,6 @@ class ObjectCopierTest extends TestCase
                         $this->assertEquals(
                             'arn:aws:s3:us-west-2:123456789012:accesspoint:mydest',
                             $cmd['Bucket']
-                        );
-                        break;
-
-                    case 'UploadPartCopy':
-                        $this->assertEquals(
-                            'mydest-123456789012.s3-accesspoint.us-west-2.amazonaws.com',
-                            $req->getUri()->getHost()
-                        );
-                        $this->assertEquals('/destKey', $req->getUri()->getPath());
-                        $this->assertEquals(
-                            'arn:aws:s3:us-west-2:123456789012:accesspoint:mydest',
-                            $cmd['Bucket']
-                        );
-                        $this->assertEquals(
-                            '/arn:aws:s3:us-west-2:123456789012:accesspoint:mysource/sourceKey',
-                            $cmd['CopySource']
-                        );
-                        $this->assertEquals(
-                            '/arn:aws:s3:us-west-2:123456789012:accesspoint:mysource/sourceKey',
-                            $req->getHeader('x-amz-copy-source')[0]
                         );
                         break;
 


### PR DESCRIPTION
*Issue  2299*

*Description of changes:*
S3 client fails to copy when the source bucket is specified through an access point arn, and this is caused because the path of the object specified should contain "/object/" in between the generated bucket url and the object to be copied, and the current implementation does not have this special handling. To fix this behavior I added a condition in the function that generates the source path, where I validate if is an access point then I add the "/object/" part to the path to be returned.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
