### PR TITLE
fix source_profile handling

### DIFF
--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -705,6 +705,12 @@ class CredentialProvider
         $sourceProfileName = "";
         if (!empty($roleProfile['source_profile'])) {
             $sourceProfileName = $roleProfile['source_profile'];
+            # in ~/.aws/config all the named profile (except 'default') are
+            # prefix with 'profile '
+            if ($filename == (self::getHomeDir() . '/.aws/config') &&
+                $sourceProfileName != 'default') {
+                $sourceProfileName = 'profile ' . $sourceProfileName;
+            }
             if (!isset($profiles[$sourceProfileName])) {
                 return self::reject("source_profile " . $sourceProfileName
                     . " using profile " . $profileName . " does not exist"


### PR DESCRIPTION
"$profiles" keys are [prefix with "profile "](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html), but source_profile attribute isn't so the SDK never found the source_profile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# how to reproduce

~/.aws/config
```
[profile source]
…

[profile role]
role_arn = arn:aws:iam::…:role/…
source_profile = source
```

test.php
```
<?php

require 'vendor/autoload.php';
use Aws\Sts\StsClient;

$client = new StsClient([
        'region' => 'eu-west-1',
        'version' => '2011-06-15'
]);

$result = $client->getCallerIdentity([]);

print($result);
```

```
export AWS_PROFILE=role
php test.php
```

result: fail  
expected result: ok

But if you use this ~/.aws/config (which is ill formatted according to [the doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)), it works:
```
[profile source]
…

[profile role]
role_arn = arn:aws:iam::…:role/…
source_profile = profile source
```

# note

follow https://github.com/aws/aws-sdk-php/pull/2516 , which is already closed