### PR TITLE
bugfix: duplicated bucket in bucket endpoint path

### DIFF
--- a/.changes/nextrelease/bucket-endpoint-patch.json
+++ b/.changes/nextrelease/bucket-endpoint-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Fixes issue with path-style endpoints which resulted in duplicated buckets in request uri path."
+  }
+]

--- a/src/S3/BucketEndpointMiddleware.php
+++ b/src/S3/BucketEndpointMiddleware.php
@@ -46,6 +46,14 @@ class BucketEndpointMiddleware
         return $nextHandler($command, $request);
     }
 
+    /**
+     * Performs a one-time removal of Bucket from path, then if
+     * the bucket name is duplicated in the path, performs additional
+     * removal which is dependent on the number of occurrences of the bucket
+     * name in a path-like format in the key name.
+     *
+     * @return string
+     */
     private function removeBucketFromPath($path, $bucket, $key)
     {
         $occurrencesInKey = $this->getBucketNameOccurrencesInKey($key, $bucket);

--- a/src/S3/BucketEndpointMiddleware.php
+++ b/src/S3/BucketEndpointMiddleware.php
@@ -46,12 +46,15 @@ class BucketEndpointMiddleware
         return $nextHandler($command, $request);
     }
 
-    private function removeBucketFromPath($path, $bucket)
+    private function removeBucketFromPath($path, $bucket, $key)
     {
-        $len = strlen($bucket) + 1;
-        if (substr($path, 0, $len) === "/{$bucket}") {
-            $path = substr($path, $len);
-        }
+        $occurrencesInKey = $this->getBucketNameOccurrencesInKey($key, $bucket);
+        do {
+            $len = strlen($bucket) + 1;
+            if (substr($path, 0, $len) === "/{$bucket}") {
+                $path = substr($path, $len);
+            }
+        } while (substr_count($path, "/{$bucket}") > $occurrencesInKey + 1);
 
         return $path ?: '/';
     }
@@ -68,25 +71,42 @@ class BucketEndpointMiddleware
         return $host;
     }
 
+    private function getBucketNameOccurrencesInKey($key, $bucket)
+    {
+        $occurrences = 0;
+        if (empty($key)) {
+            return $occurrences;
+        }
+
+        $segments = explode('/', $key);
+        foreach($segments as $segment) {
+            if (strpos($segment, $bucket) === 0) {
+                $occurrences++;
+            }
+        }
+        return $occurrences;
+    }
+
     private function modifyRequest(
         RequestInterface $request,
         CommandInterface $command
     ) {
+        $key = isset($command['Key']) ? $command['Key'] : null;
         $uri = $request->getUri();
         $path = $uri->getPath();
         $host = $uri->getHost();
         $bucket = $command['Bucket'];
-        $path = $this->removeBucketFromPath($path, $bucket);
+        $path = $this->removeBucketFromPath($path, $bucket, $key);
         $host = $this->removeDuplicateBucketFromHost($host, $bucket);
 
         // Modify the Key to make sure the key is encoded, but slashes are not.
-        if ($command['Key']) {
+        if ($key) {
             $path = S3Client::encodeKey(rawurldecode($path));
         }
 
         return $request->withUri(
             $uri->withHost($host)
-            ->withPath($path)
+                ->withPath($path)
         );
     }
 }

--- a/tests/S3/BucketEndpointMiddlewareTest.php
+++ b/tests/S3/BucketEndpointMiddlewareTest.php
@@ -111,4 +111,63 @@ class BucketEndpointMiddlewareTest extends TestCase
         );
         $s3->execute($command);
     }
+
+    public function testHandlesDuplicatePath()
+    {
+        $s3 = $this->getTestClient('s3', [
+            'endpoint'        => 'http://domain.com/test',
+            'bucket_endpoint' => true,
+            'use_path_style_endpoint' => true
+        ]);
+        $this->addMockResults($s3, [[]]);
+        $command = $s3->getCommand('headBucket', [
+            'Bucket' => 'test',
+        ]);
+        $command->getHandlerList()->appendSign(
+            Middleware::tap(function ($cmd, $req) {
+                $this->assertSame('domain.com', $req->getUri()->getHost());
+                $this->assertSame('/test/', $req->getUri()->getPath());
+            })
+        );
+        $s3->execute($command);
+    }
+
+    public function keyContainsBucketNameProvider()
+    {
+        return [
+            ['bucketname'],
+            ['/bucketname'],
+            ['foo/bucketname/'],
+            ['/foo/bucketname'],
+            ['///bucketname'],
+            ['bucketname/bucketname/bucketname/bucketname'],
+            ['/bucketname/bucketname/bucketname/bucketname']
+        ];
+    }
+
+    /**
+     * @dataProvider keyContainsBucketNameProvider
+     *
+     * @param $key
+     */
+    public function testsHandlesDuplicatePathWithKeyContainsBucketName($key)
+    {
+        $s3 = $this->getTestClient('s3', [
+            'endpoint'        => 'http://domain.com/bucketname',
+            'bucket_endpoint' => true,
+            'use_path_style_endpoint' => true
+        ]);
+        $this->addMockResults($s3, [[]]);
+        $command = $s3->getCommand('headObject', [
+            'Bucket' => 'bucketname',
+            'Key' => $key
+        ]);
+        $command->getHandlerList()->appendSign(
+            Middleware::tap(function ($cmd, $req) use ($key) {
+                $this->assertSame('domain.com', $req->getUri()->getHost());
+                $this->assertSame('/bucketname/' . $key, $req->getUri()->getPath());
+            })
+        );
+        $s3->execute($command);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
closes #2588, potentially addresses #2585

*Description of changes:*

Prevents duplication of bucket in bucket endpoint path.  Additionally, users will need to be more explicit about what type of endpoint they expect when using the `bucket_endpoint` customization — with EndpointV2 resolution custom endpoints _must_ be passed to the provider, which means a bucket name is always prepended to the hostname unless `use_path_style_endpoint` is set to a value of `true`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
