### PR TITLE
enhancement: address deprecation warnings

### DIFF
--- a/src/Crypto/Polyfill/ByteArray.php
+++ b/src/Crypto/Polyfill/ByteArray.php
@@ -138,6 +138,7 @@ class ByteArray extends \SplFixedArray
      * @param int $newval
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($index, $newval)
     {
         parent::offsetSet($index, $newval & 0xff);

--- a/src/EndpointV2/Ruleset/RulesetStandardLibrary.php
+++ b/src/EndpointV2/Ruleset/RulesetStandardLibrary.php
@@ -155,7 +155,11 @@ class RulesetStandardLibrary
      */
     public function parseUrl($url)
     {
-        $parsed = parse_url($url);
+        if (is_null($url)) {
+            return null;
+        }
+
+        $parsed = $parsed = parse_url($url);
 
         if ($parsed === false || !empty($parsed['query'])) {
             return null;

--- a/tests/Endpoint/UseDualstackEndpoint/ConfigurationProviderTest.php
+++ b/tests/Endpoint/UseDualstackEndpoint/ConfigurationProviderTest.php
@@ -141,7 +141,7 @@ EOT;
         file_put_contents($dir . '/config', $this->iniFile);
         putenv('HOME=' . dirname($dir));
         /** @var ConfigurationInterface $result */
-        $result = call_user_func(ConfigurationProvider::ini(null, null))->wait();
+        $result = call_user_func(ConfigurationProvider::ini('foo-region', null))->wait();
         $this->assertSame($expected->toArray(), $result->toArray());
         unlink($dir . '/config');
     }
@@ -155,7 +155,7 @@ EOT;
         file_put_contents($dir . '/alt_config', $this->altIniFile);
         putenv('HOME=' . dirname($dir));
         /** @var ConfigurationInterface $result */
-        $result = call_user_func(ConfigurationProvider::ini(null, null))->wait();
+        $result = call_user_func(ConfigurationProvider::ini('foo-region', null))->wait();
         $this->assertSame($expected->toArray(), $result->toArray());
         unlink($dir . '/config');
         unlink($dir . '/alt_config');


### PR DESCRIPTION
*Description of changes:*
Fixes deprecation warnings related to passing null as an argument to `strpos` and `parseurl`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
