### PR TITLE
feat: Support removing unused services only in dev environment

### DIFF
--- a/src/Script/Composer/Composer.php
+++ b/src/Script/Composer/Composer.php
@@ -7,11 +7,23 @@ use Symfony\Component\Filesystem\Filesystem;
 
 class Composer
 {
-    public static function removeUnusedServices(
-        Event      $event,
-        Filesystem $filesystem = null
-    )
+
+    public static function removeUnusedServicesInDev(Event $event, Filesystem $filesystem = null)
     {
+        self::removeUnusedServicesWithConfig($event, $filesystem, true);
+    }
+
+    public static function removeUnusedServices(Event $event, Filesystem $filesystem = null)
+    {
+        self::removeUnusedServicesWithConfig($event, $filesystem, false);
+    }
+
+    private static function removeUnusedServicesWithConfig(Event $event, Filesystem $filesystem = null, $isDev = false)
+    {
+        if ($isDev && !$event->isDevMode()){
+            return;
+        }
+
         $composer = $event->getComposer();
         $extra = $composer->getPackage()->getExtra();
         $listedServices = isset($extra['aws/aws-sdk-php'])

--- a/src/Script/Composer/README.md
+++ b/src/Script/Composer/README.md
@@ -5,7 +5,7 @@ you have feedback on the implementation, please visit the [open discussion](http
 we have on the topic.
 
 To avoid shipping unused services, specify which services you would like to keep in your `composer.json` file and
-use the `Aws\\Script\\Composer::removeUnusedServices` script:   
+use the `Aws\\Script\\Composer::removeUnusedServices` or `Aws\\Script\\Composer::removeUnusedServicesInDev` script:   
 
 ```
 {


### PR DESCRIPTION
Before people always to removing those unused services in any environments, If they miss some services that they are still using, that will cause some risks.

Now you can use the `onlyRemoveUnusedServicesInDev` method to avoid the risks.