### PR TITLE
bugfix: fix integ tests

### DIFF
--- a/.changes/nextrelease/fix-integ-tests.json
+++ b/.changes/nextrelease/fix-integ-tests.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "Bugfix",
+    "type": "bugfix",
     "category": "",
     "description": "Updates to Integ tests."
   }

--- a/.changes/nextrelease/fix-integ-tests.json
+++ b/.changes/nextrelease/fix-integ-tests.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "Bugfix",
+    "category": "",
+    "description": "Updates to Integ tests."
+  }
+]

--- a/.changes/nextrelease/fix-integ-tests.json
+++ b/.changes/nextrelease/fix-integ-tests.json
@@ -2,6 +2,6 @@
   {
     "type": "bugfix",
     "category": "",
-    "description": "Updates to Integ tests."
+    "description": "Modernizes integ tests, removes integ test that relies on SigV2."
   }
 ]

--- a/behat.yml
+++ b/behat.yml
@@ -33,3 +33,6 @@ default:
         s3Encryption:
             paths: [ "%paths.base%/features/s3Encryption" ]
             contexts: [ Aws\Test\Integ\S3EncryptionContext ]
+        s3EncryptionV2:
+            paths: [ "%paths.base%/features/s3EncryptionV2" ]
+            contexts: [ Aws\Test\Integ\S3EncryptionContextV2 ]

--- a/features/s3/postObject.feature
+++ b/features/s3/postObject.feature
@@ -1,28 +1,14 @@
 @s3 @integ
 Feature: POST object uploads
 
-    Scenario: Upload an object via POST object with Signature V2
-        Given I have an s3 client and I have a file
-        And I have an array of form inputs as following:
-        |key              |value              |
-        |acl              |public-read        |
-        And I provide a json string policy as following:
-        """
-        {"expiration":"2026-04-25T22:53:16Z",
-        "conditions":[{"acl":"public-read"}]}
-        """
-        When I create a POST object SigV2 with inputs and policy
-        And I make a HTTP POST request
-        Then the file called "file.ext" is uploaded
-
     Scenario: Upload an object via POST object with Signature V4
         Given I have an s3 client and I have a file
         And I have an array of form inputs as following:
         |key              |value              |
-        |acl              |public-read        |
+        |acl              |bucket-owner-read  |
         And I provide an array of policy conditions as following:
         |key              |value              |
-        |acl              |public-read        |
+        |acl              |bucket-owner-read  |
         And I want the policy expires after "+ 2 hours"
         When I create a POST object SigV4 with inputs and policy
         And I make a HTTP POST request

--- a/features/s3Encryption/encryption.feature
+++ b/features/s3Encryption/encryption.feature
@@ -2,41 +2,36 @@
 Feature: S3 Client Side Encryption
 
   Scenario: Upload PHP's GCM encrypted fixtures
-    When I get all fixtures for "aes_gcm" from "aws-s3-shared-tests"
-    Then I encrypt each fixture with "kms" "AWS_SDK_TEST_ALIAS" "us-west-2" and "aes_gcm"
-    And upload "PHP" data with folder "version_2"
-
-  Scenario: Upload PHP's CBC encrypted fixtures
-    When I get all fixtures for "aes_cbc" from "aws-s3-shared-tests"
-    Then I encrypt each fixture with "kms" "AWS_SDK_TEST_ALIAS" "us-west-2" and "aes_cbc"
+    When I get all fixtures for "aes_gcm" from "aws-sdk-php-crypto-tests"
+    Then I encrypt each fixture with "kms" "AWS_SDK_PHP_TEST_ALIAS" "us-west-2" and "aes_gcm"
     And upload "PHP" data with folder "version_2"
 
   Scenario: Get all PHP plaintext fixtures for kms keyed aes gcm
-    When I get all fixtures for "aes_gcm" from "aws-s3-shared-tests"
+    When I get all fixtures for "aes_gcm" from "aws-sdk-php-crypto-tests"
     Then I decrypt each fixture against "PHP" "version_2"
     And I compare the decrypted ciphertext to the plaintext
 
   Scenario: Get all PHP plaintext fixtures for kms keyed aes cbc
-    When I get all fixtures for "aes_cbc" from "aws-s3-shared-tests"
+    When I get all fixtures for "aes_cbc" from "aws-sdk-php-crypto-tests"
     Then I decrypt each fixture against "PHP" "version_2"
     And I compare the decrypted ciphertext to the plaintext
 
   Scenario: Get all Go plaintext fixtures for kms keyed aes gcm
-    When I get all fixtures for "aes_gcm" from "aws-s3-shared-tests"
+    When I get all fixtures for "aes_gcm" from "aws-sdk-php-crypto-tests"
     Then I decrypt each fixture against "Go" "version_2"
     And I compare the decrypted ciphertext to the plaintext
 
   Scenario: Get all Go plaintext fixtures for kms keyed aes cbc
-    When I get all fixtures for "aes_cbc" from "aws-s3-shared-tests"
+    When I get all fixtures for "aes_cbc" from "aws-sdk-php-crypto-tests"
     Then I decrypt each fixture against "Go" "version_2"
     And I compare the decrypted ciphertext to the plaintext
 
   Scenario: Get all Java plaintext fixtures for kms keyed aes gcm
-    When I get all fixtures for "aes_gcm" from "aws-s3-shared-tests"
+    When I get all fixtures for "aes_gcm" from "aws-sdk-php-crypto-tests"
     Then I decrypt each fixture against "Java" "version_2"
     And I compare the decrypted ciphertext to the plaintext
 
   Scenario: Get all Java plaintext fixtures for kms keyed aes cbc
-    When I get all fixtures for "aes_cbc" from "aws-s3-shared-tests"
+    When I get all fixtures for "aes_cbc" from "aws-sdk-php-crypto-tests"
     Then I decrypt each fixture against "Java" "version_2"
     And I compare the decrypted ciphertext to the plaintext

--- a/features/s3EncryptionV2/encryptionV2.feature
+++ b/features/s3EncryptionV2/encryptionV2.feature
@@ -1,14 +1,9 @@
-@s3Encryption @integ
-Feature: S3 Client Side Encryption
+@s3EncryptionV2 @integ
+Feature: S3 Client Side Encryption V2
 
   Scenario: Upload PHP's GCM encrypted fixtures
     When I get all fixtures for "aes_gcm" from "aws-sdk-php-crypto-tests"
     Then I encrypt each fixture with "kms" "AWS_SDK_PHP_TEST_ALIAS" "us-west-2" and "aes_gcm"
-    And upload "PHP" data with folder "version_2"
-
-  Scenario: Upload PHP's CBC encrypted fixtures
-    When I get all fixtures for "aes_cbc" from "aws-sdk-php-crypto-tests"
-    Then I encrypt each fixture with "kms" "AWS_SDK_PHP_TEST_ALIAS" "us-west-2" and "aes_cbc"
     And upload "PHP" data with folder "version_2"
 
   Scenario: Get all PHP plaintext fixtures for kms keyed aes gcm

--- a/src/Crypto/EncryptionTraitV2.php
+++ b/src/Crypto/EncryptionTraitV2.php
@@ -73,7 +73,7 @@ trait EncryptionTraitV2
         $cipherOptions['Cipher'] = strtolower($cipherOptions['Cipher']);
 
         if (!self::isSupportedCipher($cipherOptions['Cipher'])) {
-            throw new \InvalidArgumentException('The cipher requested is not'
+            throw new \InvalidArgumentException('The cipher' . "{$cipherOptions['Cipher']}" . ' requested is not'
                 . ' supported by the SDK.');
         }
 

--- a/src/Crypto/EncryptionTraitV2.php
+++ b/src/Crypto/EncryptionTraitV2.php
@@ -73,7 +73,7 @@ trait EncryptionTraitV2
         $cipherOptions['Cipher'] = strtolower($cipherOptions['Cipher']);
 
         if (!self::isSupportedCipher($cipherOptions['Cipher'])) {
-            throw new \InvalidArgumentException('The cipher' . "{$cipherOptions['Cipher']}" . ' requested is not'
+            throw new \InvalidArgumentException('The cipher requested is not'
                 . ' supported by the SDK.');
         }
 

--- a/tests/Integ/NativeStreamContext.php
+++ b/tests/Integ/NativeStreamContext.php
@@ -91,7 +91,7 @@ class NativeStreamContext extends TestCase implements
      */
     public function iCreateASubdirectory($subdir)
     {
-        mkdir($this->getS3Path($subdir));
+        mkdir($this->getS3Path($subdir), 520);
         sleep(1);
     }
 

--- a/tests/Integ/S3Context.php
+++ b/tests/Integ/S3Context.php
@@ -226,18 +226,6 @@ class S3Context implements Context, SnippetAcceptingContext
     }
 
     /**
-     * @Given I provide a json string policy as following:
-     */
-    public function iProvideAJsonStringPolicyAsFollowing(PyStringNode $string)
-    {
-        $policy = json_decode($string->getRaw(),true);
-        $policy['conditions'][] = ["bucket" => self::getResourceName()];
-        $policy['conditions'][] = ["starts-with", '$key', ""];
-
-        $this->jsonPolicy = json_encode($policy);
-    }
-
-    /**
      * @Given I provide an array of policy conditions as following:
      */
     public function iProvideAnArrayOfPolicyConditionsAsFollowing(TableNode $table)

--- a/tests/Integ/S3Context.php
+++ b/tests/Integ/S3Context.php
@@ -238,20 +238,6 @@ class S3Context implements Context, SnippetAcceptingContext
     }
 
     /**
-     * @When I create a POST object SigV2 with inputs and policy
-     */
-    public function iCreateAPostObjectSigvWithInputsAndPolicy()
-    {
-        $postObject = new PostObject(
-            $this->s3Client,
-            self::getResourceName(),
-            $this->formInputs,
-            $this->jsonPolicy
-        );
-        $this->preparePostData($postObject);
-    }
-
-    /**
      * @Given I provide an array of policy conditions as following:
      */
     public function iProvideAnArrayOfPolicyConditionsAsFollowing(TableNode $table)

--- a/tests/Integ/S3EncryptionContextV2.php
+++ b/tests/Integ/S3EncryptionContextV2.php
@@ -1,19 +1,19 @@
 <?php
 namespace Aws\Test\Integ;
 
-use Aws\Crypto\KmsMaterialsProvider;
+use Aws\Crypto\AbstractCryptoClientV2;
+use Aws\Crypto\KmsMaterialsProviderV2;
 use Aws\Crypto\MetadataEnvelope;
 use Aws\Exception\AwsException;
-use Aws\S3\Crypto\S3EncryptionClient;
+use Aws\S3\Crypto\S3EncryptionClientV2;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Behat\Tester\Exception\PendingException;
-use Aws\Crypto\AbstractCryptoClient;
 use Aws\Kms\KmsClient;
 use PHPUnit\Framework\Assert;
 
-class S3EncryptionContext implements Context, SnippetAcceptingContext
+class S3EncryptionContextV2 implements Context, SnippetAcceptingContext
 {
     use IntegUtils;
 
@@ -23,7 +23,6 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
     private $plaintexts;
     private $decrypted;
     private $operationParams;
-
     private $region;
     private $cipher;
     private $bucket;
@@ -93,7 +92,7 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
         ]);
         $keyArn = $this->getKmsArnFromAlias($kmsClient, $alias);
 
-        $materialsProvider = new KmsMaterialsProvider(
+        $materialsProvider = new KmsMaterialsProviderV2(
             $kmsClient,
             $keyArn
         );
@@ -115,7 +114,7 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
                     continue 2;
             }
 
-            if (!AbstractCryptoClient::isSupportedCipher($shortCipher)) {
+            if (AbstractCryptoClientV2::isSupportedCipher($shortCipher)) {
                 continue;
             }
 
@@ -138,9 +137,12 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
             'region' => $this->region,
             'version' => 'latest'
         ]);
-        $s3EncryptionClient = new S3EncryptionClient($s3Client);
+        $s3EncryptionClient = new S3EncryptionClientV2($s3Client);
 
         foreach ($this->plaintexts as $fileKeyPart => $plaintext) {
+            if (empty($this->operationParams[$fileKeyPart])) {
+                continue;
+            }
             $params = $this->operationParams[$fileKeyPart];
             $params['Key'] = 'crypto_tests/'
                 . $this->cipher
@@ -148,6 +150,7 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
                 . '/language_' . $language
                 . '/ciphertext_test_case_' . $fileKeyPart;
             $params['Body'] = $plaintext;
+            $params['@KmsEncryptionContext'] = [];
 
             $s3EncryptionClient->putObject($params);
         }
@@ -158,7 +161,7 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
      */
     public function iDecryptEachFixtureAgainstLanguageEncryptionVersion($language, $folder)
     {
-        $materialsProvider = new KmsMaterialsProvider(
+        $materialsProvider = new KmsMaterialsProviderV2(
             self::getSdk()->createKms([
                 'region' => $this->region
             ])
@@ -168,7 +171,7 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
             'region' => $this->region,
             'version' => 'latest'
         ]);
-        $s3EncryptionClient = new S3EncryptionClient($s3Client);
+        $s3EncryptionClient = new S3EncryptionClientV2($s3Client);
 
         $fileKeyParts = array_keys($this->plaintexts);
         foreach ($fileKeyParts as $fileKeyPart) {
@@ -196,7 +199,10 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
             }
 
             $params['@MaterialsProvider'] = $materialsProvider;
-            $result = $s3EncryptionClient->getObject($params);
+            $params['@SecurityProfile'] = 'V2_AND_LEGACY';
+            $params['@KmsAllowDecryptWithAnyCmk'] = true;
+            //Suppress warning emitted for using legacy encryption modes
+            $result = @$s3EncryptionClient->getObject($params);
             $this->decrypted[$fileKeyPart] = (string)$result['Body'];
         }
     }
@@ -235,4 +241,3 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
         return '';
     }
 }
-


### PR DESCRIPTION
*Description of changes:*

Updates crypto test resources, removes deprecated block cipher uploads, switches `S3EncryptionClient` to `S3EncryptionClientV2`.  Same with the KMS materials provider.  Switches `PostObjectV4` test to bucket owner read permissions, removes test for deprecated `PostObjectV2`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.  
