### PR TITLE
bugfix: unset aws_region during unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clear-cache:
 	php build/aws-clear-cache.php
 
 test:
-	@AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_CSM_ENABLED=false \
+	@AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_CSM_ENABLED=false AWS_REGION= \
 	vendor/bin/phpunit --testsuite=unit $(TEST)
 
 test-phar: package


### PR DESCRIPTION
*Description of changes:*
Temporarily unsets `AWS_REGION` when running unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
