### PR TITLE
make aws-crt-php optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "mtdowling/jmespath.php": "^2.6",
         "ext-pcre": "*",
         "ext-json": "*",
-        "ext-simplexml": "*",
-        "aws/aws-crt-php": "^1.0.4"
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "composer/composer" : "^1.10.22",
@@ -50,7 +49,8 @@
         "ext-curl": "To send requests using cURL",
         "ext-sockets": "To use client-side monitoring",
         "doctrine/cache": "To use the DoctrineCacheAdapter",
-        "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications"
+        "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+        "aws/aws-crt-php": "To use S3 Multi-region Access Point"
     },
     "autoload": {
         "psr-4": {
@@ -70,4 +70,3 @@
         }
     }
 }
-


### PR DESCRIPTION
*Issue #, if available:*

- aws/aws-crt-php is about to change the requirement to require installing the native extension `ext-awscrt` first. So that it will break the current customers

*Description of changes:*
- Details of why we change the requirement can be found https://github.com/awslabs/aws-crt-php/pull/89
- Make `aws/aws-crt-php` a suggestion instead of require

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
