### PR TITLE
bugfix: add ability to calculate ContentMD5 for PutObject and UploadPart

### DIFF
--- a/.changes/nextrelease/nextrelease.json
+++ b/.changes/nextrelease/nextrelease.json
@@ -3,5 +3,10 @@
        "type": "bugfix",
        "category": "EndpointV2",
        "description": "Test fixes related to signing, particularly sigv4a."
+     },
+     {
+       "type": "bugfix",
+       "category": "S3",
+       "description": "Adds ability to calculate ContentMD5 for PutObject and UploadPart"
      }
    ]

--- a/.changes/nextrelease/nextrelease.json
+++ b/.changes/nextrelease/nextrelease.json
@@ -3,10 +3,5 @@
        "type": "bugfix",
        "category": "EndpointV2",
        "description": "Test fixes related to signing, particularly sigv4a."
-     },
-     {
-       "type": "bugfix",
-       "category": "S3",
-       "description": "Adds ability to calculate ContentMD5 for PutObject and UploadPart"
      }
    ]

--- a/src/S3/ApplyChecksumMiddleware.php
+++ b/src/S3/ApplyChecksumMiddleware.php
@@ -99,8 +99,8 @@ class ApplyChecksumMiddleware
         $checksumRequired = isset($checksumInfo['requestChecksumRequired'])
             ? $checksumInfo['requestChecksumRequired']
             : null;
-            if (!empty($checksumRequired) && !$request->hasHeader('Content-MD5')
-                || in_array($name, self::$sha256AndMd5) && $addContentMD5
+            if ((!empty($checksumRequired) && !$request->hasHeader('Content-MD5'))
+                || (in_array($name, self::$sha256AndMd5) && $addContentMD5)
             ) {
                 // Set the content MD5 header for operations that require it.
                 $request = $request->withHeader(

--- a/src/S3/ApplyChecksumMiddleware.php
+++ b/src/S3/ApplyChecksumMiddleware.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\RequestInterface;
 class ApplyChecksumMiddleware
 {
     use CalculatesChecksumTrait;
-    private static $sha256 = [
+    private static $sha256AndMd5 = [
         'PutObject',
         'UploadPart',
     ];
@@ -53,6 +53,11 @@ class ApplyChecksumMiddleware
         $next = $this->nextHandler;
         $name = $command->getName();
         $body = $request->getBody();
+
+        //Checks if AddContentMD5 has been specified for PutObject or UploadPart
+        $addContentMD5 = isset($command['AddContentMD5'])
+            ?  $command['AddContentMD5']
+            : null;
 
         $op = $this->api->getOperation($command->getName());
 
@@ -94,7 +99,9 @@ class ApplyChecksumMiddleware
         $checksumRequired = isset($checksumInfo['requestChecksumRequired'])
             ? $checksumInfo['requestChecksumRequired']
             : null;
-            if (!empty($checksumRequired) && !$request->hasHeader('Content-MD5')) {
+            if (!empty($checksumRequired) && !$request->hasHeader('Content-MD5')
+                || in_array($name, self::$sha256AndMd5) && $addContentMD5
+            ) {
                 // Set the content MD5 header for operations that require it.
                 $request = $request->withHeader(
                     'Content-MD5',
@@ -104,7 +111,7 @@ class ApplyChecksumMiddleware
             }
         }
 
-        if (in_array($name, self::$sha256) && $command['ContentSHA256']) {
+        if (in_array($name, self::$sha256AndMd5) && $command['ContentSHA256']) {
             // Set the content hash header if provided in the parameters.
             $request = $request->withHeader(
                 'X-Amz-Content-Sha256',

--- a/src/S3/MultipartUploader.php
+++ b/src/S3/MultipartUploader.php
@@ -126,6 +126,13 @@ class MultipartUploader extends AbstractUploader
 
         $body->seek(0);
         $data['Body'] = $body;
+
+        if (isset($config['add_content_md5'])
+            && $config['add_content_md5'] === true
+        ) {
+            $data['AddContentMD5'] = true;
+        }
+
         $data['ContentLength'] = $contentLength;
 
         return $data;

--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -27,6 +27,7 @@ class ObjectUploader implements PromisorInterface
         'params'        => [],
         'part_size'     => null,
     ];
+    private $addContentMD5;
 
     /**
      * @param S3ClientInterface $client         The S3 Client used to execute
@@ -59,6 +60,9 @@ class ObjectUploader implements PromisorInterface
         $this->body = Psr7\Utils::streamFor($body);
         $this->acl = $acl;
         $this->options = $options + self::$defaults;
+        // Handle "add_content_md5" option.
+        $this->addContentMD5 = isset($options['add_content_md5'])
+            && $options['add_content_md5'] === true;
     }
 
     /**
@@ -83,6 +87,7 @@ class ObjectUploader implements PromisorInterface
                 'Key'    => $this->key,
                 'Body'   => $this->body,
                 'ACL'    => $this->acl,
+                'AddContentMD5' => $this->addContentMD5
             ] + $this->options['params']);
         if (is_callable($this->options['before_upload'])) {
             $this->options['before_upload']($command);

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -900,6 +900,12 @@ class S3Client extends AwsClient implements S3ClientInterface
         $api['shapes']['UploadPartRequest']['members']['ContentSHA256'] = ['shape' => 'ContentSHA256'];
         $docs['shapes']['ContentSHA256']['append'] = $opt;
 
+        // Add the AddContentMD5 parameter.
+        $docs['shapes']['AddContentMD5']['base'] = 'Set to true to calculate the ContentMD5 for the upload.';
+        $api['shapes']['AddContentMD5'] = ['type' => 'boolean'];
+        $api['shapes']['PutObjectRequest']['members']['AddContentMD5'] = ['shape' => 'AddContentMD5'];
+        $api['shapes']['UploadPartRequest']['members']['AddContentMD5'] = ['shape' => 'AddContentMD5'];
+
         // Add the SaveAs parameter.
         $docs['shapes']['SaveAs']['base'] = 'The path to a file on disk to save the object data.';
         $api['shapes']['SaveAs'] = ['type' => 'string'];
@@ -940,7 +946,8 @@ class S3Client extends AwsClient implements S3ClientInterface
         //Add a note to ContentMD5 for PutObject and UploadPart that specifies the value is required
         // When uploading to a bucket with object lock enabled and that it is not computed automatically
         $objectLock = '<div class="alert alert-info">This value is required if uploading to a bucket '
-            . 'which has Object Lock enabled. It will not be calculated for you.</div>';
+            . 'which has Object Lock enabled. It will not be calculated for you automatically. If you wish to have '
+            . 'the value calculated for you, use the `AddContentMD5` parameter.</div>';
         $docs['shapes']['ContentMD5']['appendOnly'] = [
             'message' => $objectLock,
             'shapes' => ['PutObjectRequest', 'UploadPartRequest']

--- a/src/S3/Transfer.php
+++ b/src/S3/Transfer.php
@@ -27,6 +27,7 @@ class Transfer implements PromisorInterface
     private $mupThreshold;
     private $before;
     private $s3Args = [];
+    private $addContentMD5;
 
     /**
      * When providing the $source argument, you may provide a string referencing
@@ -134,6 +135,10 @@ class Transfer implements PromisorInterface
                 $this->addDebugToBefore($options['debug']);
             }
         }
+
+        // Handle "add_content_md5" option.
+        $this->addContentMD5 = isset($options['add_content_md5'])
+            && $options['add_content_md5'] === true;
     }
 
     /**
@@ -342,6 +347,7 @@ class Transfer implements PromisorInterface
         $args = $this->s3Args;
         $args['SourceFile'] = $filename;
         $args['Key'] = $this->createS3Key($filename);
+        $args['AddContentMD5'] = $this->addContentMD5;
         $command = $this->client->getCommand('PutObject', $args);
         $this->before and call_user_func($this->before, $command);
 
@@ -361,6 +367,7 @@ class Transfer implements PromisorInterface
             'before_upload'   => $this->before,
             'before_complete' => $this->before,
             'concurrency'     => $this->concurrency,
+            'add_content_md5' => $this->addContentMD5
         ]))->promise();
     }
 

--- a/tests/S3/MultipartUploaderTest.php
+++ b/tests/S3/MultipartUploaderTest.php
@@ -165,6 +165,7 @@ class MultipartUploaderTest extends TestCase
         $uploadOptions = [
             'bucket'          => 'foo',
             'key'             => 'bar',
+            'add_content_md5' => true,
             'params'          => [
                 'RequestPayer'  => 'test',
                 'ContentLength' => $size
@@ -175,6 +176,7 @@ class MultipartUploaderTest extends TestCase
             'before_upload'   => function($command) use ($size) {
                 $this->assertLessThan($size, $command['ContentLength']);
                 $this->assertSame('test', $command['RequestPayer']);
+                $this->assertTrue(isset($command['ContentMD5']));
             },
             'before_complete' => function($command) {
                 $this->assertSame('test', $command['RequestPayer']);

--- a/tests/S3/ObjectUploaderTest.php
+++ b/tests/S3/ObjectUploaderTest.php
@@ -240,8 +240,10 @@ class ObjectUploaderTest extends TestCase
         $client = $this->getTestClient('s3');
         $uploadOptions = [
             'params'          => ['RequestPayer' => 'test'],
+            'add_content_md5' => true,
             'before_upload'   => function($command) {
                 $this->assertSame('test', $command['RequestPayer']);
+                $this->assertTrue(isset($command['ContentMD5']));
             },
         ];
         $url = 'https://foo.s3.amazonaws.com/bar';
@@ -275,11 +277,13 @@ class ObjectUploaderTest extends TestCase
         $uploadOptions = [
             'mup_threshold'   => self::MB * 4,
             'params'          => ['RequestPayer' => 'test'],
+            'add_content_md5' => true,
             'before_initiate' => function($command) {
                 $this->assertSame('test', $command['RequestPayer']);
             },
             'before_upload'   => function($command) {
                 $this->assertSame('test', $command['RequestPayer']);
+                $this->assertTrue(isset($command['ContentMD5']));
             },
             'before_complete' => function($command) {
                 $this->assertSame('test', $command['RequestPayer']);

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -2228,4 +2228,47 @@ EOXML;
         );
         $s3->execute($command);
     }
+
+    public function testAutomaticallyComputesMD5ForPutObject()
+    {
+        $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [[]]);
+        $command = $s3->getCommand('PutObject',
+            ['Bucket' => 'foo', 'Key' => 'foo', 'Body' => 'test', 'AddContentMD5' => true]
+        );
+        $command->getHandlerList()->appendSign(
+            Middleware::tap(function ($cmd, $req) {
+                $this->assertSame(
+                    'CY9rzUYh03PK3k6DJie09g==',
+                    $req->getHeader('Content-MD5')[0]
+                );
+            })
+        );
+        $s3->execute($command);
+    }
+
+    public function testAutomaticallyComputesMD5ForUploadPart()
+    {
+        $s3 = $this->getTestClient('s3');
+        $this->addMockResults($s3, [[]]);
+        $command = $s3->getCommand('UploadPart',
+            [
+                'Bucket' => 'foo',
+                'Key' => 'foo',
+                'Body' => 'test',
+                'PartNumber' => 1,
+                'UploadId' => 'foo',
+                'AddContentMD5' => true
+            ]
+        );
+        $command->getHandlerList()->appendSign(
+            Middleware::tap(function ($cmd, $req) {
+                $this->assertSame(
+                    'CY9rzUYh03PK3k6DJie09g==',
+                    $req->getHeader('Content-MD5')[0]
+                );
+            })
+        );
+        $s3->execute($command);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #2256 

*Description of changes:*
Adds `AddContentMD5` parameter, which allows ApplyChecksumMiddleware to compute MD5 checksums for `PutObject` and `UploadPart`.  Additionally, the ObjectLoader, MultiPartUploader and the Transfer utility will now accept an option of `add_content_md5`, which when set to `true` will have the MD5 checksum calculated by ApplyChecksumMiddleware.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
