### PR TITLE
Fix deprecated use of ${var} in DocModel.php

### DIFF
--- a/src/Api/DocModel.php
+++ b/src/Api/DocModel.php
@@ -90,8 +90,8 @@ class DocModel
 
         $result = '';
         $d = $this->docs['shapes'][$shapeName];
-        if (isset($d['refs']["{$parentName}\$${ref}"])) {
-            $result = $d['refs']["{$parentName}\$${ref}"];
+        if (isset($d['refs']["{$parentName}\${$ref}"])) {
+            $result = $d['refs']["{$parentName}\${$ref}"];
         } elseif (isset($d['base'])) {
             $result = $d['base'];
         }


### PR DESCRIPTION
Since PHP 8.2 the syntax "${var}" is deprecated.
"{$var}" should be used instead.

*Description of changes:*

PHPCompatibility detected the following issues with PHP 8.2:
```
FILE: /.../aws/aws-sdk-php/src/Api/DocModel.php
--------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
--------------------------------------------------------------------------------------------------------
 93 | WARNING | Using ${var} in strings is deprecated since PHP 8.2, use {$var} instead. Found: ${ref}
    |         | (PHPCompatibility.TextStrings.RemovedDollarBraceStringEmbeds.DeprecatedVariableSyntax)
 94 | WARNING | Using ${var} in strings is deprecated since PHP 8.2, use {$var} instead. Found: ${ref}
    |         | (PHPCompatibility.TextStrings.RemovedDollarBraceStringEmbeds.DeprecatedVariableSyntax)
--------------------------------------------------------------------------------------------------------
```

This PR fixes them by using the recommended `{$var}` syntax instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
