### PR TITLE
Switch resource check to class check for PHP v8 compatibility

### DIFF
--- a/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
+++ b/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
@@ -235,7 +235,7 @@ abstract class AbstractMonitoringMiddleware
         // Before version 8, sockets are resources
         // After version 8, sockets are instances of Socket
         if (PHP_MAJOR_VERSION >= 8) {
-            return !(self::$socket instanceof Socket);
+            return !(self::$socket instanceof \Socket);
         } else {
             return is_resource(self::$socket);
         }

--- a/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
+++ b/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
@@ -224,6 +224,23 @@ abstract class AbstractMonitoringMiddleware
         return $event;
     }
 
+    
+    /**
+     * Checks if the socket is created.
+     *
+     * @return bool Returns true if the socket is created, false otherwise.
+     */
+    private function isSocketCreated()
+    {
+        // Before version 8, sockets are resources
+        // After version 8, sockets are instances of Socket
+        if (PHP_MAJOR_VERSION >= 8) {
+                !(self::$socket instanceof Socket);
+        } else {
+            return is_resource(self::$socket);
+        }
+    }
+
     /**
      * Creates a UDP socket resource and stores it with the class, or retrieves
      * it if already instantiated and connected. Handles error-checking and
@@ -235,7 +252,7 @@ abstract class AbstractMonitoringMiddleware
      */
     private function prepareSocket($forceNewConnection = false)
     {
-        if (!is_resource(self::$socket)
+        if (!$this->isSocketCreated() 
             || $forceNewConnection
             || socket_last_error(self::$socket)
         ) {

--- a/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
+++ b/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
@@ -235,7 +235,7 @@ abstract class AbstractMonitoringMiddleware
         // Before version 8, sockets are resources
         // After version 8, sockets are instances of Socket
         if (PHP_MAJOR_VERSION >= 8) {
-                !(self::$socket instanceof Socket);
+            return !(self::$socket instanceof Socket);
         } else {
             return is_resource(self::$socket);
         }

--- a/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
+++ b/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
@@ -235,7 +235,7 @@ abstract class AbstractMonitoringMiddleware
         // Before version 8, sockets are resources
         // After version 8, sockets are instances of Socket
         if (PHP_MAJOR_VERSION >= 8) {
-            return !(self::$socket instanceof \Socket);
+            return (self::$socket instanceof \Socket);
         } else {
             return is_resource(self::$socket);
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-php/issues/2527

*Description of changes:*
In PHP v8 on, Sockets are now classes instead of resources. This PR fixes the PHP v8 compatibility issue in this library.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
