### PR TITLE
bugfix: ACL on bucket creation in S3 Streamwrapper

### DIFF
--- a/.changes/nextrelease/streamwrapper-acl.json
+++ b/.changes/nextrelease/streamwrapper-acl.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Removes ACL from bucket creation in S3 Streamwrapper."
+  }
+]

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "aws/aws-crt-php": "^1.0.4",
-        "psr/http-message": "<1.1"
     },
     "require-dev": {
         "composer/composer" : "^1.10.22",
@@ -44,7 +43,8 @@
         "paragonie/random_compat": ">= 2",
         "sebastian/comparator": "^1.2.3 || ^4.0",
         "yoast/phpunit-polyfills": "^1.0",
-        "dms/phpunit-arraysubset-asserts": "^0.4.0"
+        "dms/phpunit-arraysubset-asserts": "^0.4.0",
+        "psr/http-message": "<1.1"
     },
     "suggest": {
         "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ext-pcre": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "aws/aws-crt-php": "^1.0.4"
+        "aws/aws-crt-php": "^1.0.4",
+        "psr/http-message": "<1.1"
     },
     "require-dev": {
         "composer/composer" : "^1.10.22",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-pcre": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "aws/aws-crt-php": "^1.0.4",
+        "aws/aws-crt-php": "^1.0.4"
     },
     "require-dev": {
         "composer/composer" : "^1.10.22",

--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -817,6 +817,7 @@ class StreamWrapper
             return $this->triggerError("Bucket already exists: {$path}");
         }
 
+        unset($params['ACL']);
         return $this->boolCall(function () use ($params, $path) {
             $this->getClient()->createBucket($params);
             $this->clearCacheKey($path);

--- a/tests/Crypto/RandomByteStream.php
+++ b/tests/Crypto/RandomByteStream.php
@@ -34,6 +34,9 @@ class RandomByteStream implements StreamInterface
         });
     }
 
+    /**
+     * @returns int
+     */
     public function getSize()
     {
         return $this->maxLength;

--- a/tests/Crypto/RandomByteStream.php
+++ b/tests/Crypto/RandomByteStream.php
@@ -35,7 +35,7 @@ class RandomByteStream implements StreamInterface
     }
 
     /**
-     * @returns int
+     * @return int|null
      */
     public function getSize()
     {

--- a/tests/S3/StreamWrapperPathStyleTest.php
+++ b/tests/S3/StreamWrapperPathStyleTest.php
@@ -268,7 +268,7 @@ class StreamWrapperPathStyleTest extends TestCase
         mkdir('s3://already-existing-bucket/key');
     }
 
-    public function testCreatingBucketsSetsAclBasedOnPermissions()
+    public function testCreatingBucketsDoesNotSetAcl()
     {
         $history = new History();
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
@@ -296,9 +296,9 @@ class StreamWrapperPathStyleTest extends TestCase
         $this->assertSame('PUT', $entries[1]['request']->getMethod());
         $this->assertSame('/bucket/', $entries[1]['request']->getUri()->getPath());
         $this->assertSame('s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertSame('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertSame('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertSame('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCreatesNestedSubfolder()

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -381,7 +381,7 @@ class StreamWrapperTest extends TestCase
         mkdir('s3://already-existing-bucket/key');
     }
 
-    public function testCreatingBucketsSetsAclBasedOnPermissions()
+    public function testCreatingBucketsDoesNotSetACL()
     {
         $history = new History();
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
@@ -409,9 +409,9 @@ class StreamWrapperTest extends TestCase
         $this->assertSame('PUT', $entries[1]['request']->getMethod());
         $this->assertSame('/', $entries[1]['request']->getUri()->getPath());
         $this->assertSame('bucket.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertSame('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertSame('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertSame('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCreatesNestedSubfolder()

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -381,7 +381,7 @@ class StreamWrapperTest extends TestCase
         mkdir('s3://already-existing-bucket/key');
     }
 
-    public function testCreatingBucketsDoesNotSetACL()
+    public function testCreatingBucketsDoesNotSetAcl()
     {
         $history = new History();
         $this->client->getHandlerList()->appendSign(Middleware::history($history));

--- a/tests/S3/StreamWrapperV2ExistenceTest.php
+++ b/tests/S3/StreamWrapperV2ExistenceTest.php
@@ -337,7 +337,7 @@ class StreamWrapperV2ExistenceTest extends TestCase
         mkdir('s3://already-existing-bucket/key');
     }
 
-    public function testCreatingBucketsSetsAclBasedOnPermissions()
+    public function testCreatingBucketsDoesNotSetAcl()
     {
         $history = new History();
         $this->client->getHandlerList()->appendSign(Middleware::history($history));
@@ -377,9 +377,9 @@ class StreamWrapperV2ExistenceTest extends TestCase
         $this->assertSame('PUT', $entries[1]['request']->getMethod());
         $this->assertSame('/', $entries[1]['request']->getUri()->getPath());
         $this->assertSame('bucket.s3.amazonaws.com', $entries[1]['request']->getUri()->getHost());
-        $this->assertSame('public-read', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertSame('authenticated-read', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
-        $this->assertSame('private', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[3]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertSame('', (string) $entries[5]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCreatesNestedSubfolder()


### PR DESCRIPTION
*Issue #, if available:*
#2674 

*Description of changes:*
Unsets ACL param when calling `createBucket` from S3StreamWrapper.  Starting this month, all new S3 buckets automatically enable BPA upon creation, meaning the only valid ACL option upon creation is `private`.  This is automatically handled on the S3 side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
