### PR TITLE
enhancement: hostname resolution

### DIFF
--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -211,6 +211,8 @@ class EcsCredentialProvider
      */
     private function isLoopbackAddress($host)
     {
+        $host = gethostbyname($host);
+
         if (!filter_var($host, FILTER_VALIDATE_IP)) {
             return false;
         }

--- a/tests/Credentials/fixtures/ecs/uri-token-resolution.json
+++ b/tests/Credentials/fixtures/ecs/uri-token-resolution.json
@@ -63,6 +63,34 @@
       }
     },
     {
+      "description": "http loopback(v4) with host resolution (no port)",
+      "env": {
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://localhost/credentials"
+      },
+      "expect": {
+        "type": "success",
+        "request": {
+          "method": "GET",
+          "uri": "http://localhost/credentials",
+          "headers": {}
+        }
+      }
+    },
+    {
+      "description": "http loopback(v4) with host resolution (port)",
+      "env": {
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://localhost:8080/credentials"
+      },
+      "expect": {
+        "type": "success",
+        "request": {
+          "method": "GET",
+          "uri": "http://localhost:8080/credentials",
+          "headers": {}
+        }
+      }
+    },
+    {
       "description": "http loopback(v6) URI",
       "env": {
         "AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://[::1]/credentials"


### PR DESCRIPTION
*Description of changes:*
Adds hostname resolution to the ECS credential provider. E.G. things like `localhost` will pass validation rather than relying on a strict ipv4/v6 string validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
