### PR TITLE
chore: unskip LCK tests

### DIFF
--- a/tests/EventBridge/EventBridgeEndpointMiddlewareTest.php
+++ b/tests/EventBridge/EventBridgeEndpointMiddlewareTest.php
@@ -97,10 +97,6 @@ class EventBridgeEndpointMiddlewareTest extends TestCase
         if (!$isCrtAvailable && !empty($endpointId)) {
             $this->markTestSkipped();
         }
-        $isMvpRegion = getenv('AIRGAPPED_REGION') == 'LCK';
-        if ($isMvpRegion) {
-            $this->markTestSkipped();
-        }
         
         $clientConfig = [
             'region' => $clientRegion,

--- a/tests/S3/BucketEndpointArnMiddlewareTest.php
+++ b/tests/S3/BucketEndpointArnMiddlewareTest.php
@@ -40,10 +40,6 @@ class BucketEndpointArnMiddlewareTest extends TestCase
         $signingRegion,
         $signingService
     ) {
-        $isMvpRegion = getenv('AIRGAPPED_REGION') == 'LCK';
-        if ($isMvpRegion) {
-            $this->markTestSkipped();
-        }
         $s3 = $this->getTestClient('s3', $options);
         $this->addMockResults($s3, [[]]);
         $command = $s3->getCommand(

--- a/tests/S3/S3EndpointMiddlewareTest.php
+++ b/tests/S3/S3EndpointMiddlewareTest.php
@@ -549,10 +549,6 @@ class S3EndpointMiddlewareTest extends TestCase
         $endpointUrl,
         $expectedEndpoint)
     {
-        $isMvpRegion = getenv('AIRGAPPED_REGION') == 'LCK';
-        if ($isMvpRegion) {
-            $this->markTestSkipped();
-        }
         //additional flags is not used yet, will be in the future if dualstack support is added
         $clientConfig = [
             'region' => $clientRegion,


### PR DESCRIPTION
*Description of changes:*
Removing markTestSkipped method to allow tests to run in airgapped regions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
