### PR TITLE
Bump guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^5.3.3 || ^6.2.1 || ^7.0",
+        "guzzlehttp/guzzle": "^5.3.3 || ^6.5.7 || ^7.4.4",
         "guzzlehttp/psr7": "^1.7.0 || ^2.1.1",
         "guzzlehttp/promises": "^1.4.0",
         "mtdowling/jmespath.php": "^2.6",

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^5.3.3 || ^6.5.7 || ^7.4.4",
-        "guzzlehttp/psr7": "^1.7.0 || ^2.1.1",
+        "guzzlehttp/guzzle": "^6.5.7 || ^7.4.4",
+        "guzzlehttp/psr7": "^1.8.5 || ^2.3",
         "guzzlehttp/promises": "^1.4.0",
         "mtdowling/jmespath.php": "^2.6",
         "ext-pcre": "*",


### PR DESCRIPTION
*Description of changes:*
Bumping Guzzle & PSR7 to address [CVE-2022-31043](https://www.cve.org/CVERecord?id=CVE-2022-31043).  Similar changes had been made and reverted due to confusion around which advisories were being addressed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
