### PR TITLE
bugfix: signature provider when sigv4a is specified

### DIFF
--- a/.changes/nextrelease/signature-provider-fix.json
+++ b/.changes/nextrelease/signature-provider-fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "SignatureProvider",
+    "description": "Fixes issue with selecting correct provider when sigv4a signing is specified."
+  }
+]

--- a/src/Signature/SignatureProvider.php
+++ b/src/Signature/SignatureProvider.php
@@ -124,7 +124,9 @@ class SignatureProvider
                         ? new S3SignatureV4($service, $region)
                         : new SignatureV4($service, $region);
                 case 'v4a':
-                    return new SignatureV4($service, $region, ['use_v4a' => true]);
+                    return !empty(self::$s3v4SignedServices[$service])
+                        ? new S3SignatureV4($service, $region)
+                        : new SignatureV4($service, $region, ['use_v4a' => true]);
                 case 'v4-unsigned-body':
                     return !empty(self::$s3v4SignedServices[$service])
                     ? new S3SignatureV4($service, $region, ['unsigned-body' => 'true'])

--- a/tests/Signature/SignatureProviderTest.php
+++ b/tests/Signature/SignatureProviderTest.php
@@ -16,8 +16,11 @@ class SignatureProviderTest extends TestCase
             ['v4', 'Aws\Signature\S3SignatureV4', 's3'],
             ['v4', 'Aws\Signature\S3SignatureV4', 's3control'],
             ['v4', 'Aws\Signature\S3SignatureV4', 's3-object-lambda'],
+            ['v4a', 'Aws\Signature\S3SignatureV4', 's3'],
+            ['v4a', 'Aws\Signature\S3SignatureV4', 's3control'],
+            ['v4a', 'Aws\Signature\S3SignatureV4', 's3-object-lambda'],
             ['v4-unsigned-body', 'Aws\Signature\SignatureV4', 'foo'],
-            ['anonymous', 'Aws\Signature\AnonymousSignature', 's3'],
+            ['anonymous', 'Aws\Signature\AnonymousSignature', 's3']
         ];
     }
 

--- a/tests/Signature/SignatureProviderTest.php
+++ b/tests/Signature/SignatureProviderTest.php
@@ -19,6 +19,9 @@ class SignatureProviderTest extends TestCase
             ['v4a', 'Aws\Signature\S3SignatureV4', 's3'],
             ['v4a', 'Aws\Signature\S3SignatureV4', 's3control'],
             ['v4a', 'Aws\Signature\S3SignatureV4', 's3-object-lambda'],
+            ['v4a', 'Aws\Signature\SignatureV4', 'eventbridge'],
+            ['v4a', 'Aws\Signature\SignatureV4', 'eventbridge'],
+            ['v4a', 'Aws\Signature\SignatureV4', 'eventbridge'],
             ['v4-unsigned-body', 'Aws\Signature\SignatureV4', 'foo'],
             ['anonymous', 'Aws\Signature\AnonymousSignature', 's3']
         ];


### PR DESCRIPTION
*Description of changes:*
Previously, sigv4a was determined in the s3 signer by looking for an mrap identifier.  With dynamic endpoint resolution, sigv4a can be specified beforehand, leading to the incorrect signer being selected for s3 sigv4a.  This results in the content-sha256 header (which is required for all s3 payloads) not being added to the request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
