### PR TITLE
Fix count() empty MockHandler

### DIFF
--- a/src/MockHandler.php
+++ b/src/MockHandler.php
@@ -33,6 +33,7 @@ class MockHandler implements \Countable
         callable $onFulfilled = null,
         callable $onRejected = null
     ) {
+        $this->queue = [];
         $this->onFulfilled = $onFulfilled;
         $this->onRejected = $onRejected;
 

--- a/tests/MockHandlerTest.php
+++ b/tests/MockHandlerTest.php
@@ -30,6 +30,12 @@ class MockHandlerTest extends TestCase
         $this->assertCount(3, $h);
     }
 
+    public function testCanCountEmpty()
+    {
+        $h = new Mockhandler();
+        $this->assertCount(0, $h);
+    }
+
     public function testReturnsMockResultsFromQueue()
     {
         $h = new MockHandler();


### PR DESCRIPTION
# Issue

`count()` on empty MockHandler results in error

```php
count(): Parameter must be an array or an object that implements Countable
```

```shell
vendor/bin/phpunit --filter=MockHandlerTest
PHPUnit 9.5.25 #StandWithUkraine

Warning:       No code coverage driver available

..E......                                                           9 / 9 (100%)

Time: 00:00.266, Memory: 54.00 MB

There was 1 error:

1) Aws\Test\MockHandlerTest::testCanCountEmpty
count(): Parameter must be an array or an object that implements Countable
```

# Description of changes:

Initialise `$this->queue` as empty array when MockHandler instantiates.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
