### PR TITLE
bugfix: update to standard library

### DIFF
--- a/.changes/nextrelease/std-lib-patch.json
+++ b/.changes/nextrelease/std-lib-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "EndpointV2",
+    "description": "Update to standard library ParseArn function."
+  }
+]

--- a/src/EndpointV2/Ruleset/RulesetStandardLibrary.php
+++ b/src/EndpointV2/Ruleset/RulesetStandardLibrary.php
@@ -227,7 +227,7 @@ class RulesetStandardLibrary
 
         $arn = [];
         $parts = explode(':', $arnString, 6);
-        if (sizeof($parts) > 6) {
+        if (sizeof($parts) < 6) {
             return null;
         }
 
@@ -244,8 +244,7 @@ class RulesetStandardLibrary
             return null;
         }
         $resource = $arn['resourceId'];
-        $delimiter = strpos($resource, ':') !== false ? ':' : '/';
-        $arn['resourceId'] = explode($delimiter, $resource);
+        $arn['resourceId'] = preg_split("/[:\/]/", $resource);
 
         return $arn;
     }


### PR DESCRIPTION
*Description of changes:*
Splits arn resource Ids on both `:` and `/` delimiters rather than selecting one or the other.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
