### PR TITLE
Update smokecontext

### DIFF
--- a/tests/Integ/SmokeContext.php
+++ b/tests/Integ/SmokeContext.php
@@ -350,7 +350,11 @@ class SmokeContext extends Assert implements
     public function theValueAtShouldBeAList($key)
     {
         $this->assertInstanceOf(Result::class, $this->response);
-        $this->assertIsArray($this->response->search($key));
+        if (method_exists($this, 'assertIsArray')) {
+            $this->assertIsArray($this->response->search($key));
+        } else {
+            $this->assertInternalType('array', $this->response->search($key));
+        }
     }
 
     /**


### PR DESCRIPTION
Adds fallback for `AssertIsArray` if method does not exist.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
