### PR TITLE
enhancement: improve credential extensibility messaging

### DIFF
--- a/.changes/nextrelease/creds-extensibility-update.json
+++ b/.changes/nextrelease/creds-extensibility-update.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enchancement",
+    "category": "Credentials",
+    "description": "Emit warning rather than log error when extending IMDS credentials"
+  }
+]

--- a/.changes/nextrelease/creds-extensibility-update.json
+++ b/.changes/nextrelease/creds-extensibility-update.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "enchancement",
+    "type": "enhancement",
     "category": "Credentials",
     "description": "Emit warning rather than log error when extending IMDS credentials"
   }

--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -108,6 +108,6 @@ Attempting credential expiration extension due to a credential service
 availability issue. A refresh of these credentials will be attempted again 
 after {$extension} minutes.\n
 EOT;
-        error_log($message);
+        trigger_error($message, E_USER_WARNING);
     }
 }

--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -99,6 +99,12 @@ class Credentials implements CredentialsInterface, \Serializable
         $this->expires = $data['expires'];
     }
 
+    /**
+     * Internal-only. Used when IMDS is unreachable
+     * or returns expires credentials.
+     *
+     * @internal
+     */
     public function extendExpiration() {
         $extension = mt_rand(5, 10);
         $this->expires = time() + $extension * 60;

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -983,17 +983,17 @@ class InstanceProfileProviderTest extends TestCase
      */
     public function testExtendsExpirationAndSendsRequestIfImdsYieldsExpiredCreds($client)
     {
-        //Capture extension message
-        $capture = tmpfile();
-        ini_set('error_log', stream_get_meta_data($capture)['uri']);
+        //expect warning emitted from extension
+        $this->expectWarning();
+        $this->expectWarningMessageMatches(
+            '/Attempting credential expiration extension/'
+        );
 
         $provider = new InstanceProfileProvider([
             'client' => $client
         ]);
         $creds = $provider()->wait();
 
-        $message = stream_get_contents($capture);
-        $this->assertMatchesRegularExpression('/Attempting credential expiration extension/', $message);
         $this->assertSame('foo', $creds->getAccessKeyId());
         $this->assertSame('baz', $creds->getSecretKey());
         $this->assertFalse($creds->isExpired());
@@ -1065,7 +1065,7 @@ class InstanceProfileProviderTest extends TestCase
      */
     public function testExtendsExpirationAndSendsRequestIfImdsUnavailable($client)
     {
-        //Warning emitted from extension
+        //expect warning emitted from extension
         $this->expectWarning();
         $this->expectWarningMessageMatches(
             '/Attempting credential expiration extension/'

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -1065,9 +1065,8 @@ class InstanceProfileProviderTest extends TestCase
      */
     public function testExtendsExpirationAndSendsRequestIfImdsUnavailable($client)
     {
-        //Capture extension message
-        $capture = tmpfile();
-        ini_set('error_log', stream_get_meta_data($capture)['uri']);
+        //Warning emitted from extension
+        $this->expectWarning();
 
         $expiredTime = time() - 1000;
         $expiredCreds = new Credentials('foo', 'baz', null, $expiredTime);
@@ -1077,9 +1076,6 @@ class InstanceProfileProviderTest extends TestCase
             'client' => $client
         ]);
         $creds = $provider($expiredCreds)->wait();
-
-        $message = stream_get_contents($capture);
-        $this->assertMatchesRegularExpression('/Attempting credential expiration extension/', $message);
         $this->assertSame('foo', $creds->getAccessKeyId());
         $this->assertSame('baz', $creds->getSecretKey());
         $this->assertFalse($expiredCreds->isExpired());

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -1067,6 +1067,9 @@ class InstanceProfileProviderTest extends TestCase
     {
         //Warning emitted from extension
         $this->expectWarning();
+        $this->expectWarningMessageMatches(
+            '/Attempting credential expiration extension/'
+        );
 
         $expiredTime = time() - 1000;
         $expiredCreds = new Credentials('foo', 'baz', null, $expiredTime);


### PR DESCRIPTION
*Description of changes:*
Triggers error (error level warning) upon credentials extension rather than logging an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
