### PR TITLE
Set default to empty string (fix PHP 8.1 deprecation warnings)

### DIFF
--- a/src/Crypto/EncryptionTrait.php
+++ b/src/Crypto/EncryptionTrait.php
@@ -156,7 +156,7 @@ trait EncryptionTrait
                     $cipherOptions['Iv'],
                     $cipherOptions['Aad'] = isset($cipherOptions['Aad'])
                         ? $cipherOptions['Aad']
-                        : null,
+                        : '',
                     $cipherOptions['TagLength'],
                     $cipherOptions['KeySize']
                 );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
changed the default value to empty string for getting rid of deprecation warning on openssl_encrypt using PHP 8.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
