### PR TITLE
Also run the test workflow for PHP 8.0 and 8.1.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       #for each of the following versions of PHP, with and without --prefer-lowest
       matrix:
-        php-versions: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         composer-options: ['', '--prefer-lowest']
     #set the name for each job
     name: PHP ${{ matrix.php-versions }} ${{ matrix.composer-options }}
@@ -63,7 +63,7 @@ jobs:
       run: make test
 
     #static analysis
-    - if: ${{ matrix.php-versions >= '7.1' && matrix.php-versions <= 7.4 && matrix.composer-options == '' }}
+    - if: ${{ matrix.php-versions >= '7.1' && matrix.php-versions <= 8.1 && matrix.composer-options == '' }}
       name: Static analysis
       run: |
         composer require --dev nette/neon "^3.0"
@@ -79,6 +79,6 @@ jobs:
         make package
 
     #generate code coverage
-    - if: ${{ matrix.php-versions == '7.1' && matrix.composer-options == '' }}
+    - if: ${{ matrix.php-versions == '8.1' && matrix.composer-options == '' }}
       name: Code coverage
       run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
*Description of changes:*

This PR addresses the fact that no tests are run for PHP versions `8.0` and `8.1`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
