### PR TITLE
bugfix: update batching integ

### DIFF
--- a/tests/Integ/BatchingContext.php
+++ b/tests/Integ/BatchingContext.php
@@ -198,9 +198,9 @@ class BatchingContext extends TestCase implements
             ->getQueueUrl(['QueueName' => self::$resource])['QueueUrl'];
         $messages = [];
         while (count($messages) < $messageCount) {
-            $result = $this->client->receiveMessage([
+            $result = @$this->client->receiveMessage([
                 'QueueUrl' => $queueUrl,
-                'MaxNumberOfMessages' => (int) $messageCount,
+                'MaxNumberOfMessages' => $messageCount,
             ]);
 
             foreach ($result['Messages'] as $message) {

--- a/tests/Integ/BatchingContext.php
+++ b/tests/Integ/BatchingContext.php
@@ -200,7 +200,7 @@ class BatchingContext extends TestCase implements
         while (count($messages) < $messageCount) {
             $result = $this->client->receiveMessage([
                 'QueueUrl' => $queueUrl,
-                'MaxNumberOfMessages' => $messageCount,
+                'MaxNumberOfMessages' => (int) $messageCount,
             ]);
 
             foreach ($result['Messages'] as $message) {


### PR DESCRIPTION
*Description of changes:*
Suppresses warning which causes integ test to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
