### PR TITLE
bugfix: add MD5 header for PutObject and UploadPart by default

### DIFF
--- a/.changes/nextrelease/checksum-patch.json
+++ b/.changes/nextrelease/checksum-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Fixes bug where MD5 header is not added for PutObject and UploadPart"
+  }
+]

--- a/.changes/nextrelease/endpoint-patch.json
+++ b/.changes/nextrelease/endpoint-patch.json
@@ -1,7 +1,0 @@
-[
-  {
-    "type": "bugfix",
-    "category": "EndpointV2",
-    "description": "Fixes #2572"
-  }
-]

--- a/src/S3/ApplyChecksumMiddleware.php
+++ b/src/S3/ApplyChecksumMiddleware.php
@@ -17,7 +17,8 @@ use Psr\Http\Message\RequestInterface;
 class ApplyChecksumMiddleware
 {
     use CalculatesChecksumTrait;
-    private static $sha256 = [
+
+    private static $sha256AndMD5 = [
         'PutObject',
         'UploadPart',
     ];
@@ -91,10 +92,11 @@ class ApplyChecksumMiddleware
 
         if (!empty($checksumInfo)) {
         //if the checksum member is absent, check if it's required
-        $checksumRequired = isset($checksumInfo['requestChecksumRequired'])
-            ? $checksumInfo['requestChecksumRequired']
-            : null;
-            if (!empty($checksumRequired) && !$request->hasHeader('Content-MD5')) {
+            $checksumRequired = isset($checksumInfo['requestChecksumRequired'])
+                ? $checksumInfo['requestChecksumRequired']
+                : null;
+            if ((!empty($checksumRequired) || in_array($name, self::$sha256AndMD5))
+                && !$request->hasHeader('Content-MD5')) {
                 // Set the content MD5 header for operations that require it.
                 $request = $request->withHeader(
                     'Content-MD5',
@@ -104,7 +106,7 @@ class ApplyChecksumMiddleware
             }
         }
 
-        if (in_array($name, self::$sha256) && $command['ContentSHA256']) {
+        if (in_array($name, self::$sha256AndMD5) && $command['ContentSHA256']) {
             // Set the content hash header if provided in the parameters.
             $request = $request->withHeader(
                 'X-Amz-Content-Sha256',

--- a/tests/S3/ApplyChecksumMiddlewareTest.php
+++ b/tests/S3/ApplyChecksumMiddlewareTest.php
@@ -21,7 +21,6 @@ class ApplyChecksumMiddlewareTest extends TestCase
     {
         $s3 = $this->getTestClient(
             's3',
-            ['api_provider' => ApiProvider::filesystem(__DIR__ . '/fixtures')]
         );
         $this->addMockResults($s3, [[]]);
         $command = $s3->getCommand($operation, $args);
@@ -67,6 +66,20 @@ class ApplyChecksumMiddlewareTest extends TestCase
                 false,
                 null,
             ],
+            // Test MD5 added for operations which conditionally require it
+            [
+                'PutObject',
+                ['Bucket' => 'foo', 'Key'    => 'foo', 'Body' => 'test'],
+                true,
+                'CY9rzUYh03PK3k6DJie09g=='
+            ],
+            // Test MD5 added for operations which conditionally require it
+            [
+                'UploadPart',
+                ['Bucket' => 'foo', 'Key'    => 'foo', 'Body' => 'test', 'PartNumber' => 1, 'UploadId' => 1],
+                true,
+                'CY9rzUYh03PK3k6DJie09g=='
+            ]
         ];
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#2256 

*Description of changes:*
Adds MD5 header to PutOBject and UploadPart by default, which is in line with other AWS SDK behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
