### PR TITLE
bugfix: remove queueurl middleware

### DIFF
--- a/.changes/nextrelease/remove-sqs-middleware.json
+++ b/.changes/nextrelease/remove-sqs-middleware.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Sqs",
+    "description": "Moves queue url middleware, which is no longer needed after the SQS migration from query to json protocol."
+  }
+]

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -64,7 +64,6 @@ class SqsClient extends AwsClient
     {
         parent::__construct($config);
         $list = $this->getHandlerList();
-        $list->appendBuild($this->queueUrl(), 'sqs.queue_url');
         $list->appendSign($this->validateMd5(), 'sqs.md5');
     }
 
@@ -91,29 +90,6 @@ class SqsClient extends AwsClient
             $queueArn = substr_replace($queueArn, '.fifo', -5);
         }
         return $queueArn;
-    }
-
-    /**
-     * Moves the URI of the queue to the URI in the input parameter.
-     *
-     * @return callable
-     */
-    private function queueUrl()
-    {
-        return static function (callable $handler) {
-            return function (
-                CommandInterface $c,
-                RequestInterface $r = null
-            ) use ($handler) {
-                if ($c->hasParam('QueueUrl')) {
-                    $r = $r->withUri(UriResolver::resolve(
-                        $r->getUri(),
-                        new Uri($c['QueueUrl'])
-                    ));
-                }
-                return $handler($c, $r);
-            };
-        };
     }
 
     /**

--- a/tests/Sqs/SqsClientTest.php
+++ b/tests/Sqs/SqsClientTest.php
@@ -165,19 +165,4 @@ class SqsClientTest extends TestCase
         $this->addMockResults($client, [new Result()]);
         $client->listQueues();
     }
-
-    public function testUpdatesQueueUrl()
-    {
-        // Setup state of command/request
-        $newUrl = 'https://queue.amazonaws.com/stuff/in/the/path';
-        $client = new SqsClient([
-            'region'  => 'us-east-1',
-            'version' => 'latest'
-        ]);
-        $this->addMockResults($client, [[]]);
-        $client->getHandlerList()->appendSign(Middleware::tap(function ($c, $r) use ($newUrl) {
-            $this->assertSame($newUrl, (string)$r->getUri());
-        }));
-        $client->receiveMessage(['QueueUrl' => $newUrl]);
-    }
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #2822 

*Description of changes:*
Removes SQS queue url middleware, which replaced the base url with the queue url, when `QueueUrl` was provided.  Because SQS has migrated to JSON protocol, this is now being handled by SQS using the `QueueUrl` value provided in the JSON payload.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
