### PR TITLE
Add options to createPresignedRequest method

### DIFF
--- a/src/S3/S3MultiRegionClient.php
+++ b/src/S3/S3MultiRegionClient.php
@@ -321,7 +321,8 @@ class S3MultiRegionClient extends BaseClient implements S3ClientInterface
         );
         return $client->createPresignedRequest(
             $client->getCommand($command->getName(), $command->toArray()),
-            $expires
+            $expires,
+            $options
         );
     }
 


### PR DESCRIPTION
*Issue: None

*Description of changes:*
This tiny change will make it possible to sign pre-signed-requests with optional parameters, this can be used to make use of this part of the code:

https://github.com/aws/aws-sdk-php/blob/725492580ef8a49108e39803dc266c25faa30d5a/src/Signature/SignatureV4.php#L169-L171

This wil make it possible to sign the S3 links with a timestamp in the past!
This is very handy if you want to make use of short caching.
Without the options, every signed url will have an unique signature, because time() function is used.

Found here:
https://github.com/clauculo/aws-sdk-php/blob/725492580ef8a49108e39803dc266c25faa30d5a/src/Signature/SignatureV4.php#L171

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
