### PR TITLE
enhancement: treat php >=8.1 deprecation warning on Credentials.php

### DIFF
--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -23,8 +23,8 @@ class Credentials implements CredentialsInterface, \Serializable
      */
     public function __construct($key, $secret, $token = null, $expires = null)
     {
-        $this->key = trim($key);
-        $this->secret = trim($secret);
+        $this->key = trim((string) $key);
+        $this->secret = trim((string) $secret);
         $this->token = $token;
         $this->expires = $expires;
     }


### PR DESCRIPTION
*Issue #, if available:*

**trim(): Passing null to parameter # 1 ($string) of type string is deprecated on Credentials.php**

*Description of changes:*

A casting to string was applied to ensure this type is been used in trim function.

The behavior keeps the same on [older versions of php](https://onlinephp.io/c/dc989) (no break changes). 

[Reference](https://stackoverflow.com/questions/71707325/migration-to-php-8-1-how-to-fix-deprecated-passing-null-to-parameter-error-r)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
