### PR TITLE
[CloudFront] Add exception when signature generation fails

### DIFF
--- a/.changes/nextrelease/cloudfront-signed-urls.json
+++ b/.changes/nextrelease/cloudfront-signed-urls.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "CloudFront",
+        "description": "Throw exception when an empty signature for signed url is generated."
+    }
+]

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -121,7 +121,12 @@ class Signer
                 $errorMessages[] = $newMessage;
             }
             
-            throw new \RuntimeException(implode("\n",$errorMessages));
+            $exceptionMessage = "An error has occurred when signing the policy";
+            if (count($errorMessages) > 0) {
+                $exceptionMessage = implode("\n", $errorMessages);
+            }
+
+            throw new \RuntimeException($exceptionMessage);
         }
 
         return $signature;

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -72,6 +72,7 @@ class Signer
      * @return array The values needed to construct a signed URL or cookie
      * @throws \InvalidArgumentException  when not provided either a policy or a
      *                                    resource and a expires
+     * @throws \RuntimeException when generated signature is empty
      *
      * @link http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-cookies.html
      */
@@ -113,7 +114,15 @@ class Signer
     private function sign($policy)
     {
         $signature = '';
-        openssl_sign($policy, $signature, $this->pkHandle);
+        
+        if(!openssl_sign($policy, $signature, $this->pkHandle)) {
+            $errorMessages = [];
+            while(($newMessage = openssl_error_string()) !== false) {
+                $errorMessages[] = $newMessage;
+            }
+            
+            throw new \RuntimeException(implode("\n",$errorMessages));
+        }
 
         return $signature;
     }


### PR DESCRIPTION
See #2608

*Description of changes:*
On recent RHEL/RockyLinux/Alma 9 the default system security policies disable SHA-1 in OpenSSL.

This cause `CloudFrontClient` to silently fail signature generation in `getSignedUrl` and generate an URL with empty signature.
I've added a check for empty signature and an exception with OpenSSL errors to help to identify the issue.
I'd like to add a test but I'm struggling to find a way to dynamically disable the algorithm during unit tests, any suggestion is welcome.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
