### PR TITLE
Fix Log Prefix Formation with Multi-Account Organization Support in C…

### DIFF
--- a/.changes/nextrelease/ enhancement-add-organization-template-cloud-trail
+++ b/.changes/nextrelease/ enhancement-add-organization-template-cloud-trail
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "CloudTrail",
+        "description": "Fix Log Prefix Formation with Multi-Account Organization Support in CloudTrail"
+    }
+]

--- a/src/CloudTrail/LogFileIterator.php
+++ b/src/CloudTrail/LogFileIterator.php
@@ -20,7 +20,7 @@ class LogFileIterator extends \IteratorIterator
 {
     // For internal use
     const DEFAULT_TRAIL_NAME = 'Default';
-    const PREFIX_TEMPLATE = 'prefix/AWSLogs/account/CloudTrail/region/date/';
+    const PREFIX_TEMPLATE = 'prefix/AWSLogs/organization/account/CloudTrail/region/date/';
     const PREFIX_WILDCARD = '*';
 
     // Option names used internally or externally
@@ -30,6 +30,7 @@ class LogFileIterator extends \IteratorIterator
     const END_DATE = 'end_date';
     const ACCOUNT_ID = 'account_id';
     const LOG_REGION = 'log_region';
+    const ORGANIZATION_ID = 'organization_id';
 
     /** @var S3Client S3 client used to perform ListObjects operations */
     private $s3Client;
@@ -163,6 +164,9 @@ class LogFileIterator extends \IteratorIterator
             'prefix' => isset($options[self::KEY_PREFIX])
                     ? $options[self::KEY_PREFIX]
                     : null,
+            'organization' => isset($options[self::ORGANIZATION_ID])
+                    ? $options[self::ORGANIZATION_ID]
+                    : null,                    
             'account' => isset($options[self::ACCOUNT_ID])
                     ? $options[self::ACCOUNT_ID]
                     : self::PREFIX_WILDCARD,
@@ -175,6 +179,8 @@ class LogFileIterator extends \IteratorIterator
         // Determine the longest key prefix that can be used to retrieve all
         // of the relevant log files.
         $candidatePrefix = ltrim(strtr(self::PREFIX_TEMPLATE, $parts), '/');
+        // Normalize the key prefix to remove double slashes
+        $candidatePrefix = preg_replace('#/{2,}#', '/', $candidatePrefix);
         $logKeyPrefix = $candidatePrefix;
         $index = strpos($candidatePrefix, self::PREFIX_WILDCARD);
 


### PR DESCRIPTION
Description:
This PR introduces a necessary change to the AWS SDK PHP to address an issue encountered during the configuration of AWS CloudTrail with the 'Enable for all accounts in my organization' option. This setting introduces an additional directory layer after AWSLogs to accommodate organization IDs, which was not accounted for in the existing SDK logic. As a result, log retrieval for multi-account setups within an organization was failing. The implemented fix normalizes the log prefix, ensuring that the SDK can successfully access and iterate over log files in S3 buckets across multiple AWS accounts with the organization feature enabled.

Impact:
This update ensures seamless functionality for new multi-account organizational setups while preserving the behavior for existing single-account implementations. It's an optional adjustment that only affects users who opt into organization-level logging.