### PR TITLE
enhancement: update S3 ContentMD5 documentation

### DIFF
--- a/.changes/nextrelease/nextrelease.json
+++ b/.changes/nextrelease/nextrelease.json
@@ -1,5 +1,7 @@
-{
-  "type": "enhancement",
-  "category": "S3",
-  "description": "Updates to ContentMD5 api documentation."
-}
+[
+  {
+    "type": "enhancement",
+    "category": "S3",
+    "description": "Updates to ContentMD5 api documentation."
+  }
+]

--- a/.changes/nextrelease/nextrelease.json
+++ b/.changes/nextrelease/nextrelease.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "S3",
+  "description": "Updates to ContentMD5 api documentation."
+}

--- a/src/Api/DocModel.php
+++ b/src/Api/DocModel.php
@@ -97,7 +97,17 @@ class DocModel
         }
 
         if (isset($d['append'])) {
-            $result .= $d['append'];
+            if (!isset($d['excludeAppend'])
+                && !in_array($parentName, $d['excludeAppend'])
+            ) {
+                $result .= $d['append'];
+            }
+        }
+
+        if (isset($d['appendOnly'])) {
+            if (in_array($parentName, $d['appendOnly']['shapes'])) {
+                $result .= $d['appendOnly']['message'];
+            }
         }
 
         return $this->clean($result);

--- a/src/Api/DocModel.php
+++ b/src/Api/DocModel.php
@@ -104,10 +104,10 @@ class DocModel
             }
         }
 
-        if (isset($d['appendOnly'])) {
-            if (in_array($parentName, $d['appendOnly']['shapes'])) {
-                $result .= $d['appendOnly']['message'];
-            }
+        if (isset($d['appendOnly'])
+           && in_array($parentName, $d['appendOnly']['shapes'])
+        ) {
+            $result .= $d['appendOnly']['message'];
         }
 
         return $this->clean($result);

--- a/src/Api/DocModel.php
+++ b/src/Api/DocModel.php
@@ -98,7 +98,7 @@ class DocModel
 
         if (isset($d['append'])) {
             if (!isset($d['excludeAppend'])
-                && !in_array($parentName, $d['excludeAppend'])
+                || !in_array($parentName, $d['excludeAppend'])
             ) {
                 $result .= $d['append'];
             }

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -906,6 +906,20 @@ class S3Client extends AwsClient implements S3ClientInterface
             "sa-east-1",
         ];
 
+        // Add a note that the ContentMD5 is automatically computed, except for with PutObject and UploadPart
+        $docs['shapes']['ContentMD5']['append'] = '<div class="alert alert-info">The value will be computed on '
+            . 'your behalf.</div>';
+        $docs['shapes']['ContentMD5']['excludeAppend'] = ['PutObjectRequest', 'UploadPartRequest'];
+
+        //Add a note to ContentMD5 for PutObject and UploadPart that specifies the value is required
+        // When uploading to a bucket with object lock enabled and that it is not computed automatically
+        $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
+            . 'which has Object Lock enabled. It will not be calculated for you.</div>';
+        $docs['shapes']['ContentMD5']['appendOnly'] = [
+            'message' => $objectLock,
+            'shapes' => ['PutObjectRequest', 'UploadPartRequest']
+        ];
+
         return [
             new Service($api, ApiProvider::defaultProvider()),
             new DocModel($docs)

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -872,8 +872,6 @@ class S3Client extends AwsClient implements S3ClientInterface
         $api['shapes']['ContentSHA256'] = ['type' => 'string'];
         $api['shapes']['PutObjectRequest']['members']['ContentSHA256'] = ['shape' => 'ContentSHA256'];
         $api['shapes']['UploadPartRequest']['members']['ContentSHA256'] = ['shape' => 'ContentSHA256'];
-        unset($api['shapes']['PutObjectRequest']['members']['ContentMD5']);
-        unset($api['shapes']['UploadPartRequest']['members']['ContentMD5']);
         $docs['shapes']['ContentSHA256']['append'] = $opt;
 
         // Add the SaveAs parameter.
@@ -909,8 +907,10 @@ class S3Client extends AwsClient implements S3ClientInterface
         ];
 
         // Add a note that the ContentMD5 is optional.
-        $docs['shapes']['ContentMD5']['append'] = '<div class="alert alert-info">The value will be computed on '
-            . 'your behalf.</div>';
+        $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
+            . 'which has Object Lock enabled. It will not be calculated for you.</div>';
+        $api['shapes']['PutObjectRequest']['members'] .= $objectLock;
+        $api['shapes']['UploadPartRequest']['members']['ContentMD5']['append'] .= $objectLock;
 
         return [
             new Service($api, ApiProvider::defaultProvider()),

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -909,7 +909,9 @@ class S3Client extends AwsClient implements S3ClientInterface
         // Add a note that the ContentMD5 is required for Object Lock enabled buckets for PutObject and UploadPart.
         $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
             . 'which has Object Lock enabled. It will not be calculated for you.</div>';
+        print_r(['shapes']['PutObjectRequest']['members']['ContentMD5']);
         $api['shapes']['PutObjectRequest']['members']['ContentMD5'] .= $objectLock;
+        print_r($api['shapes']['UploadPartRequest']['members']['ContentMD5']);
         $api['shapes']['UploadPartRequest']['members']['ContentMD5'] .= $objectLock;
 
         return [

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -909,10 +909,8 @@ class S3Client extends AwsClient implements S3ClientInterface
         // Add a note that the ContentMD5 is required for Object Lock enabled buckets for PutObject and UploadPart.
         $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
             . 'which has Object Lock enabled. It will not be calculated for you.</div>';
-        print_r(['shapes']['PutObjectRequest']['members']['ContentMD5']);
-        $api['shapes']['PutObjectRequest']['members']['ContentMD5'] .= $objectLock;
-        print_r($api['shapes']['UploadPartRequest']['members']['ContentMD5']);
-        $api['shapes']['UploadPartRequest']['members']['ContentMD5'] .= $objectLock;
+        $api['shapes']['PutObjectRequest']['members']['ContentMD5']['append'] = $objectLock;
+        $api['shapes']['UploadPartRequest']['members']['ContentMD5']['append'] = $objectLock;
 
         return [
             new Service($api, ApiProvider::defaultProvider()),

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -909,8 +909,8 @@ class S3Client extends AwsClient implements S3ClientInterface
         // Add a note that the ContentMD5 is required for Object Lock enabled buckets for PutObject and UploadPart.
         $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
             . 'which has Object Lock enabled. It will not be calculated for you.</div>';
-        $api['shapes']['PutObjectRequest']['members'] .= $objectLock;
-        $api['shapes']['UploadPartRequest']['members']['ContentMD5']['append'] .= $objectLock;
+        $api['shapes']['PutObjectRequest']['members']['ContentMD5'] .= $objectLock;
+        $api['shapes']['UploadPartRequest']['members']['ContentMD5'] .= $objectLock;
 
         return [
             new Service($api, ApiProvider::defaultProvider()),

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -906,12 +906,6 @@ class S3Client extends AwsClient implements S3ClientInterface
             "sa-east-1",
         ];
 
-        // Add a note that the ContentMD5 is required for Object Lock enabled buckets for PutObject and UploadPart.
-        $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
-            . 'which has Object Lock enabled. It will not be calculated for you.</div>';
-        $api['shapes']['PutObjectRequest']['members']['ContentMD5']['append'] = $objectLock;
-        $api['shapes']['UploadPartRequest']['members']['ContentMD5']['append'] = $objectLock;
-
         return [
             new Service($api, ApiProvider::defaultProvider()),
             new DocModel($docs)

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -906,7 +906,7 @@ class S3Client extends AwsClient implements S3ClientInterface
             "sa-east-1",
         ];
 
-        // Add a note that the ContentMD5 is optional.
+        // Add a note that the ContentMD5 is required for Object Lock enabled buckets for PutObject and UploadPart.
         $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
             . 'which has Object Lock enabled. It will not be calculated for you.</div>';
         $api['shapes']['PutObjectRequest']['members'] .= $objectLock;


### PR DESCRIPTION
*Issue #, if available:*
closes #2304, addresses #2256

*Description of changes:*
Restores `PutObject` and `UploadPart` `ContentMD5` documentation, removes note that states "the value will be computed on your behalf" from operations where `ContentMD5` is required. 

S3 already includes a note that states SDKs will compute the MD5 for operations that require it. This is visible in our api docs.  Example: https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#putbucketacl. 

The S3 `ContentMD5` docs for `UploadPart`: 

```
The base64-encoded 128-bit MD5 digest of the part data. This parameter is auto-populated when using the command from the CLI. This parameter is required if object lock parameters are specified.
```

The S3 `ContentMD5` docs for `PutObject`:

```
The base64-encoded 128-bit MD5 digest of the message (without the headers) according to RFC 1864. This header can be used as a message integrity check to verify that the data is the same data that was originally sent. Although it is optional, we recommend using the Content-MD5 mechanism as an end-to-end integrity check. For more information about REST request authentication, see
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
