### PR TITLE
Add support for psr/simple-cache v2 and v3

### DIFF
--- a/.changes/nextrelease/simple-cache.json
+++ b/.changes/nextrelease/simple-cache.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "",
+    "description": "Adds support for psr/simple-cache v2 and v3"
+  }
+]

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "nette/neon": "^2.3",
         "andrewsville/php-token-reflection": "^1.4",
         "psr/cache": "^1.0",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "paragonie/random_compat": ">= 2",
         "sebastian/comparator": "^1.2.3 || ^4.0",
         "yoast/phpunit-polyfills": "^1.0",


### PR DESCRIPTION
*Issue #, if available:*
I don't think i need to create an issue for this.

*Description of changes:*
I need this change when peer-dependencies require different version of the `psr/simple-cache` package.
In my case, the package `mobiledetect/mobiledetectlib` require version 3. Since these versions do not change public interface (only type safety was added) i think it is safe to allow this.