### PR TITLE
Take dependency on http-message ^1.0

### DIFF
--- a/.changes/nextrelease/http-message-fix.json
+++ b/.changes/nextrelease/http-message-fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "",
+    "description": "Takes explicit dependency on psr/http-message >= 1.0 to avoid conflicts."
+  }
+]

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ext-pcre": "*",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "aws/aws-crt-php": "^1.0.4"
+        "aws/aws-crt-php": "^1.0.4",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "composer/composer" : "^1.10.22",
@@ -39,7 +40,6 @@
         "nette/neon": "^2.3",
         "andrewsville/php-token-reflection": "^1.4",
         "psr/cache": "^1.0",
-        "psr/http-message": "^1.0",
         "psr/simple-cache": "^1.0",
         "paragonie/random_compat": ">= 2",
         "sebastian/comparator": "^1.2.3 || ^4.0",


### PR DESCRIPTION
*Description of changes:*
Takes explicit dependency on `psr/http-message`, which prevents resolution to incompatible versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
