### PR TITLE
bugfix: collision in endpoint command arguments

### DIFF
--- a/.changes/nextrelease/endpoint-patch.json
+++ b/.changes/nextrelease/endpoint-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "EndpointV2",
+    "description": "Fixes #2572"
+  }
+]

--- a/src/EndpointV2/EndpointV2SerializerTrait.php
+++ b/src/EndpointV2/EndpointV2SerializerTrait.php
@@ -138,7 +138,14 @@ trait EndpointV2SerializerTrait
         $filteredArgs = [];
 
         foreach($rulesetParams as $name => $value) {
-            if (isset($rulesetParams[$name]) && isset($commandArgs[$name])) {
+            if (isset($commandArgs[$name])) {
+                $builtIn = $value->getBuiltIn();
+
+                if (isset($builtIn)
+                    && strpos($builtIn, 'SDK') === 0
+                ) {
+                    continue;
+                }
                 $filteredArgs[$name] = $commandArgs[$name];
             }
         }

--- a/tests/EndpointV2/EndpointV2SerializerTraitTest.php
+++ b/tests/EndpointV2/EndpointV2SerializerTraitTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace Aws\Test\EndpointV2;
+
+use Aws\Middleware;
+use Aws\Test\UsesServiceTrait;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers Aws\EndpointV2\EndpointV2SerializerTrait
+ */
+class EndpointV2SerializerTraitTest extends TestCase
+{
+    use UsesServiceTrait;
+
+    /**
+     * Ensures SDK-level config options used for ruleset evaluation
+     * are not overridden by a collision with a command argument
+     */
+    public function testCommandEndpointDoesNotOverrideSdkEndpoint()
+    {
+        $clientArgs = [
+            'region' => 'us-east-1',
+            'endpoint' => 'https://foo.com'
+        ];
+
+        $client = $this->getTestClient('sns', $clientArgs);
+        $this->addMockResults($client, [[]]);
+        $command = $client->getCommand(
+            'subscribe',
+            [
+                'TopicArn' => 'foo',
+                'Protocol' => 'https',
+                'Endpoint' => 'http://someurl.com'
+            ]
+        );
+        $list = $client->getHandlerList();
+        $list->appendSign(Middleware::tap(function($cmd, $req) {
+            $this->assertStringContainsString(
+                'foo.com',
+                $req->getUri()->getHost()
+            );
+        }));
+        $handler = $list->resolve();
+        $handler($command)->wait();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
#2572 

*Description of changes:*
Fixes issue in Sns `subscribe` where the `Endpoint` parameter overrides an SDK-level configuration value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
