### PR TITLE
chore: update invalid covers annotations

### DIFF
--- a/tests/Api/ShapeTest.php
+++ b/tests/Api/ShapeTest.php
@@ -6,8 +6,8 @@ use Aws\Api\ShapeMap;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
- * @covers Shape
- * @covers \Aws\Api\AbstractModel
+ * @covers Aws\Api\Shape
+ * @covers Aws\Api\AbstractModel
  */
 class ShapeTest extends TestCase
 {

--- a/tests/ClientSideMonitoring/ApiCallAttemptMonitoringMiddlewareTest.php
+++ b/tests/ClientSideMonitoring/ApiCallAttemptMonitoringMiddlewareTest.php
@@ -15,8 +15,8 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers ApiCallAttemptMonitoringMiddleware
- * @covers \Aws\ClientSideMonitoring\AbstractMonitoringMiddleware
+ * @covers Aws\ClientSideMonitoring\ApiCallAttemptMonitoringMiddleware
+ * @covers Aws\ClientSideMonitoring\AbstractMonitoringMiddleware
  */
 class ApiCallAttemptMonitoringMiddlewareTest extends TestCase
 {

--- a/tests/ClientSideMonitoring/ApiCallMonitoringMiddlewareTest.php
+++ b/tests/ClientSideMonitoring/ApiCallMonitoringMiddlewareTest.php
@@ -12,8 +12,8 @@ use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers ApiCallMonitoringMiddleware
- * @covers \Aws\ClientSideMonitoring\AbstractMonitoringMiddleware
+ * @covers Aws\ClientSideMonitoring\ApiCallMonitoringMiddleware
+ * @covers Aws\ClientSideMonitoring\AbstractMonitoringMiddleware
  */
 class ApiCallMonitoringMiddlewareTest extends TestCase
 {

--- a/tests/ClientSideMonitoring/ConfigurationProviderTest.php
+++ b/tests/ClientSideMonitoring/ConfigurationProviderTest.php
@@ -13,7 +13,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 
 /**
- * @covers ConfigurationProvider
+ * @covers Aws\ClientSideMonitoring\ConfigurationProvider
  */
 class ConfigurationProviderTest extends TestCase
 {

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -16,7 +16,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 
 /**
- * @covers CredentialProvider
+ * @covers Aws\Credentials\CredentialProvider
  */
 class CredentialProviderTest extends TestCase
 {

--- a/tests/Endpoint/UseDualstackEndpoint/ConfigurationProviderTest.php
+++ b/tests/Endpoint/UseDualstackEndpoint/ConfigurationProviderTest.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Promise;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
- * @covers ConfigurationProvider
+ * @covers Aws\Endpoint\UseDualstackEndpoint\ConfigurationProvider
  */
 class ConfigurationProviderTest extends TestCase
 {

--- a/tests/Endpoint/UseFipsEndpoint/ConfigurationProviderTest.php
+++ b/tests/Endpoint/UseFipsEndpoint/ConfigurationProviderTest.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Promise;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
- * @covers ConfigurationProvider
+ * @covers Aws\Endpoint\UseFipsEndpoint\ConfigurationProvider
  */
 class ConfigurationProviderTest extends TestCase
 {

--- a/tests/EndpointDiscovery/ConfigurationProviderTest.php
+++ b/tests/EndpointDiscovery/ConfigurationProviderTest.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Promise;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
- * @covers ConfigurationProvider
+ * @covers Aws\EndpointDiscovery\ConfigurationProvider
  */
 class ConfigurationProviderTest extends TestCase
 {

--- a/tests/EndpointDiscovery/EndpointDiscoveryMiddlewareTest.php
+++ b/tests/EndpointDiscovery/EndpointDiscoveryMiddlewareTest.php
@@ -23,7 +23,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * @covers EndpointDiscoveryMiddleware
+ * @covers Aws\EndpointDiscovery\EndpointDiscoveryMiddleware
  */
 class EndpointDiscoveryMiddlewareTest extends TestCase
 {

--- a/tests/S3/UseArnRegion/ConfigurationProviderTest.php
+++ b/tests/S3/UseArnRegion/ConfigurationProviderTest.php
@@ -11,7 +11,7 @@ use GuzzleHttp\Promise;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
- * @covers ConfigurationProvider
+ * @covers Aws\S3\UseArnRegion\ConfigurationProvider
  */
 class ConfigurationProviderTest extends TestCase
 {


### PR DESCRIPTION
*Description of changes:*
Fixes PHPUnit warnings for invalid annotations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
