### PR TITLE
chore: update documentation to reflect php support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Jump To:
 1. **Sign up for AWS** – Before you begin, you need to
    sign up for an AWS account and retrieve your [AWS credentials][docs-signup].
 2. **Minimum requirements** – To run the SDK, your system will need to meet the
-   [minimum requirements][docs-requirements], including having **PHP >= 5.5**.
+   [minimum requirements][docs-requirements], including having **PHP >= 7.2.5**.
    We highly recommend having it compiled with the cURL extension and cURL
    7.16.2+ compiled with a TLS backend (e.g., NSS or OpenSSL).
 3. **Install the SDK** – Using [Composer] is the recommended way to install the


### PR DESCRIPTION
After August 15, 2023, AWS SDK for PHP will not longer support PHP versions 7.2.4 and below, and therefore we are updating our documentation to reflect the new minimum PHP version required, that is PHP 7.2.5.

*Issue #2799*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
