### PR TITLE
Bugfix: remove ACL logic in S3 streamwrapper

### DIFF
--- a/.changes/nextrelease/acl-fix.json
+++ b/.changes/nextrelease/acl-fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "Bugfix",
+    "category": "S3",
+    "description": "Removes logic which determines and applies ACLs in S3 StreamWrapper's `mkdir` method."
+  }
+]

--- a/.changes/nextrelease/acl-fix.json
+++ b/.changes/nextrelease/acl-fix.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "Bugfix",
+    "type": "bugfix",
     "category": "S3",
     "description": "Removes logic which determines and applies ACLs in S3 StreamWrapper's `mkdir` method."
   }

--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -362,10 +362,6 @@ class StreamWrapper
             return false;
         }
 
-        if (!isset($params['ACL'])) {
-            $params['ACL'] = $this->determineAcl($mode);
-        }
-
         return empty($params['Key'])
             ? $this->createBucket($path, $params)
             : $this->createSubfolder($path, $params);
@@ -817,7 +813,6 @@ class StreamWrapper
             return $this->triggerError("Bucket already exists: {$path}");
         }
 
-        unset($params['ACL']);
         return $this->boolCall(function () use ($params, $path) {
             $this->getClient()->createBucket($params);
             $this->clearCacheKey($path);
@@ -884,22 +879,6 @@ class StreamWrapper
         return $result['CommonPrefixes']
             ? $this->triggerError('Subfolder contains nested folders')
             : true;
-    }
-
-    /**
-     * Determine the most appropriate ACL based on a file mode.
-     *
-     * @param int $mode File mode
-     *
-     * @return string
-     */
-    private function determineAcl($mode)
-    {
-        switch (substr(decoct($mode), 0, 1)) {
-            case '7': return 'public-read';
-            case '6': return 'authenticated-read';
-            default: return 'private';
-        }
     }
 
     /**

--- a/tests/S3/StreamWrapperPathStyleTest.php
+++ b/tests/S3/StreamWrapperPathStyleTest.php
@@ -316,7 +316,7 @@ class StreamWrapperPathStyleTest extends TestCase
         $entries = $history->toArray();
         $this->assertSame('HEAD', $entries[0]['request']->getMethod());
         $this->assertSame('PUT', $entries[1]['request']->getMethod());
-        $this->assertStringContainsString('public-read', $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertStringContainsString('', $entries[1]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCannotDeleteS3()

--- a/tests/S3/StreamWrapperTest.php
+++ b/tests/S3/StreamWrapperTest.php
@@ -429,7 +429,7 @@ class StreamWrapperTest extends TestCase
         $entries = $history->toArray();
         $this->assertSame('HEAD', $entries[0]['request']->getMethod());
         $this->assertSame('PUT', $entries[1]['request']->getMethod());
-        $this->assertStringContainsString('public-read', $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertStringContainsString('', $entries[1]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCannotDeleteS3()

--- a/tests/S3/StreamWrapperV2ExistenceTest.php
+++ b/tests/S3/StreamWrapperV2ExistenceTest.php
@@ -402,7 +402,7 @@ class StreamWrapperV2ExistenceTest extends TestCase
         $entries = $history->toArray();
         $this->assertSame('HEAD', $entries[0]['request']->getMethod());
         $this->assertSame('PUT', $entries[1]['request']->getMethod());
-        $this->assertStringContainsString('public-read', $entries[1]['request']->getHeaderLine('x-amz-acl'));
+        $this->assertStringContainsString('', $entries[1]['request']->getHeaderLine('x-amz-acl'));
     }
 
     public function testCannotDeleteS3()


### PR DESCRIPTION
*Description of changes:*

Because of S3's [recent changes](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) which enable BPA by default in buckets created after April 2023, we are no longer able to create buckets using ACLs.  Additionally, we are no longer to reasonably determine whether object creation using an ACL is possible.  For customer who wish to create objects using an ACL, they must provide it as a parameter in the stream context.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
