### PR TITLE
fix source_profile handling

### DIFF
--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -704,7 +704,7 @@ class CredentialProvider
 
         $sourceProfileName = "";
         if (!empty($roleProfile['source_profile'])) {
-            $sourceProfileName = $roleProfile['source_profile'];
+            $sourceProfileName = "profile " . $roleProfile['source_profile'];
             if (!isset($profiles[$sourceProfileName])) {
                 return self::reject("source_profile " . $sourceProfileName
                     . " using profile " . $profileName . " does not exist"


### PR DESCRIPTION
"$profiles" keys are prefix with "profile " , but source_profile attribut isn't so the SDK never found the source_profile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.