### PR TITLE
bugfix: add fixes for #2558, #2559

### DIFF
--- a/.changes/nextrelease/endpoint-patch-2.json
+++ b/.changes/nextrelease/endpoint-patch-2.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "EndpointV2",
+    "description": "Fixes #2558, #2559"
+  }
+]

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -275,7 +275,7 @@ abstract class RestSerializer
     private function appendQuery($query, $endpoint)
     {
         $append = Psr7\Query::build($query);
-        return $endpoint .= strpos($endpoint, '?') ? "&{$append}" : "?$append";
+        return $endpoint .= strpos($endpoint, '?') !== false ? "&{$append}" : "?{$append}";
     }
 
     private function getVarDefinitions($command, $args)

--- a/src/S3/BucketEndpointArnMiddleware.php
+++ b/src/S3/BucketEndpointArnMiddleware.php
@@ -61,7 +61,7 @@ class BucketEndpointArnMiddleware
         Service $service,
         $region,
         array $config = [],
-        $isUseEndpointV2
+        $isUseEndpointV2 = false
     ) {
         $this->partitionProvider = PartitionEndpointProvider::defaultProvider();
         $this->region = $region;

--- a/src/S3Control/EndpointArnMiddleware.php
+++ b/src/S3Control/EndpointArnMiddleware.php
@@ -87,7 +87,7 @@ class EndpointArnMiddleware
         Service  $service,
                  $region,
         array    $config = [],
-        $isUseEndpointV2
+        $isUseEndpointV2 = false
     )
     {
         $this->partitionProvider = PartitionEndpointProvider::defaultProvider();


### PR DESCRIPTION
*Issue #, if available:*
#2558, #2559

*Description of changes:*
Makes `$endpointV2` params option in both endpointarn middleware and adds a strict check for `?` when appending query params.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
