### PR TITLE
fix/deprecated-default-user-agent

### DIFF
--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Message\ResponseInterface as GuzzleResponse;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface as Psr7Request;
 use Psr\Http\Message\StreamInterface as Psr7StreamInterface;
 
@@ -163,7 +164,7 @@ class GuzzleHandler
         $request->setHeader(
             'User-Agent',
             $request->getHeader('User-Agent')
-                . ' ' . Client::getDefaultUserAgent()
+                . ' ' . Utils::defaultUserAgent()
         );
 
         // Make sure the delay is configured, if provided.

--- a/src/Handler/GuzzleV7/GuzzleHandler.php
+++ b/src/Handler/GuzzleV7/GuzzleHandler.php
@@ -1,0 +1,89 @@
+<?php
+namespace Aws\Handler\GuzzleV7;
+
+use Exception;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\TransferStats;
+use GuzzleHttp\Utils;
+use Psr\Http\Message\RequestInterface as Psr7Request;
+
+/**
+ * A request handler that sends PSR-7-compatible requests with Guzzle 6.
+ */
+class GuzzleHandler
+{
+    /** @var ClientInterface */
+    private $client;
+
+    /**
+     * @param ClientInterface $client
+     */
+    public function __construct(ClientInterface $client = null)
+    {
+        $this->client = $client ?: new Client();
+    }
+
+    /**
+     * @param Psr7Request $request
+     * @param array       $options
+     *
+     * @return Promise\Promise
+     */
+    public function __invoke(Psr7Request $request, array $options = [])
+    {
+        $request = $request->withHeader(
+            'User-Agent',
+            $request->getHeaderLine('User-Agent')
+                . ' ' . Utils::defaultUserAgent()
+        );
+
+        return $this->client->sendAsync($request, $this->parseOptions($options))
+            ->otherwise(
+                static function ($e) {
+                    $error = [
+                        'exception'        => $e,
+                        'connection_error' => $e instanceof ConnectException,
+                        'response'         => null,
+                    ];
+
+                    if (
+                        ($e instanceof RequestException)
+                        && $e->getResponse()
+                    ) {
+                        $error['response'] = $e->getResponse();
+                    }
+
+                    return new Promise\RejectedPromise($error);
+                }
+            );
+    }
+
+    private function parseOptions(array $options)
+    {
+        if (isset($options['http_stats_receiver'])) {
+            $fn = $options['http_stats_receiver'];
+            unset($options['http_stats_receiver']);
+
+            $prev = isset($options['on_stats'])
+                ? $options['on_stats']
+                : null;
+
+            $options['on_stats'] = static function (
+                TransferStats $stats
+            ) use ($fn, $prev) {
+                if (is_callable($prev)) {
+                    $prev($stats);
+                }
+                $transferStats = ['total_time' => $stats->getTransferTime()];
+                $transferStats += $stats->getHandlerStats();
+                $fn($transferStats);
+            };
+        }
+
+        return $options;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,6 +2,7 @@
 namespace Aws;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
@@ -275,10 +276,12 @@ function default_http_handler()
 {
     $version = guzzle_major_version();
     // If Guzzle 6 or 7 installed
-    if ($version === 6 || $version === 7) {
+    if ($version === 7) {
+        return new \Aws\Handler\GuzzleV7\GuzzleHandler();
+    }
+    if ($version === 6) {
         return new \Aws\Handler\GuzzleV6\GuzzleHandler();
     }
-
     // If Guzzle 5 installed
     if ($version === 5) {
         return new \Aws\Handler\GuzzleV5\GuzzleHandler();
@@ -295,17 +298,12 @@ function default_http_handler()
 function default_user_agent()
 {
     $version = guzzle_major_version();
-    // If Guzzle 6 or 7 installed
-    if ($version === 6 || $version === 7) {
+    // If Guzzle 6 installed
+    if ($version === 6) {
         return \GuzzleHttp\default_user_agent();
+    }else{
+        return Utils::defaultUserAgent();
     }
-
-    // If Guzzle 5 installed
-    if ($version === 5) {
-        return \GuzzleHttp\Client::getDefaultUserAgent();
-    }
-
-    throw new \RuntimeException('Unknown Guzzle version: ' . $version);
 }
 
 /**


### PR DESCRIPTION
Issue #, if available:
All other implementations are not conistent over versions guzzle 5 to 7
some will be removed in guzzle 8
guzzle 6 doesnt have Utils::defaultUserAgent()

Description of changes:
changed defaultagent detection behaviour to the one available in Utils Class
Utils::defaultUserAgent()

guzzle function.php:
" * @deprecated default_user_agent will be removed in guzzlehttp/guzzle:8.0. Use Utils::defaultUserAgent instead."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
