### PR TITLE
bugfix: instanceprofileprovider retries

### DIFF
--- a/.changes/nextrelease/imds-retries.json
+++ b/.changes/nextrelease/imds-retries.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Credentials",
+    "description": "fixes issue with attempt count when refreshing credentials"
+  }
+]

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -56,7 +56,6 @@ class InstanceProfileProvider
         $this->timeout = (float) getenv(self::ENV_TIMEOUT) ?: (isset($config['timeout']) ? $config['timeout'] : 1.0);
         $this->profile = isset($config['profile']) ? $config['profile'] : null;
         $this->retries = (int) getenv(self::ENV_RETRIES) ?: (isset($config['retries']) ? $config['retries'] : 3);
-        $this->attempts = 0;
         $this->client = isset($config['client'])
             ? $config['client'] // internal use only
             : \Aws\default_http_handler();
@@ -69,6 +68,7 @@ class InstanceProfileProvider
      */
     public function __invoke($previousCredentials = null)
     {
+        $this->attempts = 0;
         return Promise\Coroutine::of(function () use ($previousCredentials) {
 
             // Retrieve token or switch out of secure mode

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -300,7 +300,8 @@ class InstanceProfileProviderTest extends TestCase
      */
     public function testHandlesSuccessScenarios(
         callable $client,
-        CredentialsInterface $expected
+        CredentialsInterface $expected,
+        $expectedAttempts = null
     ) {
         $provider = new InstanceProfileProvider([
             'client' => $client,
@@ -325,6 +326,9 @@ class InstanceProfileProviderTest extends TestCase
             $expected->getExpiration(),
             $credentials->getExpiration()
         );
+        if ($expectedAttempts) {
+            $this->assertAttributeEquals($expectedAttempts, 'attempts', $provider);
+        }
     }
 
     public function successTestCases()
@@ -409,7 +413,8 @@ class InstanceProfileProviderTest extends TestCase
                     'MockProfile',
                     $creds
                 ),
-                $credsObject
+                $credsObject,
+                6
             ],
 
             // Insecure data flow, with retries for request exception
@@ -428,7 +433,8 @@ class InstanceProfileProviderTest extends TestCase
                     'MockProfile',
                     $creds
                 ),
-                $credsObject
+                $credsObject,
+                5
             ],
 
             // Secure data flow, with retries for json exception
@@ -443,7 +449,8 @@ class InstanceProfileProviderTest extends TestCase
                     'MockProfile',
                     $creds
                 ),
-                $credsObject
+                $credsObject,
+                4
             ],
 
             // Insecure data flow, with retries for json exception
@@ -458,7 +465,8 @@ class InstanceProfileProviderTest extends TestCase
                     'MockProfile',
                     $creds
                 ),
-                $credsObject
+                $credsObject,
+                4
             ],
 
             // Secure data flow, with retries for ConnectException (Guzzle 7)
@@ -486,7 +494,8 @@ class InstanceProfileProviderTest extends TestCase
                     $creds,
                     true
                 ),
-                $credsObject
+                $credsObject,
+                6
             ],
 
             // Insecure data flow, with retries for ConnectException (Guzzle 7)
@@ -506,7 +515,8 @@ class InstanceProfileProviderTest extends TestCase
                     $creds,
                     true
                 ),
-                $credsObject
+                $credsObject,
+                5
             ],
         ];
     }
@@ -1176,5 +1186,25 @@ class InstanceProfileProviderTest extends TestCase
                 )
             ]
         ];
+    }
+
+    public function testResetsAttempts()
+    {
+        $now = time() + 10000;
+        $creds = ['foo', 'baz', null, "@{$now}"];
+
+        $client = $this->getSecureTestClient(
+            [],
+            'MockProfile',
+            $creds
+        );
+
+        $provider = new InstanceProfileProvider([
+            'client' => $client
+        ]);
+
+        $provider()->wait();
+        $provider()->wait();
+        $this->assertAttributeLessThanOrEqual(3, 'attempts', $provider);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#2484 

*Description of changes:*
Changes InstanceProfileProvider's attempt initialization such that attempts are reset each time a provider instance is invoked.  This allows for retries when requests to imds fail during credential refreshing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
