### PR TITLE
Fix denylisting x-amz-user-agent in SignatureV4

### DIFF
--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -67,7 +67,7 @@ class SignatureV4 implements SignatureInterface
             'from'                  => true,
             'referer'               => true,
             'user-agent'            => true,
-            'X-Amz-User-Agent'      => true,
+            'x-amz-user-agent'      => true,
             'x-amzn-trace-id'       => true,
             'aws-sdk-invocation-id' => true,
             'aws-sdk-retry'         => true,


### PR DESCRIPTION
When checking headers for signature inclusion, they are lowercased, thus `X-Amz-User-Agent` is never skipped from signature, even though it is blacklisted exactly like that.

*Description of changes:*
X-Amz-User-Agent turned to lowercase in blacklist, as all checks with blacklist are with lowercased headers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
