### PR TITLE
bugfix: S3 query patch

### DIFF
--- a/.changes/nextrelease/restserializer-patch.json
+++ b/.changes/nextrelease/restserializer-patch.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "Bugfix",
+    "type": "bugfix",
     "category": "Api",
     "description": "Ensures query is separated by `/` when a request uri path is empty."
   }

--- a/.changes/nextrelease/restserializer-patch.json
+++ b/.changes/nextrelease/restserializer-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "Bugfix",
+    "category": "Api",
+    "description": "Ensures query is separated by `/` when a request uri path is empty."
+  }
+]

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -71,6 +71,10 @@ abstract class RestSerializer
         }
         $uri = $this->buildEndpoint($operation, $commandArgs, $opts);
 
+        if (empty($uri->getPath()) && !empty($uri->getQuery())) {
+            $uri = $uri->withPath('/');
+        }
+
         return new Request(
             $operation['http']['method'],
             $uri,

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -71,10 +71,6 @@ abstract class RestSerializer
         }
         $uri = $this->buildEndpoint($operation, $commandArgs, $opts);
 
-        if (empty($uri->getPath()) && !empty($uri->getQuery())) {
-            $uri = $uri->withPath('/');
-        }
-
         return new Request(
             $operation['http']['method'],
             $uri,

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -2214,4 +2214,18 @@ EOXML;
         );
         $s3->execute($command);
     }
+
+    public function testAddsForwardSlashIfEmptyPathAndQuery()
+    {
+        $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [[]]);
+        $command = $s3->getCommand('listObjectsV2', ['Bucket' => 'foo']);
+        $command->getHandlerList()->appendSign(
+            Middleware::tap(function ($cmd, $req) {
+                $this->assertSame('/', $req->getUri()->getPath());
+                $this->assertSame('list-type=2', $req->getUri()->getQuery());
+            })
+        );
+        $s3->execute($command);
+    }
 }


### PR DESCRIPTION
*Description of changes:*

Handles cases when there is an empty request path, but a non-empty query. This is a non-issue with standard signing, but resolves an issue with calculating SigV4A signatures and reflects legacy endpoint resolution behavior prior to S3 model processing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
