### PR TITLE
bugfix: account for leading / in rest serializer

### DIFF
--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -245,7 +245,9 @@ abstract class RestSerializer
         }
 
         //Accounts for leading / in relative path
-        if (strpos($relative, '//') === 0) {
+        if ($this->api->isModifiedModel()
+            && strpos($relative, '//') === 0
+        ) {
             return new Uri($this->endpoint . $relative);
         }
 

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -244,6 +244,11 @@ abstract class RestSerializer
             $relative = substr($relative, 1);
         }
 
+        //Accounts for leading / in relative path
+        if (strpos($relative, '//') === 0) {
+            return new Uri($this->endpoint . $relative);
+        }
+
         // Expand path place holders using Amazon's slightly different URI
         // template syntax.
         return UriResolver::resolve($this->endpoint, new Uri($relative));


### PR DESCRIPTION
*Issue #, if available:*
#2563

*Description of changes:*
Evaluates relative path for leading `/` to account for removal of members from requestUri paths.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
