### PR TITLE
append query - fix checking strpos of ?

### DIFF
--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -275,7 +275,7 @@ abstract class RestSerializer
     private function appendQuery($query, $endpoint)
     {
         $append = Psr7\Query::build($query);
-        return $endpoint .= strpos($endpoint, '?') ? "&{$append}" : "?$append";
+        return $endpoint .= (strpos($endpoint, '?') !== false) ? "&{$append}" : "?$append";
     }
 
     private function getVarDefinitions($command, $args)


### PR DESCRIPTION
*Issue #, if available:* 
#2559

*Description of changes:*
`src/Api/Serializer/RestSerializer.php` > `appendQuery()` performs a `strpos` check on a passed through `$endpoint` to see if it contains a `?`, but doesn't take into consideration that it could be at the start of the `$endpoint`. This then lead to the incorrect endpoint being queried (ignoring passed through query params).

This change is to make sure that the strict check is performed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
