### PR TITLE
Update functions signature to include return type

### DIFF
--- a/src/Api/AbstractModel.php
+++ b/src/Api/AbstractModel.php
@@ -36,8 +36,7 @@ abstract class AbstractModel implements \ArrayAccess
     /**
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->definition[$offset])
             ? $this->definition[$offset] : null;
@@ -46,8 +45,7 @@ abstract class AbstractModel implements \ArrayAccess
     /**
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->definition[$offset] = $value;
     }
@@ -55,8 +53,7 @@ abstract class AbstractModel implements \ArrayAccess
     /**
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->definition[$offset]);
     }
@@ -64,8 +61,7 @@ abstract class AbstractModel implements \ArrayAccess
     /**
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->definition[$offset]);
     }

--- a/src/Api/DateTimeResult.php
+++ b/src/Api/DateTimeResult.php
@@ -116,8 +116,7 @@ class DateTimeResult extends \DateTime implements \JsonSerializable
      *
      * @return string
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return (string) $this;
     }

--- a/src/HandlerList.php
+++ b/src/HandlerList.php
@@ -308,8 +308,7 @@ class HandlerList implements \Countable
     /**
      * @return int
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->steps[self::INIT])
             + count($this->steps[self::VALIDATE])

--- a/src/HasDataTrait.php
+++ b/src/HasDataTrait.php
@@ -13,8 +13,7 @@ trait HasDataTrait
     /**
      * @return \Traversable
      */
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->data);
     }
@@ -27,8 +26,7 @@ trait HasDataTrait
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
-    public function & offsetGet($offset)
+    public function & offsetGet($offset): mixed
     {
         if (isset($this->data[$offset])) {
             return $this->data[$offset];
@@ -41,8 +39,7 @@ trait HasDataTrait
     /**
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->data[$offset] = $value;
     }
@@ -50,8 +47,7 @@ trait HasDataTrait
     /**
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
@@ -59,8 +55,7 @@ trait HasDataTrait
     /**
      * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
     }
@@ -73,8 +68,7 @@ trait HasDataTrait
     /**
      * @return int
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }


### PR DESCRIPTION
*Description of changes:*
These changes just update the function signatures to include their return type. 
*Motivation:*
We have a custom drupal module to create a user for our developers to AWS IAM, every time we give new access to developers we got a huge error message about deprecated functions. I tried to update the package with composer and add `#[\ReturnTypeWillChange]` but it hasn't solved the issue, after further investigation, I managed to solve the warnings by adding the return type into function declaration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
