### PR TITLE
Using proper PHP comparison operators

### DIFF
--- a/.changes/nextrelease/validator-comparison-operators
+++ b/.changes/nextrelease/validator-comparison-operators
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "Api",
+        "description": "Using proper PHP comparison operators and array method signature"
+    }
+]

--- a/src/Api/Validator.php
+++ b/src/Api/Validator.php
@@ -245,19 +245,19 @@ class Validator
         }
     }
 
-    private function checkArray($arr)
+    private function checkArray(array $arr)
     {
         return $this->isIndexed($arr) || $this->isAssociative($arr);
     }
 
-    private function isAssociative($arr)
+    private function isAssociative(array $arr)
     {
-        return count(array_filter(array_keys($arr), "is_string")) == count($arr);
+        return count(array_filter(array_keys($arr), "is_string")) === count($arr);
     }
 
     private function isIndexed(array $arr)
     {
-        return $arr == array_values($arr);
+        return $arr === array_values($arr);
     }
 
     private function checkCanString($value)
@@ -272,7 +272,7 @@ class Validator
         $type = gettype($value);
 
         return isset($valid[$type]) ||
-            ($type == 'object' && method_exists($value, '__toString'));
+            ($type === 'object' && method_exists($value, '__toString'));
     }
 
     private function checkAssociativeArray($value)
@@ -325,7 +325,7 @@ class Validator
                     $nonNullCount++;
                 }
             }
-            return $nonNullCount == 1;
+            return $nonNullCount === 1;
         }
         return !is_null($value);
     }


### PR DESCRIPTION
*Description of changes:*

This change is mostly focused on using the triple `===` comparison operator. Although, I took the chance to validate the parameters passed to the functions `checkArray` and `isAssociative`, now set as `array`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
