### PR TITLE
Fix self callables

### DIFF
--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -87,7 +87,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback();
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['csm']) && $config['csm'] instanceof CacheInterface) {
@@ -172,7 +172,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
                 return self::reject("'$profile' not found in config file");
             }
             if (!isset($data[$profile]['csm_enabled'])) {
-                return self::reject("Required CSM config values not present in 
+                return self::reject("Required CSM config values not present in
                     INI profile '{$profile}' ({$filename})");
             }
 

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -133,7 +133,7 @@ class CredentialProvider
 
         return self::memoize(
             call_user_func_array(
-                'self::chain',
+                [CredentialProvider::class, 'chain'],
                 array_values($defaultChain)
             )
         );
@@ -900,4 +900,3 @@ class CredentialProvider
         || !empty($_SERVER[EcsCredentialProvider::ENV_FULL_URI]);
     }
 }
-

--- a/src/DefaultsMode/ConfigurationProvider.php
+++ b/src/DefaultsMode/ConfigurationProvider.php
@@ -82,7 +82,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback();
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['defaultsMode'])

--- a/src/Endpoint/UseDualstackEndpoint/ConfigurationProvider.php
+++ b/src/Endpoint/UseDualstackEndpoint/ConfigurationProvider.php
@@ -80,7 +80,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback($region);
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['use_dual_stack_endpoint'])
@@ -144,7 +144,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
                 return self::reject("'$profile' not found in config file");
             }
             if (!isset($data[$profile][self::INI_USE_DUAL_STACK_ENDPOINT])) {
-                return self::reject("Required use dualstack endpoint config values 
+                return self::reject("Required use dualstack endpoint config values
                     not present in INI profile '{$profile}' ({$filename})");
             }
 

--- a/src/Endpoint/UseFipsEndpoint/ConfigurationProvider.php
+++ b/src/Endpoint/UseFipsEndpoint/ConfigurationProvider.php
@@ -79,7 +79,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback($config['region']);
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['use_fips_endpoint'])
@@ -143,7 +143,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
                 return self::reject("'$profile' not found in config file");
             }
             if (!isset($data[$profile][self::INI_USE_FIPS_ENDPOINT])) {
-                return self::reject("Required use fips endpoint config values 
+                return self::reject("Required use fips endpoint config values
                     not present in INI profile '{$profile}' ({$filename})");
             }
 

--- a/src/EndpointDiscovery/ConfigurationProvider.php
+++ b/src/EndpointDiscovery/ConfigurationProvider.php
@@ -83,7 +83,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback($config);
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['endpoint_discovery'])
@@ -190,7 +190,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
                 return self::reject("'$profile' not found in config file");
             }
             if (!isset($data[$profile]['endpoint_discovery_enabled'])) {
-                return self::reject("Required endpoint discovery config values 
+                return self::reject("Required endpoint discovery config values
                     not present in INI profile '{$profile}' ({$filename})");
             }
 

--- a/src/Retry/ConfigurationProvider.php
+++ b/src/Retry/ConfigurationProvider.php
@@ -85,7 +85,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback();
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['retries'])

--- a/src/S3/RegionalEndpoint/ConfigurationProvider.php
+++ b/src/S3/RegionalEndpoint/ConfigurationProvider.php
@@ -80,7 +80,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback();
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['s3_us_east_1_regional_endpoint'])
@@ -139,7 +139,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
                 return self::reject("'$profile' not found in config file");
             }
             if (!isset($data[$profile][self::INI_ENDPOINTS_TYPE])) {
-                return self::reject("Required S3 regional endpoint config values 
+                return self::reject("Required S3 regional endpoint config values
                     not present in INI profile '{$profile}' ({$filename})");
             }
 

--- a/src/S3/UseArnRegion/ConfigurationProvider.php
+++ b/src/S3/UseArnRegion/ConfigurationProvider.php
@@ -80,7 +80,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback();
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['use_arn_region'])
@@ -144,7 +144,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
                 return self::reject("'$profile' not found in config file");
             }
             if (!isset($data[$profile][self::INI_USE_ARN_REGION])) {
-                return self::reject("Required S3 Use Arn Region config values 
+                return self::reject("Required S3 Use Arn Region config values
                     not present in INI profile '{$profile}' ({$filename})");
             }
 

--- a/src/Sts/RegionalEndpoints/ConfigurationProvider.php
+++ b/src/Sts/RegionalEndpoints/ConfigurationProvider.php
@@ -82,7 +82,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         $configProviders[] = self::fallback();
 
         $memo = self::memoize(
-            call_user_func_array('self::chain', $configProviders)
+            call_user_func_array([ConfigurationProvider::class, 'chain'], $configProviders)
         );
 
         if (isset($config['sts_regional_endpoints'])
@@ -160,7 +160,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
                 return self::reject("'$profile' not found in config file");
             }
             if (!isset($data[$profile][self::INI_ENDPOINTS_TYPE])) {
-                return self::reject("Required STS regional endpoints config values 
+                return self::reject("Required STS regional endpoints config values
                     not present in INI profile '{$profile}' ({$filename})");
             }
 


### PR DESCRIPTION
These changes are necessary to solve some deprecation notices for PHP 8.2 where `self::` is used in a callable context. This isn't supported anymore. I didn't add any tests because this should technically get a new 8.2 build. However, the 8.0 and 8.1 builds are also still pending so I figured it didn't make sense to add an 8.2 build before that PR was merged: https://github.com/aws/aws-sdk-php/pull/2403

Here's the upgrade notice: https://github.com/php/php-src/blob/PHP-8.2/UPGRADING#L157-L167

Right now, we're trying to get a passing PHP 8.2 build for Laravel. This library is one of the last blockers to get a passing build. See failures in the Laravel build:

<img width="1750" alt="Screenshot 2022-09-08 at 14 34 49" src="https://user-images.githubusercontent.com/594614/189123058-a753e81a-a282-4d05-b48e-526d77fa4c47.png">

It would be great to get a merge and a release for this @SamRemis. Thanks!