### PR TITLE
fix(MultipartUpload): changed ObjectURL for CompleteMultipartUpload into effectiveUri

### DIFF
--- a/src/S3/PutObjectUrlMiddleware.php
+++ b/src/S3/PutObjectUrlMiddleware.php
@@ -49,7 +49,14 @@ class PutObjectUrlMiddleware
                             : null;
                         break;
                     case 'CompleteMultipartUpload':
-                        $result['ObjectURL'] = $result['Location'];
+                        $objectUrl = null;
+                        $effectiveUri = $result['@metadata']['effectiveUri'] ?? null;
+                        if ($effectiveUri !== null) {
+                            $parsedUrl = parse_url($effectiveUri);
+                            $objectUrl = $parsedUrl['scheme'] . '://' . $parsedUrl['host'] . $parsedUrl['path'];
+                        }
+                        
+                        $result['ObjectURL'] = $objectUrl ?? $result['Location'];
                         break;
                 }
                 return $result;


### PR DESCRIPTION
*Description of changes:* I spent several hours to figure out why some files return ObjectURL with "**%2F**", but some files with "**/**", it turned out that **CompleteMultipartUpload** puts "Location" URL to ObjectURL while PutObject and CopyObject put the **effectiveUri**, changed this so CompleteMultipartUpload will return **effecitveUri** if it's available and "Location" if it's not available.

![image](https://github.com/aws/aws-sdk-php/assets/3595194/dccf14da-760b-4302-9651-b5d1cf74be4f)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
