### PR TITLE
Bugfix: EndpointV2 sigv4a tests

### DIFF
--- a/.changes/nextrelease/nextrelease.json
+++ b/.changes/nextrelease/nextrelease.json
@@ -1,0 +1,7 @@
+   [
+     {
+       "type": "bugfix",
+       "category": "EndpointV2",
+       "description": "Test fixes related to signing, particularly sigv4a."
+     }
+   ]

--- a/src/EndpointV2/EndpointV2SerializerTrait.php
+++ b/src/EndpointV2/EndpointV2SerializerTrait.php
@@ -206,7 +206,7 @@ trait EndpointV2SerializerTrait
             && $authScheme['name'] !== 'sigv4a'
         ) {
             $normalizedAuthScheme['version'] = 's3v4';
-        } elseif($authScheme['name'] === 'none') {
+        } elseif ($authScheme['name'] === 'none') {
             $normalizedAuthScheme['version'] = 'anonymous';
         }
         else {

--- a/src/EndpointV2/EndpointV2SerializerTrait.php
+++ b/src/EndpointV2/EndpointV2SerializerTrait.php
@@ -185,7 +185,7 @@ trait EndpointV2SerializerTrait
         }
 
         $invalidAuthSchemesString = implode(', ', $invalidAuthSchemes);
-        $validAuthSchemesString = implode(', ', $validAuthSchemes);
+        $validAuthSchemesString = '`' . implode('`, `', $validAuthSchemes) . '`';
         throw new \InvalidArgumentException(
             "This operation requests {$invalidAuthSchemesString}"
             . " auth schemes, but the client only supports {$validAuthSchemesString}."

--- a/src/EndpointV2/EndpointV2SerializerTrait.php
+++ b/src/EndpointV2/EndpointV2SerializerTrait.php
@@ -174,6 +174,7 @@ trait EndpointV2SerializerTrait
     private function selectAuthScheme($authSchemes)
     {
         $validAuthSchemes = ['sigv4', 'sigv4a' ];
+        $unsupportedScheme = '';
 
         foreach($authSchemes as $authScheme) {
             if (in_array($authScheme['name'], $validAuthSchemes)) {
@@ -200,6 +201,7 @@ trait EndpointV2SerializerTrait
 
         if (isset($authScheme['disableDoubleEncoding'])
             && $authScheme['disableDoubleEncoding'] === true
+            && $authScheme['name'] !== 'sigv4a'
         ) {
             $normalizedAuthScheme['version'] = 's3v4';
         } else {
@@ -211,6 +213,8 @@ trait EndpointV2SerializerTrait
             $authScheme['signingName'] : null;
         $normalizedAuthScheme['region'] = isset($authScheme['signingRegion']) ?
             $authScheme['signingRegion'] : null;
+        $normalizedAuthScheme['signingRegionSet'] = isset($authScheme['signingRegionSet']) ?
+            $authScheme['signingRegionSet'] : null;
 
         return $normalizedAuthScheme;
     }

--- a/tests/EndpointV2/EndpointProviderV2Test.php
+++ b/tests/EndpointV2/EndpointProviderV2Test.php
@@ -255,6 +255,7 @@ class EndpointProviderV2Test extends TestCase
                 $expectedAuthSchemes = $expectedEndpoint['properties']['authSchemes'][0];
                 if ((isset($expectedAuthSchemes['disableDoubleEncoding'])
                     && $expectedAuthSchemes['disableDoubleEncoding'] === true)
+                    && $expectedAuthSchemes['name'] !== 'sigv4a'
                 ) {
                     $expectedVersion = 's3v4';
                 } else {
@@ -268,10 +269,18 @@ class EndpointProviderV2Test extends TestCase
                     $cmd->getAuthSchemes()['name'],
                     $expectedAuthSchemes['signingName']
                 );
-                $this->assertEquals(
-                    $cmd->getAuthSchemes()['region'],
-                    $expectedAuthSchemes['signingRegion']
-                );
+                if (isset($cmd->getAuthSchemes()['region'])) {
+                    $this->assertEquals(
+                        $cmd->getAuthSchemes()['region'],
+                        $expectedAuthSchemes['signingRegion']
+                    );
+                }elseif (isset($cmd->getAuthSchemes['signingRegionSet'])) {
+                    $this->assertEquals(
+                        $cmd->getAuthSchemes()['region'],
+                        $expectedAuthSchemes['signingRegionSet']
+                    );
+                }
+
             }
             if (isset($expectedEndpoint['headers'])) {
                 $expectedHeaders = $expectedEndpoint['headers'];

--- a/tests/EndpointV2/EndpointProviderV2Test.php
+++ b/tests/EndpointV2/EndpointProviderV2Test.php
@@ -274,13 +274,12 @@ class EndpointProviderV2Test extends TestCase
                         $cmd->getAuthSchemes()['region'],
                         $expectedAuthSchemes['signingRegion']
                     );
-                }elseif (isset($cmd->getAuthSchemes['signingRegionSet'])) {
+                } elseif (isset($cmd->getAuthSchemes['signingRegionSet'])) {
                     $this->assertEquals(
                         $cmd->getAuthSchemes()['region'],
                         $expectedAuthSchemes['signingRegionSet']
                     );
                 }
-
             }
             if (isset($expectedEndpoint['headers'])) {
                 $expectedHeaders = $expectedEndpoint['headers'];

--- a/tests/EndpointV2/EndpointV2SerializerTraitTest.php
+++ b/tests/EndpointV2/EndpointV2SerializerTraitTest.php
@@ -55,7 +55,7 @@ class EndpointV2SerializerTraitTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage(
            'This operation requests `sigvfoo`, `sigvbar`, `sigvbaz` auth schemes,'
-           . ' but the client only supports sigv4, sigv4a, none, bearer.'
+           . ' but the client only supports `sigv4`, `sigv4a`, `none`, `bearer`.'
         );
 
         $rulesetPath = __DIR__ . '/invalid-rules/invalid-scheme.json';

--- a/tests/EndpointV2/EndpointV2SerializerTraitTest.php
+++ b/tests/EndpointV2/EndpointV2SerializerTraitTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\Test\EndpointV2;
 
+use Aws\EndpointV2\EndpointDefinitionProvider;
+use Aws\EndpointV2\EndpointProviderV2;
 use Aws\Middleware;
 use Aws\Test\UsesServiceTrait;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
@@ -40,6 +42,40 @@ class EndpointV2SerializerTraitTest extends TestCase
                 $req->getUri()->getHost()
             );
         }));
+        $handler = $list->resolve();
+        $handler($command)->wait();
+    }
+
+    /**
+     * Ensures SDK-level config options used for ruleset evaluation
+     * are not overridden by a collision with a command argument
+     */
+    public function testThrowsExceptionForInvalidAuthScheme()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+           'This operation requests `sigvfoo`, `sigvbar`, `sigvbaz` auth schemes,'
+           . ' but the client only supports sigv4, sigv4a, none, bearer.'
+        );
+
+        $rulesetPath = __DIR__ . '/invalid-rules/invalid-scheme.json';
+        $rulesetDefinition = json_decode(file_get_contents($rulesetPath), true);
+        $partitions = EndpointDefinitionProvider::getPartitions();
+
+        $clientArgs = [
+            'region' => 'us-east-1',
+            'endpoint_provider' => new EndpointProviderV2($rulesetDefinition, $partitions)
+        ];
+
+        $client = $this->getTestClient('s3', $clientArgs);
+        $this->addMockResults($client, [[]]);
+        $command = $client->getCommand(
+            'headBucket',
+            [
+                'Bucket' => 'foo',
+            ]
+        );
+        $list = $client->getHandlerList();
         $handler = $list->resolve();
         $handler($command)->wait();
     }

--- a/tests/EndpointV2/invalid-rules/invalid-scheme.json
+++ b/tests/EndpointV2/invalid-rules/invalid-scheme.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "Region": {
+      "type": "string",
+      "builtIn": "AWS::Region",
+      "documentation": "The region to dispatch this request, eg. `us-east-1`."
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Template the region into the URI when region is set",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "Region"
+            }
+          ]
+        }
+      ],
+      "endpoint": {
+        "url": "https://{Region}.amazonaws.com",
+        "properties": {
+          "authSchemes": [
+            {
+              "name": "sigvfoo",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            },
+            {
+              "name": "sigvbar",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            },
+            {
+              "name": "sigvbaz",
+              "signingName": "serviceName",
+              "signingRegion": "{Region}"
+            }
+          ]
+        }
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "fallback when region is unset",
+      "conditions": [],
+      "error": "Region must be set to resolve a valid endpoint",
+      "type": "error"
+    }
+  ],
+  "version": "1.3"
+}


### PR DESCRIPTION
*Description of changes:*
Adds fix to account for `signingRegionSet` field yielded by a `sigv4a` auth scheme. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
