### PR TITLE
Composer don't noise after install

### DIFF
--- a/src/Script/Composer/Composer.php
+++ b/src/Script/Composer/Composer.php
@@ -88,8 +88,10 @@ class Composer
                 }
             }
         }
-        $event->getIO()->write(
-            "Removed $deleteCount AWS service" . ($deleteCount === 1 ? '' : 's')
-        );
+        if ($deleteCount > 0) {
+            $event->getIO()->write(
+                "Removed $deleteCount AWS service" . ($deleteCount === 1 ? '' : 's')
+            );
+        }
     }
 }


### PR DESCRIPTION
After setup "Aws\\Script\\Composer\\Composer::removeUnusedServices" every time I run `composer install` with already exists vendor I see the message:
```
Removed 0 AWS services
```
it doesn't contain readable logic, and, for example, the [same library](https://github.com/googleapis/google-api-php-client/blob/main/src/Task/Composer.php#L56) excludes zero-messages.

The PR removes the message if no package deleted