### PR TITLE
composer: exclude src/data from classmaps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "psr-4": {
             "Aws\\": "src/"
         },
-        "files": ["src/functions.php"]
+        "files": ["src/functions.php"],
+        "exclude-from-classmap": ["src/data/"]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Some static analysis tools have to scan the dependencies of the project. That includes walking through each autoloaded file of each package.

PHP files in `src/data` don't declare any usable symbols, so skipping those improves build times.

Tools like [ComposerRequireChecker](https://github.com/maglnet/ComposerRequireChecker) rely on `exclude-from-classmap` to improve the search time.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
