### PR TITLE
Update image used in CI-tests from ubuntu:18.04 to ubuntu:22.04 to avoid deprecation problems

### DIFF
--- a/.changes/nextrelease/ci-image-update
+++ b/.changes/nextrelease/ci-image-update
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Update the image used in CI-jobs from ubuntu-18.04 to ubuntu-22.04."
+    }
+]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,13 @@ permissions:
 
 jobs:
   run:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       #for each of the following versions of PHP, with and without --prefer-lowest
       matrix:
         php-versions: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         composer-options: ['', '--prefer-lowest']
+
     #set the name for each job
     name: PHP ${{ matrix.php-versions }} ${{ matrix.composer-options }}
     #set up environment variables used by unit tests

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -39,7 +39,14 @@ class SignerTest extends TestCase
      * Assert that the key file is parsed during construction
      */
     public function testBadPrivateKeyPath() {
-        $this->expectExceptionMessageMatches("/PEM .*no start line/");
+        preg_match('/OpenSSL (?<version>\d+\.\d+\.\d+)/',OPENSSL_VERSION_TEXT,$matches);
+        // OpenSSL 1.* and 3.* do not return the same error-message
+        if (isset($matches['version']) && version_compare($matches['version'],'3.0','>=')) {
+            $this->expectExceptionMessageMatches("/error:1E08010C:DECODER routines::unsupported/");
+        } else {
+            $this->expectExceptionMessageMatches("/PEM .*no start line/");
+        }
+
         $this->expectException(\InvalidArgumentException::class);
         $filename = tempnam(sys_get_temp_dir(), 'cloudfront-fake-key');
         file_put_contents($filename, "Not a real private key");

--- a/tests/Crypto/Polyfill/AesGcmTest.php
+++ b/tests/Crypto/Polyfill/AesGcmTest.php
@@ -2644,8 +2644,16 @@ class AesGcmTest extends TestCase
                 $aad,
                 $tag2
             );
-            $this->assertSame(bin2hex($exp), bin2hex($got));
-            $this->assertSame(bin2hex($tag1), bin2hex($tag2));
+
+            $failureMessage = sprintf("Failed with parameters:\n\tplaintext: %s\n\taad: %s\n\tkey: %s\n\tnonce: %s",
+                bin2hex($plaintext),
+                bin2hex($aad),
+                bin2hex($key),
+                bin2hex($nonce)
+            );
+
+            $this->assertSame(bin2hex($exp), bin2hex($got),$failureMessage);
+            $this->assertSame(bin2hex($tag1), bin2hex($tag2),$failureMessage);
         }
     }
 }


### PR DESCRIPTION
Ubuntu 18.04 is [being deprecated](https://github.com/actions/runner-images/issues/6002) in GitHub Actions since 8/8/2022 and will be fully unsupported by 4/1/2023.

To generate awareness, there are a couple of brown-out-periods where all CI-tests using that image will fail.

This merge-request will avoid any more possible failing CI-tests because of usage of a deprecated image.

## Extra commits

### 1. Update Aws\Test\CloudFront\SignerTest::testBadPrivateKeyPath()
The message thrown by OpenSSL changed from version 1.x (used in ubuntu 18.04) to version 3.x (used in ubuntu 22.04).

I only modified the test to capture this new error message.  Since both outputs are rather cryptic, I think we can improve the developer experience when `Signer::__construct()` throws a proper message to signal the provided keyfile is incorrect, and appended, the original error-message from OpenSSL.

I did not modify this now to restrict changes only related to the test-image.

### 2. Add more output-logging when Tests\Crypto\Polyfill\AesGcmTest::testCompat() fails
This tests is rather flaky and randomly fails.  Previously it only showed the result of both encryptions, which does not allow reproduction of the error.

I've added a failure-message which shows the input used, so we can reproduce the test-case the next time this flaky test fails again.

I'm aware this is not strictly related to the test-image-update, so I can split this off to a seperate PR, but as the change has no impact on the actual code or changes any tested codepaths, I thought it was acceptable to add this to this PR.

```
# Sample output
Failed with parameters:
	plaintext: ea98e4dcd86f0787e08f169ba7225d2e5921fff6...
	aad: c377dee941af1f9210e3cbd96718637a8fe446a551a83182c0...
	key: d2ff5fde9f2ce01af2cec3fee052e691f272bfac5d80e78efc3f74969c1fcb86
	nonce: aac1ca71959724f547fc9245
Failed asserting that two strings are identical.
Expected :04be5db843e1acd76413ff1214cdea22aa  (appended some text to cause test to fail)
Actual   :04be5db843e1acd76413ff1214cdea22
```

## Postscript
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
