### PR TITLE
enhancement: update partition to accept boolean values for variants

### DIFF
--- a/src/Endpoint/Partition.php
+++ b/src/Endpoint/Partition.php
@@ -287,12 +287,18 @@ final class Partition implements ArrayAccess, PartitionInterface
     {
         $variantTags = [];
         if (isset($options['use_fips_endpoint'])) {
-            if ($options['use_fips_endpoint']->isUseFipsEndpoint()) {
+            $useFips = $options['use_fips_endpoint'];
+            if (is_bool($useFips)) {
+                $useFips && $variantTags[] = 'fips';
+            } elseif ($useFips->isUseFipsEndpoint()) {
                 $variantTags[] = 'fips';
             }
         }
         if (isset($options['use_dual_stack_endpoint'])) {
-            if ($options['use_dual_stack_endpoint']->isUseDualStackEndpoint()) {
+            $useDualStack = $options['use_dual_stack_endpoint'];
+            if (is_bool($useDualStack)) {
+                $useDualStack && $variantTags[] = 'dualstack';
+            } elseif ($useDualStack->isUseDualStackEndpoint()) {
                 $variantTags[] = 'dualstack';
             }
         }

--- a/tests/Endpoint/PartitionTest.php
+++ b/tests/Endpoint/PartitionTest.php
@@ -964,4 +964,73 @@ class PartitionTest extends TestCase
             ]
         ];
     }
+
+    /**
+     * @dataProvider booleanConfigProvider
+     *
+     * @param array $tags
+     * @param @fipsConfig
+     * @param @dualstackConfig
+     */
+    public function testGetVariantWithBooleanConfigValues(
+        array $tags,
+              $fipsConfig,
+              $dualstackConfig
+    )
+    {
+        $definition = [
+            'partition' => 'aws_test',
+            'dnsSuffix' => 'amazonaws.com',
+            'regions' => [
+                'region' => [
+                    'description' => 'A description',
+                ],
+            ],
+            'services' => [
+                'service' => [
+                    'endpoints' => [
+                        'us-east-1' => [
+                            'variants' => [[
+                                'hostname' => 'service-fips.dualstack.testsuffix.com',
+                                'tags' => $tags
+                            ]]
+                        ],
+                        'us-west-2' => [],
+                    ],
+                ],
+            ],
+        ];
+        $partition = new Partition($definition);
+        $resolved = $partition([
+            'region' => 'us-east-1',
+            'service' => 'service',
+            'options' => [
+                'use_fips_endpoint' => $fipsConfig,
+                'use_dual_stack_endpoint' => $dualstackConfig
+            ]
+        ]);
+
+        $this->assertStringContainsString('testsuffix.com', $resolved['endpoint']);
+    }
+
+    public function booleanConfigProvider()
+    {
+        return [
+            [
+                ['fips'],
+                true,
+                false
+            ],
+            [
+                ['dualstack'],
+                false,
+                true
+            ],
+            [
+                ['fips', 'dualstack'],
+                true,
+                true
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
*Description of changes:*

Allows boolean values to be passed for `use_fips_endpoint` and `use_dual_stack_endpoint` Partition config.  This code path can be reached when instantiating a PartitionEndpointProvider.  Use case here is to bypass dynamic endpoint resolution for testing purposes while also being able to use endpoint variants. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
