### PR TITLE
fix: use dynamic class name instead of reference

### DIFF
--- a/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
+++ b/src/ClientSideMonitoring/AbstractMonitoringMiddleware.php
@@ -224,18 +224,21 @@ abstract class AbstractMonitoringMiddleware
         return $event;
     }
 
-    
+
     /**
-     * Checks if the socket is created.
+     * Checks if the socket is created. If PHP version is greater or equals to 8 then,
+     * it will check if the var is instance of \Socket otherwise it will check if is
+     * a resource.
      *
      * @return bool Returns true if the socket is created, false otherwise.
      */
-    private function isSocketCreated()
+    private function isSocketCreated(): bool
     {
         // Before version 8, sockets are resources
         // After version 8, sockets are instances of Socket
         if (PHP_MAJOR_VERSION >= 8) {
-            return (self::$socket instanceof \Socket);
+            $socketClass = '\Socket';
+            return self::$socket instanceof $socketClass;
         } else {
             return is_resource(self::$socket);
         }
@@ -252,7 +255,7 @@ abstract class AbstractMonitoringMiddleware
      */
     private function prepareSocket($forceNewConnection = false)
     {
-        if (!$this->isSocketCreated() 
+        if (!$this->isSocketCreated()
             || $forceNewConnection
             || socket_last_error(self::$socket)
         ) {


### PR DESCRIPTION
To prevent check errors in PHP versions below to 8, I am changing the check for if self::$socket is an instance of \Socket by using dynamic class name instead of direct reference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
