### PR TITLE
Allow S3EncryptionClient::putObject to accept any type that implement StreamInterface

### DIFF
--- a/src/Crypto/EncryptionTrait.php
+++ b/src/Crypto/EncryptionTrait.php
@@ -3,7 +3,7 @@ namespace Aws\Crypto;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\AppendStream;
-use GuzzleHttp\Psr7\Stream;
+use Psr\Http\Message\StreamInterface;
 
 trait EncryptionTrait
 {
@@ -32,8 +32,8 @@ trait EncryptionTrait
      * Builds an AesStreamInterface and populates encryption metadata into the
      * supplied envelope.
      *
-     * @param Stream $plaintext Plain-text data to be encrypted using the
-     *                          materials, algorithm, and data provided.
+     * @param StreamInterface $plaintext Plain-text data to be encrypted using the
+     *                                   materials, algorithm, and data provided.
      * @param array $cipherOptions Options for use in determining the cipher to
      *                             be used for encrypting data.
      * @param MaterialsProvider $provider A provider to supply and encrypt
@@ -49,7 +49,7 @@ trait EncryptionTrait
      * @internal
      */
     public function encrypt(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         array $cipherOptions,
         MaterialsProvider $provider,
         MetadataEnvelope $envelope
@@ -130,8 +130,8 @@ trait EncryptionTrait
      * Generates a stream that wraps the plaintext with the proper cipher and
      * uses the content encryption key (CEK) to encrypt the data when read.
      *
-     * @param Stream $plaintext Plain-text data to be encrypted using the
-     *                          materials, algorithm, and data provided.
+     * @param StreamInterface $plaintext Plain-text data to be encrypted using the
+     *                                   materials, algorithm, and data provided.
      * @param string $cek A content encryption key for use by the stream for
      *                    encrypting the plaintext data.
      * @param array $cipherOptions Options for use in determining the cipher to
@@ -142,7 +142,7 @@ trait EncryptionTrait
      * @internal
      */
     protected function getEncryptingStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         $cek,
         &$cipherOptions
     ) {

--- a/src/Crypto/EncryptionTraitV2.php
+++ b/src/Crypto/EncryptionTraitV2.php
@@ -3,7 +3,6 @@ namespace Aws\Crypto;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\AppendStream;
-use GuzzleHttp\Psr7\Stream;
 use Psr\Http\Message\StreamInterface;
 
 trait EncryptionTraitV2
@@ -37,8 +36,8 @@ trait EncryptionTraitV2
      * Builds an AesStreamInterface and populates encryption metadata into the
      * supplied envelope.
      *
-     * @param Stream $plaintext Plain-text data to be encrypted using the
-     *                          materials, algorithm, and data provided.
+     * @param StreamInterface $plaintext Plain-text data to be encrypted using the
+     *                                   materials, algorithm, and data provided.
      * @param array $options    Options for use in encryption, including cipher
      *                          options, and encryption context.
      * @param MaterialsProviderV2 $provider A provider to supply and encrypt
@@ -54,7 +53,7 @@ trait EncryptionTraitV2
      * @internal
      */
     public function encrypt(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         array $options,
         MaterialsProviderV2 $provider,
         MetadataEnvelope $envelope
@@ -145,8 +144,8 @@ trait EncryptionTraitV2
      * Generates a stream that wraps the plaintext with the proper cipher and
      * uses the content encryption key (CEK) to encrypt the data when read.
      *
-     * @param Stream $plaintext Plain-text data to be encrypted using the
-     *                          materials, algorithm, and data provided.
+     * @param StreamInterface $plaintext Plain-text data to be encrypted using the
+     *                                   materials, algorithm, and data provided.
      * @param string $cek A content encryption key for use by the stream for
      *                    encrypting the plaintext data.
      * @param array $cipherOptions Options for use in determining the cipher to
@@ -157,7 +156,7 @@ trait EncryptionTraitV2
      * @internal
      */
     protected function getEncryptingStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         $cek,
         &$cipherOptions
     ) {


### PR DESCRIPTION
`putObject` is throwing an exception if user passed a stream implemented to `StreamInterface`. I checked the usage of `$plaintext` and found that `$plaintext` is using only for constructors of `AesGcmEncryptingStream` and `AesEncryptingStream`. Those constructors requiring `StreamInterface` as first arguments. So we do not have to stick into `Stream` in `EncryptionTrait`s.

Now we are doing like this.
```php
$tfh = tmpfile();
fwrite($tfh, (string)$stream);

$result = $encryptedS3Client->putObject([
      '@MaterialsProvider' => $this->kmsProvider,
      '@CipherOptions' => $cipherOptions,
      'Bucket' => $bucket,
      'Key' => $path,
      'Body' => $tfh,
]);
```

With this PR we can save some cost like this:-
```php
$result = $encryptedS3Client->putObject([
      '@MaterialsProvider' => $this->kmsProvider,
      '@CipherOptions' => $cipherOptions,
      'Bucket' => $bucket,
      'Key' => $path,
      'Body' => $stream,
]);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
