### PR TITLE
Parse Json error code if it is present in HTTP response header

### DIFF
--- a/.changes/nextrelease/ziyanli-amazon-php-master.json
+++ b/.changes/nextrelease/ziyanli-amazon-php-master.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "feature",
+        "category": "",
+        "description": "Parse json error code if it is present in HTTP response header"
+    }
+]

--- a/.changes/nextrelease/ziyanli-amazon-php-master.json
+++ b/.changes/nextrelease/ziyanli-amazon-php-master.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "feature",
-        "category": "",
+        "category": "API",
         "description": "Parse json error code if it is present in HTTP response header"
     }
 ]

--- a/.changes/nextrelease/ziyanli-amazon-php-master.json
+++ b/.changes/nextrelease/ziyanli-amazon-php-master.json
@@ -1,7 +1,7 @@
 [
     {
         "type": "feature",
-        "category": "API",
+        "category": "Api",
         "description": "Parse json error code if it is present in HTTP response header"
     }
 ]

--- a/src/Api/ErrorParser/JsonParserTrait.php
+++ b/src/Api/ErrorParser/JsonParserTrait.php
@@ -21,9 +21,9 @@ trait JsonParserTrait
         ) {
             $queryError = $response->getHeaderLine('x-amzn-query-error');
             $parts = explode(';', $queryError);
-            if (isset($parts) && count($parts) == 2 && $parts[0] && $parts[1]) {
-                $error_code = $parts[0];
-                $error_type = $parts[1];
+            if (isset($parts) && count($parts) == 2 && trim($parts[0]) && trim($parts[1])) {
+                $error_code = trim($parts[0]);
+                $error_type = trim($parts[1]);
             }
         }
         if (!isset($error_type)) {

--- a/src/Api/ErrorParser/JsonParserTrait.php
+++ b/src/Api/ErrorParser/JsonParserTrait.php
@@ -15,16 +15,26 @@ trait JsonParserTrait
     private function genericHandler(ResponseInterface $response)
     {
         $code = (string) $response->getStatusCode();
-        if ($queryError = $response->getHeaderLine('x-amzn-query-error')) {
+        if ($this->api &&
+            $this->api->getMetadata('awsQueryCompatible') &&
+            $response->getHeaderLine('x-amzn-query-error')
+        ) {
+            $queryError = $response->getHeaderLine('x-amzn-query-error');
             $parts = explode(';', $queryError);
-            $error = (isset($parts) and !empty(trim($parts[0]))) ? $parts[0] : null;
+            if (isset($parts) && count($parts) == 2 && $parts[0] && $parts[1]) {
+                $error_code = $parts[0];
+                $error_type = $parts[1];
+            }
+        }
+        if (!isset($error_type)) {
+            $error_type = $code[0] == '4' ? 'client' : 'server';
         }
 
         return [
             'request_id'  => (string) $response->getHeaderLine('x-amzn-requestid'),
-            'code'        => isset($error) ? $error : null,
+            'code'        => isset($error_code) ? $error_code : null,
             'message'     => null,
-            'type'        => $code[0] == '4' ? 'client' : 'server',
+            'type'        => $error_type,
             'parsed'      => $this->parseJson($response->getBody(), $response)
         ];
     }

--- a/src/Api/ErrorParser/JsonParserTrait.php
+++ b/src/Api/ErrorParser/JsonParserTrait.php
@@ -15,15 +15,15 @@ trait JsonParserTrait
     private function genericHandler(ResponseInterface $response)
     {
         $code = (string) $response->getStatusCode();
-        if ($this->api &&
-            $this->api->getMetadata('awsQueryCompatible') &&
-            $response->getHeaderLine('x-amzn-query-error')
+        if ($this->api
+            && $this->api->getMetadata('awsQueryCompatible')
+            && $response->getHeaderLine('x-amzn-query-error')
         ) {
             $queryError = $response->getHeaderLine('x-amzn-query-error');
             $parts = explode(';', $queryError);
-            if (isset($parts) && count($parts) == 2 && trim($parts[0]) && trim($parts[1])) {
-                $error_code = trim($parts[0]);
-                $error_type = trim($parts[1]);
+            if (isset($parts) && count($parts) == 2 && $parts[0] && $parts[1]) {
+                $error_code = $parts[0];
+                $error_type = $parts[1];
             }
         }
         if (!isset($error_type)) {

--- a/src/Api/ErrorParser/JsonParserTrait.php
+++ b/src/Api/ErrorParser/JsonParserTrait.php
@@ -15,10 +15,14 @@ trait JsonParserTrait
     private function genericHandler(ResponseInterface $response)
     {
         $code = (string) $response->getStatusCode();
+        if ($queryError = $response->getHeaderLine('x-amzn-query-error')) {
+            $parts = explode(';', $queryError);
+            $error = (isset($parts) and !empty(trim($parts[0]))) ? $parts[0] : null;
+        }
 
         return [
             'request_id'  => (string) $response->getHeaderLine('x-amzn-requestid'),
-            'code'        => null,
+            'code'        => isset($error) ? $error : null,
             'message'     => null,
             'type'        => $code[0] == '4' ? 'client' : 'server',
             'parsed'      => $this->parseJson($response->getBody(), $response)

--- a/src/Api/ErrorParser/JsonRpcErrorParser.php
+++ b/src/Api/ErrorParser/JsonRpcErrorParser.php
@@ -33,8 +33,10 @@ class JsonRpcErrorParser extends AbstractErrorParser
         }
 
         if (isset($data['parsed']['__type'])) {
-            $parts = explode('#', $data['parsed']['__type']);
-            $data['code'] = isset($parts[1]) ? $parts[1] : $parts[0];
+            if (!isset($data['code'])) {
+                $parts = explode('#', $data['parsed']['__type']);
+                $data['code'] = isset($parts[1]) ? $parts[1] : $parts[0];
+            }
             $data['message'] = isset($data['parsed']['message'])
                 ? $data['parsed']['message']
                 : null;

--- a/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
+++ b/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
@@ -52,7 +52,10 @@ class JsonRpcErrorParserTest extends TestCase
     public function errorResponsesProvider()
     {
         $service = $this->generateTestService('json');
-        $awsQueryCompatibleService = $this->generateTestService('json', ['awsQueryCompatible' => true]);
+        $awsQueryCompatibleService = $this->generateTestService(
+            'json',
+            ['awsQueryCompatible' => true]
+        );
         $shapes = $service->getErrorShapes();
         $errorShape = $shapes[0];
         $client = $this->generateTestClient($service);

--- a/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
+++ b/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
@@ -144,11 +144,11 @@ class JsonRpcErrorParserTest extends TestCase
                 "x-amzn-query-error: NonExistentException;Sender\r\n\r\n" .
                 '{ "__Type": "foo", "Message": "lorem ipsum" }',
                 null,
-                new JsonRpcErrorParser(),
+                new JsonRpcErrorParser($service),
                 [
                     'code'       => 'NonExistentException',
                     'message'    => 'lorem ipsum',
-                    'type'       => 'client',
+                    'type'       => 'Sender',
                     'request_id' => 'xyz',
                     'parsed'     => [
                         'message' => 'lorem ipsum',
@@ -164,7 +164,7 @@ class JsonRpcErrorParserTest extends TestCase
                 "x-amzn-query-error: ;Sender\r\n\r\n" .
                 '{ "__Type": "foo", "Message": "lorem ipsum" }',
                 null,
-                new JsonRpcErrorParser(),
+                new JsonRpcErrorParser($service),
                 [
                     'code'       => 'foo',
                     'message'    => 'lorem ipsum',

--- a/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
+++ b/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
@@ -137,6 +137,66 @@ class JsonRpcErrorParserTest extends TestCase
                     'body' => [],
                 ]
             ],
+            // read Error code in query error header
+            [
+                "HTTP/1.1 400 Bad Request\r\n" .
+                "x-amzn-requestid: xyz\r\n" .
+                "x-amzn-query-error: NonExistentException;Sender\r\n\r\n" .
+                '{ "__Type": "foo", "Message": "lorem ipsum" }',
+                null,
+                new JsonRpcErrorParser(),
+                [
+                    'code'       => 'NonExistentException',
+                    'message'    => 'lorem ipsum',
+                    'type'       => 'client',
+                    'request_id' => 'xyz',
+                    'parsed'     => [
+                        'message' => 'lorem ipsum',
+                        '__type'    => 'foo'
+                    ],
+                    'body' => [],
+                ]
+            ],
+            // read error code in body when query error is incomplete
+            [
+                "HTTP/1.1 400 Bad Request\r\n" .
+                "x-amzn-requestid: xyz\r\n" .
+                "x-amzn-query-error: ;Sender\r\n\r\n" .
+                '{ "__Type": "foo", "Message": "lorem ipsum" }',
+                null,
+                new JsonRpcErrorParser(),
+                [
+                    'code'       => 'foo',
+                    'message'    => 'lorem ipsum',
+                    'type'       => 'client',
+                    'request_id' => 'xyz',
+                    'parsed'     => [
+                        'message' => 'lorem ipsum',
+                        '__type'    => 'foo'
+                    ],
+                    'body' => [],
+                ]
+            ],
+            // read error code in body when query error is null or empty
+            [
+                "HTTP/1.1 400 Bad Request\r\n" .
+                "x-amzn-requestid: xyz\r\n" .
+                "x-amzn-query-error: \r\n\r\n" .
+                '{ "__Type": "foo", "Message": "lorem ipsum" }',
+                null,
+                new JsonRpcErrorParser(),
+                [
+                    'code'       => 'foo',
+                    'message'    => 'lorem ipsum',
+                    'type'       => 'client',
+                    'request_id' => 'xyz',
+                    'parsed'     => [
+                        'message' => 'lorem ipsum',
+                        '__type'    => 'foo'
+                    ],
+                    'body' => [],
+                ]
+            ],
         ];
     }
 }

--- a/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
+++ b/tests/Api/ErrorParser/JsonRpcErrorParserTest.php
@@ -52,6 +52,7 @@ class JsonRpcErrorParserTest extends TestCase
     public function errorResponsesProvider()
     {
         $service = $this->generateTestService('json');
+        $awsQueryCompatibleService = $this->generateTestService('json', ['awsQueryCompatible' => true]);
         $shapes = $service->getErrorShapes();
         $errorShape = $shapes[0];
         $client = $this->generateTestClient($service);
@@ -144,7 +145,7 @@ class JsonRpcErrorParserTest extends TestCase
                 "x-amzn-query-error: NonExistentException;Sender\r\n\r\n" .
                 '{ "__Type": "foo", "Message": "lorem ipsum" }',
                 null,
-                new JsonRpcErrorParser($service),
+                new JsonRpcErrorParser($awsQueryCompatibleService),
                 [
                     'code'       => 'NonExistentException',
                     'message'    => 'lorem ipsum',
@@ -164,7 +165,7 @@ class JsonRpcErrorParserTest extends TestCase
                 "x-amzn-query-error: ;Sender\r\n\r\n" .
                 '{ "__Type": "foo", "Message": "lorem ipsum" }',
                 null,
-                new JsonRpcErrorParser($service),
+                new JsonRpcErrorParser($awsQueryCompatibleService),
                 [
                     'code'       => 'foo',
                     'message'    => 'lorem ipsum',

--- a/tests/TestServiceTrait.php
+++ b/tests/TestServiceTrait.php
@@ -45,6 +45,7 @@ trait TestServiceTrait
         ];
         if ($protocol === 'json') {
             $metadata['jsonVersion'] = "1.1";
+            $metadata['awsQueryCompatible'] = "String";
         }
 
         return new Service(

--- a/tests/TestServiceTrait.php
+++ b/tests/TestServiceTrait.php
@@ -45,7 +45,7 @@ trait TestServiceTrait
         ];
         if ($protocol === 'json') {
             $metadata['jsonVersion'] = "1.1";
-            if (array_key_exists('awsQueryCompatible', $args) && $args['awsQueryCompatible']) {
+            if (isset($args['awsQueryCompatible']) && $args['awsQueryCompatible'] === true) {
                 $metadata['awsQueryCompatible'] = "String";
             }
         }

--- a/tests/TestServiceTrait.php
+++ b/tests/TestServiceTrait.php
@@ -37,7 +37,7 @@ trait TestServiceTrait
      * @param string $protocol
      * @return Service
      */
-    private function generateTestService($protocol)
+    private function generateTestService($protocol, $args = [])
     {
         $metadata = [
             "protocol" => $protocol,
@@ -45,7 +45,9 @@ trait TestServiceTrait
         ];
         if ($protocol === 'json') {
             $metadata['jsonVersion'] = "1.1";
-            $metadata['awsQueryCompatible'] = "String";
+            if (array_key_exists('awsQueryCompatible', $args) && $args['awsQueryCompatible']) {
+                $metadata['awsQueryCompatible'] = "String";
+            }
         }
 
         return new Service(


### PR DESCRIPTION
*Description of changes:*
### Motivation
As we decided to parse `AwsQuery` Compatible `Error` in the Http response header, the required changes need to take in place on both SDK client and Service. 
This will be a pre-requisite for migrating services from AWSQuery wire protocol to AWSJson.
### What changed
Error code can be fetched from response content (for example __type#fooException). This PR takes another scenario into consideration, of which when `x-amzn-query-error` header with valid value is found from the Http response. 
- The parsed error code remains unchanged if this header is missing, or contains null or invalid value.
### SEP 
[link](https://code.amazon.com/packages/AwsDrSeps/blobs/main/--/seps/accepted/shared/query-protocol-migration-compatibility.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
