### PR TITLE
fix: standard retry retries on 40x errors

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -819,19 +819,21 @@ class S3Client extends AwsClient implements S3ClientInterface
                                     && $attempts < $config->getMaxAttempts()
                                 ) {
                                     if (!empty($result->getResponse())
-                                        && strpos(
-                                            $result->getResponse()->getBody(),
-                                            'Your socket connection to the server'
-                                        ) !== false
+                                        && $result->getResponse()->getStatusCode() >= 400
                                     ) {
-                                        $isRetryable = false;
+                                        return strpos(
+                                                $result->getResponse()->getBody(),
+                                                'Your socket connection to the server'
+                                            ) !== false;
                                     }
+
                                     if ($result->getPrevious() instanceof RequestException
                                         && $cmd->getName() !== 'CompleteMultipartUpload'
                                     ) {
                                         $isRetryable = true;
                                     }
                                 }
+
                                 return $isRetryable;
                             }
                         ]

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -1032,6 +1032,35 @@ EOXML;
         $this->assertSame(0, $retries);
     }
 
+    /**
+     * @dataProvider  clientRetrySettingsProvider
+     * @param $retrySettings
+     */
+    public function testRetriesFailOn400Errors($retrySettings) {
+        $retryCount = 0;
+        $client = new S3Client([
+            'version' => 'latest',
+            'region' => 'us-west-2',
+            'retries' => $retrySettings,
+            'http_handler' => function () use (&$retryCount) {
+                $retryCount++;
+                return new RejectedPromise([
+                    'connection_error' => false,
+                    'exception' => $this->getMockBuilder(S3Exception::class)
+                        ->disableOriginalConstructor()
+                        ->getMock(),
+                    'response' => new Response(404, [], null),
+                ]);
+            },
+        ]);
+        $client->getObjectAsync([
+            'Bucket' => 'bucket',
+            'Key' => 'key'
+        ])->otherwise(function () {})->wait();
+
+        $this->assertSame(1, $retryCount);
+    }
+
     public function testListObjectsAppliesUrlEncodingWhenNoneSupplied()
     {
         $client = new S3Client([
@@ -2291,34 +2320,5 @@ EOXML;
             })
         );
         $s3->execute($command);
-    }
-
-    /**
-     * @dataProvider  clientRetrySettingsProvider
-     * @param $retrySettings
-     */
-    public function testRetriesFailOn400Errors($retrySettings) {
-        $retryCount = 0;
-        $client = new S3Client([
-            'version' => 'latest',
-            'region' => 'us-west-2',
-            'retries' => $retrySettings,
-            'http_handler' => function () use (&$retryCount) {
-                $retryCount++;
-                return new RejectedPromise([
-                    'connection_error' => false,
-                    'exception' => $this->getMockBuilder(S3Exception::class)
-                        ->disableOriginalConstructor()
-                        ->getMock(),
-                    'response' => new Response(404, [], null),
-                ]);
-            },
-        ]);
-        $client->getObjectAsync([
-            'Bucket' => 'bucket',
-            'Key' => 'key'
-        ])->otherwise(function () {})->wait();
-
-        $this->assertSame(1, $retryCount);
     }
 }


### PR DESCRIPTION
When getting http 40x error and using the standard retry strategy, the 40x error was being retried when this type of error should not be retried, because it could lead to a loop, causing a huge number of retries that will never succeed. This behavior was caused by the way how the conditions were defined in the retry decider logic, that was overridden the decision of not retry this type of error. For reference check and compare the changes.

*Issue #2650, #2496, P85307087*

*Description of changes:*
Fix the condition that prevent http 40x errors from not being retried.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
