### PR TITLE
enhancement: sqs response md5 validation

### DIFF
--- a/.changes/nextrelease/sqs-response-middleware.json
+++ b/.changes/nextrelease/sqs-response-middleware.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "Sqs",
+    "description": "Updates response md5 validation"
+  }
+]

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -215,7 +215,7 @@ class SqsClient extends AwsClient
                                             ]
                                         );
                                     }
-                                } else if (isset($msg['MessageAttributes'])) {
+                                } else if (!empty($msg['MessageAttributes'])) {
                                     throw new SqsException(
                                         sprintf(
                                             'No Attribute MD5 found. Expected %s',

--- a/tests/Sqs/SqsClientTest.php
+++ b/tests/Sqs/SqsClientTest.php
@@ -165,4 +165,31 @@ class SqsClientTest extends TestCase
         $this->addMockResults($client, [new Result()]);
         $client->listQueues();
     }
+
+    public function testDoesNotValidateEmptyMessageAttributes()
+    {
+        $client = new SqsClient([
+            'region'  => 'us-west-2',
+            'version' => 'latest'
+        ]);
+
+        $mock = new Result([
+            'Messages' => [
+                [
+                    'Body' => 'Test',
+                    'MessageAttributes' => []
+                ]
+            ]
+        ]);
+
+        $this->addMockResults($client, [$mock]);
+        $response = $client->receiveMessage([
+            'QueueUrl' => 'http://foo.com',
+            'MessageAttributeNames' => [
+                'All'
+            ],
+        ]);
+
+        $this->assertEmpty($response->get('MessageAttributes'));
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #2827

*Description of changes:*
Updates validation of response MD5s.  If the value for `MessageAttributes` is empty, do not expect an MD5.  `SqsClient::calculateMessageAttributesMd5` returns `null` on an empty value anyway.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
