### PR TITLE
Make doesObjectExistV2 match S3ClientTrait

### DIFF
--- a/src/S3/S3ClientInterface.php
+++ b/src/S3/S3ClientInterface.php
@@ -97,7 +97,7 @@ interface S3ClientInterface extends AwsClientInterface
      * @return bool
      * @throws S3Exception|Exception if there is an unhandled exception
      */
-    public function doesObjectExistV2($bucket, $key, $includeDeleteMarkers, array $options = []);
+    public function doesObjectExistV2($bucket, $key, $includeDeleteMarkers = false, array $options = []);
 
     /**
      * Register the Amazon S3 stream wrapper with this client instance.


### PR DESCRIPTION
*Description of changes:*

Changes S3ClientInterface `doesObjectExistV2` to match definition on S3ClientTrait - see:

https://github.com/aws/aws-sdk-php/blob/47aa3e427371af4449cd9cb07af7209376a535bb/src/S3/S3ClientTrait.php#L317-L322

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
