### PR TITLE
Explicitly declare stream property on HashingStream

### DIFF
--- a/src/HashingStream.php
+++ b/src/HashingStream.php
@@ -17,6 +17,9 @@ class HashingStream implements StreamInterface
     /** @var callable|null */
     private $callback;
 
+    /** @var StreamInterface */
+    private $stream;
+
     /**
      * @param StreamInterface $stream     Stream that is being read.
      * @param HashInterface   $hash       Hash used to calculate checksum.


### PR DESCRIPTION
*Description of changes:* Resolves PHP 8.2 deprecation error when init'ing a HashingStream by declaring the stream property rather than relying on `@property`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
