### PR TITLE
Fix inconsistency with .env loaders out of the box

### DIFF
--- a/features/bootstrap/Aws/Test/Integ/ClientSideMonitoringContext.php
+++ b/features/bootstrap/Aws/Test/Integ/ClientSideMonitoringContext.php
@@ -21,6 +21,8 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
+use function Aws\getenv;
+
 class ClientSideMonitoringContext extends TestCase
     implements Context, SnippetAcceptingContext
 {

--- a/features/bootstrap/Aws/Test/Integ/IntegUtils.php
+++ b/features/bootstrap/Aws/Test/Integ/IntegUtils.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\Test\Integ;
 
+use function Aws\getenv;
+
 trait IntegUtils
 {
     private static $originalCsmEnabled;

--- a/src/AbstractConfigurationProvider.php
+++ b/src/AbstractConfigurationProvider.php
@@ -3,6 +3,8 @@ namespace Aws;
 
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a configuration object. This class provides base functionality

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -36,6 +36,8 @@ use GuzzleHttp\Promise\PromiseInterface;
 use InvalidArgumentException as IAE;
 use Psr\Http\Message\RequestInterface;
 
+use function Aws\getenv;
+
 /**
  * @internal Resolves a hash of client arguments to construct a client.
  */

--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -8,6 +8,8 @@ use Aws\ConfigurationProviderInterface;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that accepts no arguments and returns
  * a promise that is fulfilled with a {@see \Aws\ClientSideMonitoring\ConfigurationInterface}

--- a/src/Configuration/ConfigurationResolver.php
+++ b/src/Configuration/ConfigurationResolver.php
@@ -2,6 +2,8 @@
 
 namespace Aws\Configuration;
 
+use function Aws\getenv;
+
 class ConfigurationResolver
 {
     const ENV_PROFILE = 'AWS_PROFILE';

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -7,6 +7,8 @@ use Aws\Result;
 use Aws\Sts\StsClient;
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * Credential provider that provides credentials via assuming a role with a web identity
  * More Information, see: https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sts-2011-06-15.html#assumerolewithwebidentity

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -7,6 +7,8 @@ use Aws\CacheInterface;
 use Aws\Exception\CredentialsException;
 use Aws\Sts\StsClient;
 use GuzzleHttp\Promise;
+
+use function Aws\getenv;
 /**
  * Credential providers are functions that accept no arguments and return a
  * promise that is fulfilled with an {@see \Aws\Credentials\CredentialsInterface}

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -7,6 +7,8 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;
 
+use function Aws\getenv;
+
 /**
  * Credential provider that fetches container credentials with GET request.
  * container environment variables are used in constructing request URI.

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -11,6 +11,8 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;
 
+use function Aws\getenv;
+
 /**
  * Credential provider that provides credentials from the EC2 metadata service.
  */

--- a/src/DefaultsMode/ConfigurationProvider.php
+++ b/src/DefaultsMode/ConfigurationProvider.php
@@ -8,6 +8,8 @@ use Aws\DefaultsMode\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\DefaultsMode\ConfigurationInterface}

--- a/src/Endpoint/UseDualstackEndpoint/ConfigurationProvider.php
+++ b/src/Endpoint/UseDualstackEndpoint/ConfigurationProvider.php
@@ -7,6 +7,8 @@ use Aws\ConfigurationProviderInterface;
 use Aws\Endpoint\UseDualstackEndpoint\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\Endpoint\UseDualstackEndpoint\onfigurationInterface}

--- a/src/Endpoint/UseFipsEndpoint/ConfigurationProvider.php
+++ b/src/Endpoint/UseFipsEndpoint/ConfigurationProvider.php
@@ -7,6 +7,8 @@ use Aws\ConfigurationProviderInterface;
 use Aws\Endpoint\UseFipsEndpoint\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\Endpoint\UseFipsEndpoint\onfigurationInterface}

--- a/src/EndpointDiscovery/ConfigurationProvider.php
+++ b/src/EndpointDiscovery/ConfigurationProvider.php
@@ -8,6 +8,8 @@ use Aws\EndpointDiscovery\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\EndpointDiscovery\ConfigurationInterface}

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -14,6 +14,8 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\LazyOpenStream;
 use Psr\Http\Message\RequestInterface;
 
+use function Aws\getenv;
+
 final class Middleware
 {
     /**

--- a/src/Retry/ConfigurationProvider.php
+++ b/src/Retry/ConfigurationProvider.php
@@ -8,6 +8,8 @@ use Aws\Retry\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\Retry\ConfigurationInterface}

--- a/src/S3/RegionalEndpoint/ConfigurationProvider.php
+++ b/src/S3/RegionalEndpoint/ConfigurationProvider.php
@@ -7,6 +7,8 @@ use Aws\ConfigurationProviderInterface;
 use Aws\S3\RegionalEndpoint\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\S3\RegionalEndpoint\ConfigurationInterface}

--- a/src/S3/UseArnRegion/ConfigurationProvider.php
+++ b/src/S3/UseArnRegion/ConfigurationProvider.php
@@ -7,6 +7,8 @@ use Aws\ConfigurationProviderInterface;
 use Aws\S3\UseArnRegion\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\S3\UseArnRegion\ConfigurationInterface}

--- a/src/Sts/RegionalEndpoints/ConfigurationProvider.php
+++ b/src/Sts/RegionalEndpoints/ConfigurationProvider.php
@@ -8,6 +8,8 @@ use Aws\Sts\RegionalEndpoints\Exception\ConfigurationException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 
+use function Aws\getenv;
+
 /**
  * A configuration provider is a function that returns a promise that is
  * fulfilled with a {@see \Aws\Sts\RegionalEndpoints\ConfigurationInterface}

--- a/src/Token/ParsesIniTrait.php
+++ b/src/Token/ParsesIniTrait.php
@@ -1,6 +1,8 @@
 <?php
 namespace Aws\Token;
 
+use function Aws\getenv;
+
 trait ParsesIniTrait
 {
     /**

--- a/src/Token/SsoTokenProvider.php
+++ b/src/Token/SsoTokenProvider.php
@@ -4,6 +4,8 @@ namespace Aws\Token;
 use Aws\Exception\TokenException;
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * Token that comes from the SSO provider
  */

--- a/src/Token/TokenProvider.php
+++ b/src/Token/TokenProvider.php
@@ -7,6 +7,8 @@ use Aws\CacheInterface;
 use Aws\Exception\TokenException;
 use GuzzleHttp\Promise;
 
+use function Aws\getenv;
+
 /**
  * Token providers are functions that accept no arguments and return a
  * promise that is fulfilled with an {@see \Aws\Token\TokenInterface}

--- a/src/functions.php
+++ b/src/functions.php
@@ -603,3 +603,11 @@ function strip_fips_pseudo_regions($region)
     return str_replace(['fips-', '-fips'], ['', ''], $region);
 }
 
+/** @return string|false */
+function getenv(string $name)
+{
+    $out = \getenv($name);
+
+    return $out === false ? ($_ENV[$name] ?? false) : $out;
+}
+

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -516,4 +516,13 @@ EOT
             ]
         ];
     }
+
+    /**
+     * @covers Aws\getenv()
+     */
+    public function testgetenv()
+    {
+        $this->assertEquals(false, Aws\getenv('FOO'));
+        $this->assertEquals($_ENV['FOO'] = 'bar', Aws\getenv('FOO'));
+    }
 }


### PR DESCRIPTION
*Description of changes:*

PHP .env loaders such as `symfony/dotenv` or `vlucas/phpdotenv` populate `$_SERVER` out of the box, but don't call `putenv()` in order to preserve thread safeness. This means .env is loaded by them, but AWS SDK does not read it, creating inconsistent experience when handling real env variables and env variables loaded by these loaders.

With this change, we are still reading via getenv() by default, but fallback to $_SERVER in case getenv() doesn't give back anything. Can be easily extended later to other global variable holders like $_ENV