### PR TITLE
Add missing PHPDoc annotation for Doctrine Cache implementations

### DIFF
--- a/.changes/nextrelease/enhancement-add-phpdoc-doctrine-cache
+++ b/.changes/nextrelease/enhancement-add-phpdoc-doctrine-cache
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Add missing PHPDoc annotation for Doctrine Cache implementations."
+    }
+]

--- a/src/DoctrineCacheAdapter.php
+++ b/src/DoctrineCacheAdapter.php
@@ -18,6 +18,9 @@ class DoctrineCacheAdapter implements CacheInterface, Cache
         return $this->cache->fetch($key);
     }
 
+    /**
+     * @return mixed
+     */
     public function fetch($key)
     {
         return $this->get($key);
@@ -28,6 +31,9 @@ class DoctrineCacheAdapter implements CacheInterface, Cache
         return $this->cache->save($key, $value, $ttl);
     }
 
+    /**
+     * @return bool
+     */
     public function save($key, $value, $ttl = 0)
     {
         return $this->set($key, $value, $ttl);
@@ -38,16 +44,25 @@ class DoctrineCacheAdapter implements CacheInterface, Cache
         return $this->cache->delete($key);
     }
 
+    /**
+     * @return bool
+     */
     public function delete($key)
     {
         return $this->remove($key);
     }
 
+    /**
+     * @return bool
+     */
     public function contains($key)
     {
         return $this->cache->contains($key);
     }
 
+    /**
+     * @return mixed[]|null
+     */
     public function getStats()
     {
         return $this->cache->getStats();


### PR DESCRIPTION
This fixes the following deprecations produced by Symfony:

* User Deprecated: Method `Doctrine\Common\Cache\Cache::fetch()` might add `mixed` as a native return type declaration in the future. Do the same in implementation `Aws\DoctrineCacheAdapter` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* User Deprecated: Method `Doctrine\Common\Cache\Cache::save()` might add `bool` as a native return type declaration in the future. Do the same in implementation `Aws\DoctrineCacheAdapter` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* User Deprecated: Method `Doctrine\Common\Cache\Cache::delete()` might add `bool` as a native return type declaration in the future. Do the same in implementation `Aws\DoctrineCacheAdapter` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* User Deprecated: Method `Doctrine\Common\Cache\Cache::contains()` might add `bool` as a native return type declaration in the future. Do the same in implementation `Aws\DoctrineCacheAdapter` now to avoid errors or add an explicit `@return` annotation to suppress this message.
* User Deprecated: Method `Doctrine\Common\Cache\Cache::getStats()` might add `?array` as a native return type declaration in the future. Do the same in implementation `Aws\DoctrineCacheAdapter` now to avoid errors or add an explicit `@return` annotation to suppress this message.

This is similar to what was done here:
* https://github.com/aws/aws-sdk-php/pull/2434
* https://github.com/aws/aws-sdk-php/pull/2361