### PR TITLE
feat: account id endpoint resolution support

### DIFF
--- a/src/AccountIdEndpointMiddleware.php
+++ b/src/AccountIdEndpointMiddleware.php
@@ -1,0 +1,79 @@
+<?php
+namespace Aws;
+
+use Aws\Exception\CredentialsException;
+
+/**
+ * This middleware class resolves the identity from a credentials provider callable function
+ * and determine whether an account should have been resolved. When this middleware resolves
+ * identity then, the identity is included in the $command context bag property "$command['@context]"
+ * as resolved_identity. Example $command['@context]['resolved_identity'] = $resolvedIdentity, and
+ * when this property is set then, the signer middleware gives preference to use that resolved identity
+ * instead of resolving the provided credentials provider by the client. This is done to avoid having to
+ * resolve credentials more than once per request.
+ */
+class AccountIdEndpointMiddleware
+{
+    /**
+     * @var callable $nextHandler
+     */
+    private $nextHandler;
+    /**
+     * @var string $accountIdEndpointMode
+     */
+    private $accountIdEndpointMode;
+    /**
+     * @var callable $credentialsProvider
+     */
+    private $credentialsProvider;
+
+    /**
+     * @param callable $nextHandler
+     * @param string $accountIdEndpointMode
+     * @param callable $credentialsProvider
+     */
+    public function __construct($nextHandler, $accountIdEndpointMode, $credentialsProvider)
+    {
+        $this->nextHandler = $nextHandler;
+        $this->accountIdEndpointMode = $accountIdEndpointMode;
+        $this->credentialsProvider = $credentialsProvider;
+    }
+
+    /**
+     * This method wraps a new instance of the AccountIdEndpointMiddleware.
+     *
+     * @param string $accountIddEndpointMode
+     * @param callable $credentialsProvider
+     * @return callable
+     */
+    public static function wrap($accountIddEndpointMode, $credentialsProvider): callable
+    {
+        return function (callable $handler) use ($accountIddEndpointMode, $credentialsProvider) {
+            return new self($handler, $accountIddEndpointMode, $credentialsProvider);
+        };
+    }
+
+    public function __invoke($command)
+    {
+        $nextHandler = $this->nextHandler;
+        $fnCredentialsProvider = $this->credentialsProvider;
+        $resolvedIdentity = $fnCredentialsProvider()->wait();
+        if (empty($resolvedIdentity->getAccountId())) {
+            $message = function ($mode) {
+                return "It is ${mode} to resolve an account id based on the 'account_id_endpoint_mode' configuration. \n- If you are using credentials from a shared ini file, please make sure you have configured the property aws_account_id. \n- If you are using credentials defined in environment variables please make sure you have set AWS_ACCOUNT_ID. \n- Otherwise, if you are supplying credentials as part of client constructor parameters, please make sure you have set the property account_id.\n If you prefer to not use account id endpoint resolution then, please make account_id_endpoint_mode to be disabled by either providing it explicitly in the client, defining a config property in your shared config file account_id_endpoint_mode, or by setting an environment variable called AWS_ACCOUNT_ID_ENDPOINT_MODE, and the value for any of those source should be 'disabled' if the desire is to disable this behavior.";
+            };
+            switch ($this->accountIdEndpointMode) {
+                case 'required':
+                    throw new CredentialsException($message('required'));
+                case 'preferred':
+                    error_log('Warning: ' . $message('preferred'), E_WARNING|E_NOTICE);
+                    break;
+            }
+        }
+
+        $command['@context']['resolved_identity'] = $resolvedIdentity;
+
+        return $nextHandler($command);
+    }
+
+}

--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -245,6 +245,8 @@ class AwsClient implements AwsClientInterface
             $this->addEndpointV2Middleware();
         }
 
+        $this->addAccountIdEndpointMiddleware($config, $args);
+
         if (!is_null($this->api->getMetadata('awsQueryCompatible'))) {
             $this->addQueryCompatibleInputMiddleware($this->api);
         }
@@ -532,6 +534,22 @@ class AwsClient implements AwsClientInterface
             ),
             'endpoint-resolution'
         );
+    }
+
+    private function addAccountIdEndpointMiddleware(array $config, array $args)
+    {
+        $accountIdEndpointMode = !empty($args['account_id_endpoint_mode'])
+            ? $args['account_id_endpoint_mode']
+            : $config['account_id_endpoint_mode'];
+        if ($accountIdEndpointMode !== 'disabled') {
+            $this->handlerList->prependBuild(
+                AccountIdEndpointMiddleware::wrap(
+                    $accountIdEndpointMode,
+                    $this->credentialProvider
+                ),
+                'account_id_endpoint-middleware'
+            );
+        }
     }
 
     /**

--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -11,6 +11,7 @@ class Credentials implements CredentialsInterface, \Serializable
     private $secret;
     private $token;
     private $expires;
+    private $accountId;
 
     /**
      * Constructs a new BasicAWSCredentials object, with the specified AWS
@@ -21,12 +22,13 @@ class Credentials implements CredentialsInterface, \Serializable
      * @param string $token   Security token to use
      * @param int    $expires UNIX timestamp for when credentials expire
      */
-    public function __construct($key, $secret, $token = null, $expires = null)
+    public function __construct($key, $secret, $token = null, $expires = null, $accountId=null)
     {
         $this->key = trim($key);
         $this->secret = trim($secret);
         $this->token = $token;
         $this->expires = $expires;
+        $this->accountId = $accountId;
     }
 
     public static function __set_state(array $state)
@@ -35,7 +37,8 @@ class Credentials implements CredentialsInterface, \Serializable
             $state['key'],
             $state['secret'],
             $state['token'],
-            $state['expires']
+            $state['expires'],
+            $state['accountId']
         );
     }
 
@@ -64,13 +67,21 @@ class Credentials implements CredentialsInterface, \Serializable
         return $this->expires !== null && time() >= $this->expires;
     }
 
+    public function getAccountId()
+    {
+        return $this->accountId;
+    }
+
+
+
     public function toArray()
     {
         return [
             'key'     => $this->key,
             'secret'  => $this->secret,
             'token'   => $this->token,
-            'expires' => $this->expires
+            'expires' => $this->expires,
+            'accountId' => $this->expires
         ];
     }
 
@@ -97,6 +108,7 @@ class Credentials implements CredentialsInterface, \Serializable
         $this->secret = $data['secret'];
         $this->token = $data['token'];
         $this->expires = $data['expires'];
+        $this->accountId = $data['accountId'];
     }
 
     /**

--- a/src/Credentials/CredentialsInterface.php
+++ b/src/Credentials/CredentialsInterface.php
@@ -49,4 +49,6 @@ interface CredentialsInterface
      * @return array
      */
     public function toArray();
+
+    public function getAccountId();
 }

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -75,7 +75,8 @@ class EcsCredentialProvider
                     $result['AccessKeyId'],
                     $result['SecretAccessKey'],
                     $result['Token'],
-                    strtotime($result['Expiration'])
+                    strtotime($result['Expiration']),
+                    $result['AccountId']
                 );
             })->otherwise(function ($reason) {
                 $reason = is_array($reason) ? $reason['exception'] : $reason;

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -216,11 +216,17 @@ class InstanceProfileProvider
             if (!isset($result)) {
                 $credentials = $previousCredentials;
             } else {
+                $accountId = null;
+                if (!empty($result['AccountId'])) {
+                    $accountId = $result['AccountId'];
+                }
+
                 $credentials = new Credentials(
                     $result['AccessKeyId'],
                     $result['SecretAccessKey'],
                     $result['Token'],
-                    strtotime($result['Expiration'])
+                    strtotime($result['Expiration']),
+                    $accountId
                 );
             }
 

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -86,7 +86,7 @@ class EndpointV2Middleware
         $nextHandler = $this->nextHandler;
         $operation = $this->api->getOperation($command->getName());
         $commandArgs = $command->toArray();
-
+        $this->appendAccountIdParameter($commandArgs);
         $providerArgs = $this->resolveArgs($commandArgs, $operation);
         $endpoint = $this->endpointProvider->resolveEndpoint($providerArgs);
 
@@ -302,5 +302,12 @@ class EndpointV2Middleware
             $authScheme['signingRegionSet'] : null;
 
         return $normalizedAuthScheme;
+    }
+
+    private function appendAccountIdParameter(&$commandArgs)
+    {
+        if (isset($commandArgs['@context']['resolved_identity'])) {
+            $commandArgs['AWS::Auth::AccountId'] = $commandArgs['@context']['resolved_identity']->getAccountId();
+        }
     }
 }

--- a/src/IMDS/Ec2Metadata.php
+++ b/src/IMDS/Ec2Metadata.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Aws\IMDS;
+
+use Aws\IMDS\Exceptions\Ec2MetadataDisabledException;
+use Aws\IMDS\Exceptions\MetadataNotFoundException;
+use Aws\IMDS\Utils\ConfigFileProvider;
+use Aws\IMDS\Utils\Validator;
+
+/**
+ * Ec2 metadata client to interact with the Ec2 metadata service.
+ */
+final class Ec2Metadata
+{
+    const AWS_EC2_METADATA_DISABLED_KEY = 'AWS_EC2_METADATA_DISABLED';
+    const METADATA_TOKEN_PATH = '/latest/api/token';
+
+    /**
+     * The configuration holder for this client.
+     * @var Ec2MetadataConfig $config
+     */
+    private $config;
+    /**
+     * The strategy to be used for performing the get request.
+     * By default, it will always use Ec2MetadataV2GetStrategy,
+     * which is a strategy around the IMDSv2 specs.
+     * @var Ec2MetadataGetStrategy
+     */
+    private $getStrategy;
+
+    /**
+     * @param Ec2MetadataConfig $config
+     */
+    public function __construct($config)
+    {
+        $this->ifEc2MetadataDisabledThrowError();
+        $this->config = Ec2MetadataConfig::resolveDefaults($config);
+        $this->getStrategy = self::defaultGetStrategy($this->config);
+    }
+
+
+    /**
+     * The get method that execute the request against the Ec2 metadata service.
+     * @param string $path is the path to query against the Ec2 metadata service.
+     * @return Ec2MetadataResponse
+     * @throws MetadataNotFoundException
+     */
+    public function get($path) {
+        return $this->getStrategy->get($path);
+    }
+
+    /**
+     * @return Ec2MetadataConfig
+     */
+    public function config() {
+        return $this->config;
+    }
+
+    /**
+     * This method checks whether Ec2 metadata service is disabled or not.
+     * If is disabled then, an exception will be thrown stating so.
+     * @return void
+     * @throws Ec2MetadataDisabledException
+     */
+    private function ifEc2MetadataDisabledThrowError() {
+        if ((getenv(self::AWS_EC2_METADATA_DISABLED_KEY)
+                ?: strtolower(ConfigFileProvider::valueFor(self::AWS_EC2_METADATA_DISABLED_KEY) ?? '')) == "true") {
+            throw new Ec2MetadataDisabledException('Ec2 metadata service is disabled!');
+        }
+    }
+
+    /**
+     * @param Ec2MetadataConfig $config the client configuration that the strategy will use
+     * to perform the request against the Ec2 metadata service.
+     * @return Ec2MetadataV2GetStrategy
+     */
+    private static function defaultGetStrategy($config) {
+        return new Ec2MetadataV2GetStrategy($config);
+    }
+}

--- a/src/IMDS/Ec2MetadataConfig.php
+++ b/src/IMDS/Ec2MetadataConfig.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace Aws\IMDS;
+
+use Aws\IMDS\Utils\ConfigFileProvider;
+use Aws\IMDS\Utils\Validator;
+use DateInterval;
+use GuzzleHttp\Client;
+
+/**
+ * This class contains the configurations that can be provided to
+ * an ec2 metadata client.
+ */
+final class Ec2MetadataConfig
+{
+    private const AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE_KEY = 'AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE';
+    private const AWS_EC2_METADATA_SERVICE_ENDPOINT_KEY = 'AWS_EC2_METADATA_SERVICE_ENDPOINT';
+    const HTTP_OPEN_TIMEOUT_KEY = 'http_open_timeout';
+    const HTTP_READ_TIMEOUT_KEY = 'http_read_timeout';
+    const HTTP_DEBUG_OUTPUT = 'http_debug_output';
+    private const DEFAULT_IPv4_ENDPOINT = 'http://169.254.169.254';
+    private const DEFAULT_IPv6_ENDPOINT = 'http://[fd00:ec2::254]';
+    private const DEFAULT_PORT = 80;
+    const DEFAULT_HTTP_ATTRS = [
+        self::HTTP_OPEN_TIMEOUT_KEY => 1,
+        self::HTTP_READ_TIMEOUT_KEY => 1,
+        self::HTTP_DEBUG_OUTPUT => false,
+    ];
+    /**
+     * The number of retries or max attempts when doing a request
+     * against the metadata service, and that request fails. The
+     * default value is 3 attempts.
+     * @var int $retries
+     */
+    private $retries;
+    /**
+     * A customer custom provided endpoint, ex: ('http://169.254.169.254'),
+     * but if not provided then we will resolve a default endpoint.
+     * This option has precedence over $endpointMode.
+     * @var string $endpoint
+     */
+    private $endpoint;
+    /**
+     * A customer custom provided port. If not provided by default
+     * we will use 80.
+     * @var int port
+     */
+    private $port;
+    /**
+     * tokenTtl (session's token time to live) is a value in seconds,
+     * but provided as a DateInterval, to define how long a token will be valid.
+     * The default value for this is 6 hours.
+     * @var DateInterval $tokenTtl
+     */
+    private $tokenTtl;
+    /**
+     * A customer custom provided endpoint mode, but if not provided then
+     * we will use IPv4. The valid options are IPv4, where its default endpoint
+     * is ('http://169.254.169.254'), and IPv6 where its default endpoint is
+     * ('http://[fd00:ec2::254]').
+     * @var string $endpointMode
+     */
+    private $endpointMode;
+    /**
+     * This array is used to set http options such as http_open_timeout,
+     * http_read_timeout, and http_debug_output. If not provided then we will
+     * resolve default values for each option as following:
+     *  - http_open_timeout, which is the number of seconds to wait for the
+     * connection to open, will be set to 1.
+     *  - http_read_timeout, which is the number seconds for one chunk of data to be read,
+     * will be set to 1.
+     *  - http_debug_output, which is to whether or not to enable debugging on requests.
+     * By default, we will set this option to false, and we also do not recommend to enable this option
+     * in production.
+     * @var array $httpConfigAttrs
+     */
+    private $httpConfigAttrs;
+    /**
+     * A customer custom provided backoff used for retrying requests.
+     * This can be either an integer, which will be interpreted as a number
+     * of seconds to sleep, or a function that will be called with the number
+     * of retries being made as argument. Example $this->config->backoff($numOfRetries).
+     * Please make sure that if a function is provided then,
+     * a sleep is actually implemented, otherwise the retries will be done instantly.
+     * @var int|callable
+     */
+    private $backoff;
+    /**
+     * A custom http client that will handle the http requests.
+     * If not provided then we will set one by default.
+     * @internal
+     * @var Client $client
+     */
+    private $client;
+
+    /**
+     * @return int
+     */
+    public function retries() {
+        return $this->retries;
+    }
+
+    /**
+     * @return string
+     */
+    public function endpoint() {
+        return $this->endpoint;
+    }
+
+    /**
+     * @return int
+     */
+    public function port() {
+        return $this->port;
+    }
+
+    /**
+     * @return DateInterval
+     */
+    public function tokenTtl() {
+        return $this->tokenTtl;
+    }
+
+    /**
+     * @return string
+     */
+    public function endpointMode() {
+        return $this->endpointMode;
+    }
+
+    /**
+     * @return array
+     */
+    public function httpConfigAttrs() {
+        return $this->httpConfigAttrs;
+    }
+
+    /**
+     * @param $attrName
+     * @return mixed
+     */
+    public function httpConfigAttr($attrName) {
+        if (!array_key_exists($attrName, $this->httpConfigAttrs ?? [])) {
+            return null;
+        }
+
+        return $this->httpConfigAttrs[$attrName];
+    }
+
+    /**
+     * @return callable|int
+     */
+    public function backoff() {
+        return $this->backoff;
+    }
+
+    /**
+     * @return Client
+     */
+    public function client() {
+        return $this->client;
+    }
+
+    /**
+     * @param int $retries
+     * @return Ec2MetadataConfig
+     */
+    public function withRetries($retries) {
+        $this->retries = $retries;
+
+        return $this;
+    }
+
+    /**
+     * @param string $endpointMode
+     * @return Ec2MetadataConfig
+     */
+    public function withEndpointMode($endpointMode) {
+        $this->endpointMode = $endpointMode;
+
+        return $this;
+    }
+
+    /**
+     * @param string $endpoint
+     * @return Ec2MetadataConfig
+     */
+    public function withEndpoint($endpoint) {
+        $this->endpoint = $endpoint;
+
+        return $this;
+    }
+
+    /**
+     * @param int|DateInterval $tokenTtl
+     * @return Ec2MetadataConfig
+     */
+    public function withTokenTtl($tokenTtl) {
+        if (is_int($tokenTtl)) {
+            $tokenTtl = DateInterval::createFromDateString($tokenTtl. ' seconds');
+        }
+
+        $this->tokenTtl = $tokenTtl;
+
+        return $this;
+    }
+
+    /**
+     * @param int $port
+     * @return Ec2MetadataConfig
+     */
+    public function withPort($port) {
+        $this->port = $port;
+
+        return $this;
+    }
+
+    /**
+     * @param string $httpConfigAttrName
+     * @param mixed $value
+     * @return Ec2MetadataConfig
+     */
+    public function withHttpConfigAttr($httpConfigAttrName, $value) {
+        $this->httpConfigAttrs[$httpConfigAttrName] = $value ?? self::DEFAULT_HTTP_ATTRS[$httpConfigAttrName];
+
+        return $this;
+     }
+
+    /**
+     * @param int|callable $backoff
+     * @return Ec2MetadataConfig
+     */
+     public function withBackoff($backoff) {
+        $this->backoff = $backoff;
+
+        return $this;
+     }
+
+    /**
+     * @param Client $client
+     * @return Ec2MetadataConfig
+     */
+     public function withClient($client) {
+         $this->client = $client;
+
+         return $this;
+     }
+
+    /**
+     * This method resolves all the possible default values for any property
+     * in the provided configuration object that has no value in.
+     * @param Ec2MetadataConfig $config
+     * @return Ec2MetadataConfig
+     */
+    public static function resolveDefaults($config) {
+        $config->withEndpointMode($config->resolveEndpointMode());
+        $config->withEndpoint($config->resolveEndpoint());
+        $config->withTokenTtl((is_null($config->tokenTtl) ? Token::DEFAULT_TOKEN_TTL : $config->tokenTtl));
+        $config->withPort($config->port === 0 ? self::DEFAULT_PORT : $config->port);
+        $config->withHttpConfigAttr(
+            self::HTTP_OPEN_TIMEOUT_KEY,
+            $config->httpConfigAttr(self::HTTP_OPEN_TIMEOUT_KEY) ?? self::DEFAULT_HTTP_ATTRS[self::HTTP_OPEN_TIMEOUT_KEY]
+        );
+        $config->withHttpConfigAttr(
+            self::HTTP_READ_TIMEOUT_KEY,
+            $config->httpConfigAttr(self::HTTP_READ_TIMEOUT_KEY) ?? self::DEFAULT_HTTP_ATTRS[self::HTTP_READ_TIMEOUT_KEY]
+        );
+        $config->withHttpConfigAttr(
+            self::HTTP_DEBUG_OUTPUT,
+            $config->httpConfigAttr(self::HTTP_DEBUG_OUTPUT) ?? self::DEFAULT_HTTP_ATTRS[self::HTTP_DEBUG_OUTPUT]
+        );
+        $config->withClient(is_null($config->client()) ? new Client() : $config->client);
+
+        return $config;
+    }
+
+    /**
+     * This method resolves the endpoint mode. If is provided by the customer and
+     * is a valid endpointMode then, we use that endpointMode, otherwise we try to resolve
+     * this value from the different places where this can be defined, and as last option
+     * we default it to IPv4.
+     * @return string
+     */
+    private function resolveEndpointMode() {
+        $endpointMode = $this->endpointMode
+            ?: getenv(self::AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE_KEY)
+            ?: ConfigFileProvider::valueFor(self::AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE_KEY)
+            ?: EndpointMode::IPv4;
+        $endpointMode = new EndpointMode($endpointMode);
+
+        return $endpointMode->__toString();
+    }
+
+    /**
+     * This method resolves the endpoint. If is provided by the customer and
+     * is a valid URL then, we use that endpoint, otherwise we try to resolve
+     * this value from the different places where this can be defined, and as last option
+     * we default it to either http://169.254.169.254 if resolved endpointMode is IPv4
+     * or http://[fd00:ec2::254] if endpointMode is resolved as IPv6.
+     * @return string
+     */
+    private function resolveEndpoint() {
+        $endpoint = $this->endpoint;
+        if (!is_null($endpoint)) {
+            return Validator::ifNotMatchesExprThrowException($endpoint, FILTER_VALIDATE_URL, 'The provided endpoint ' . $endpoint . ' is not valid');
+        }
+
+        $endpoint = getenv(self::AWS_EC2_METADATA_SERVICE_ENDPOINT_KEY)
+            ?: ConfigFileProvider::valueFor(self::AWS_EC2_METADATA_SERVICE_ENDPOINT_KEY);
+        if (!is_null($endpoint)) {
+            return $endpoint;
+        }
+
+        // Resolve endpoint mode if not resolved yet. We need this value for resolving the default endpoint
+        if (is_null($this->endpointMode)) {
+            $this->withEndpointMode($this->resolveEndpointMode());
+        }
+
+        if ($this->endpointMode === EndpointMode::IPv4) {
+            return self::DEFAULT_IPv4_ENDPOINT;
+        } else if ($this->endpointMode === EndpointMode::IPv6) {
+            return self::DEFAULT_IPv6_ENDPOINT;
+        }
+
+        return Validator::ifNullThrowException(null, "Endpoint could not be resolved");
+    }
+}

--- a/src/IMDS/Ec2MetadataGetStrategy.php
+++ b/src/IMDS/Ec2MetadataGetStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aws\IMDS;
+
+use Aws\IMDS\Exceptions\MetadataNotFoundException;
+
+interface Ec2MetadataGetStrategy
+{
+    /**
+     * This method is used to execute the get request against the Ec2 metadata service.
+     * @param string $path is the path to query the Ec2 metadata service.
+     * @return Ec2MetadataResponse
+     * @throws MetadataNotFoundException
+     */
+    public function get($path);
+}

--- a/src/IMDS/Ec2MetadataResponse.php
+++ b/src/IMDS/Ec2MetadataResponse.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Aws\IMDS;
+
+use Aws\IMDS\Utils\Validator;
+
+class Ec2MetadataResponse
+{
+    /**
+     * @var string $body
+     */
+    private $body;
+
+    /**
+     * @param string $body
+     */
+    public function __construct($body)
+    {
+        $this->body = Validator::ifNullThrowException($body, "Metadata response is null");
+    }
+
+    /**
+     * @return false|string[]
+     */
+    public function asList() {
+        return explode("\n", $this->body);
+    }
+
+    /**
+     * @return false|string
+     */
+    public function asJson() {
+        return json_encode($this->body);
+    }
+
+    /**
+     * @return string
+     */
+    public function asString() {
+        return $this->body;
+    }
+
+    public function __toString() {
+        return $this->asString();
+    }
+
+}

--- a/src/IMDS/Ec2MetadataTrait.php
+++ b/src/IMDS/Ec2MetadataTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Aws\IMDS;
+
+use Aws\Sdk;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Exception\RequestException;
+use Psr\Http\Message\ResponseInterface;
+
+
+trait Ec2MetadataTrait
+{
+    /**
+     * @param string $url
+     * @param string $path
+     * @param array $headers
+     * @return ResponseInterface
+     * @throws GuzzleException
+     */
+    public function doPutRequest($url, $path, $headers) {
+        return $this->doRequest('PUT', $url, $path, $headers);
+    }
+
+    /**
+     * @param string $url
+     * @param string $path
+     * @param array $headers
+     * @return ResponseInterface
+     * @throws GuzzleException
+     */
+    public function doGetRequest($url, $path, $headers) {
+        return $this->doRequest('GET', $url, $path, $headers);
+    }
+
+    /**
+     * @param string $method
+     * @param string $url
+     * @param string $path
+     * @param array $headers
+     * @return ResponseInterface
+     * @throws GuzzleException
+     */
+    private function doRequest($method, $url, $path, $headers) {
+        try {
+            $request = new Request($method, $this->buildRequestURI($url, $path));
+            $headers = array_merge($headers ?? [], $this->defaultHeaders());
+            foreach ($headers as $key => $value) {
+                $request->withHeader($key, $value);
+            }
+
+            $client = new Client();
+            $reqOptions = [
+                'timeout' => $this->config->httpConfigAttr(Ec2MetadataConfig::HTTP_READ_TIMEOUT_KEY),
+                'connect_timeout' => $this->config->httpConfigAttr(Ec2MetadataConfig::HTTP_OPEN_TIMEOUT_KEY),
+            ];
+
+            return $client->send($request, $reqOptions);
+        } catch (RequestException $e) {
+            return $e->getResponse();
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function defaultHeaders() {
+        return [
+            'User-Agent' => 'aws-sdk-php/' . Sdk::VERSION
+        ];
+    }
+
+    /**
+     * @param string $url
+     * @param string $path
+     * @return string
+     */
+    private function buildRequestURI($url, $path) {
+        return $url . $path;
+    }
+}

--- a/src/IMDS/Ec2MetadataV2GetStrategy.php
+++ b/src/IMDS/Ec2MetadataV2GetStrategy.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Aws\IMDS;
+
+use Aws\IMDS\Exceptions\MetadataNotFoundException;
+use Aws\IMDS\Exceptions\RequestFailedException;
+use Aws\IMDS\Exceptions\RequestForbiddenException;
+use Aws\IMDS\Exceptions\TokenExpiredException;
+use Aws\IMDS\Exceptions\TokenFetchException;
+use Aws\IMDS\Utils\HttpStatus;
+use Aws\IMDS\Utils\Retry;
+use Aws\IMDS\Utils\RetryConfig;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+final class Ec2MetadataV2GetStrategy implements Ec2MetadataGetStrategy
+{
+    use Ec2MetadataTrait;
+    /**
+     * Client config
+     * @var Ec2MetadataConfig $config
+     */
+    private $config;
+    /**
+     * Token to perform the request against the Ec2 metadata service.
+     * @var Token $token
+     */
+    private $token;
+    /**
+     * The retry configuration to be used when retrying requests.
+     * @var RetryConfig
+     */
+    private $retryConfig;
+    /**
+     * @param Ec2MetadataConfig $config
+     */
+    public function __construct($config)
+    {
+        $this->config = $config;
+        $this->retryConfig = RetryConfig::newWithDefaults($config->retries(), $config->backoff(), self::retryBaseCondition());
+    }
+
+    /**
+     * @param string $path
+     * @inheritDoc
+     */
+    public function get($path) {
+        return Retry::retry($this->retryConfig, function () use ($path) {
+            // Let's fetch the token first
+            $this->fetchToken();
+            // Let's execute the desired get request to the ec2 metadata service
+            return $this->executeThisGetRequest($path);
+        });
+    }
+
+    /**
+     * This method is used for handling the flow
+     * for executing the request to the Ec2 metadata service,
+     * such as fetching token, and then executing the get request.
+     * @param string $path
+     * @return Ec2MetadataResponse
+     * @throws TokenFetchException|RequestForbiddenException|RequestFailedException|GuzzleException
+     */
+    private function executeThisGetRequest($path) {
+        // Then, lets execute the get request
+        $response = $this->doGetRequest($this->config->endpoint(), $path, [Token::X_AWS_EC2_METADATA_TOKEN_KEY => $this->token]);
+        if ($response->getStatusCode() === HttpStatus::OK) {
+            return new Ec2MetadataResponse($response->getBody()->getContents());
+        }
+
+        return $this->handleGetRequestResponseError($response);
+    }
+
+    /**
+     * This method is used for fetching a token from the Ec2
+     * metadata service.
+     * @return void
+     * @throws TokenFetchException|RequestForbiddenException|RequestFailedException|GuzzleException
+     */
+    private function fetchToken() {
+        if (is_null($this->token) || $this->token->isExpired()) {
+            $response = $this->doPutRequest(
+                $this->config->endpoint(),
+                Ec2Metadata::METADATA_TOKEN_PATH,
+                [Token::X_AWS_EC2_METADATA_TOKEN_TTL_SECONDS_KEY => $this->config->tokenTtl()->s]
+            );
+            if ($response->getStatusCode() === HttpStatus::OK) {
+                $ttl = \DateInterval::createFromDateString(
+                    $response->getHeader(Token::X_AWS_EC2_METADATA_TOKEN_TTL_SECONDS_KEY)[0] . ' seconds'
+                );
+                $this->token = new Token($response->getBody()->getContents(), $ttl);
+            }
+
+            return $this->handleTokenResponseError($response);
+        }
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @return null
+     */
+    private function handleTokenResponseError($response) {
+        switch ($response->getStatusCode()) {
+            case HttpStatus::MISSING_OR_INVALID_PARAMETERS:
+                throw new TokenFetchException($response->getBody()->getContents());
+            case HttpStatus::FORBIDDEN:
+                throw new RequestForbiddenException($response->getBody()->getContents());
+            default:
+                throw new RequestFailedException($response->getBody()->getContents());
+        }
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @return null
+     */
+    private function handleGetRequestResponseError($response) {
+        switch ($response->getStatusCode()) {
+            case HttpStatus::UNAUTHORIZED:
+                throw new TokenExpiredException();
+            case HttpStatus::NOT_FOUND:
+                throw new MetadataNotFoundException($response->getBody()->getContents());
+            default:
+                throw new RequestFailedException($response->getBody()->getContents());
+        }
+    }
+
+    /**
+     * This method returns a function as the base condition
+     * that decides which exceptions/errors will be retried.
+     * @return callable
+     */
+    private static function retryBaseCondition() {
+        return function ($exception) {
+            if ($exception instanceof TokenExpiredException) {
+                return true;
+            }
+
+            return false;
+        };
+    }
+}

--- a/src/IMDS/EndpointMode.php
+++ b/src/IMDS/EndpointMode.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Aws\IMDS;
+
+use Aws\IMDS\Utils\Validator;
+
+class EndpointMode
+{
+    const IPv4 = "IPv4";
+    const IPv6 = "IPv6";
+    private const EXCEPTION_CLASS = 'Aws\IMDS\Exceptions\EndpointModeNotValidException';
+    /**
+     * @var string $endpointMode
+     */
+    private $endpointMode;
+
+    /**
+     * @param string $endpointMode
+     */
+    public function __construct(string $endpointMode)
+    {
+        $this->endpointMode = Validator::ifNotInThrowException($endpointMode, [self::IPv4, self::IPv6], "endpointMode", self::EXCEPTION_CLASS);
+    }
+
+    public function __toString() {
+        return $this->endpointMode;
+    }
+
+}

--- a/src/IMDS/Exceptions/Ec2MetadataDisabledException.php
+++ b/src/IMDS/Exceptions/Ec2MetadataDisabledException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class Ec2MetadataDisabledException extends RuntimeException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Exceptions/EndpointModeNotValidException.php
+++ b/src/IMDS/Exceptions/EndpointModeNotValidException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class EndpointModeNotValidException extends RuntimeException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Exceptions/MetadataNotFoundException.php
+++ b/src/IMDS/Exceptions/MetadataNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use Throwable;
+
+class MetadataNotFoundException extends RequestNotFoundException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Exceptions/RequestFailedException.php
+++ b/src/IMDS/Exceptions/RequestFailedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use RuntimeException;
+
+class RequestFailedException extends RuntimeException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Exceptions/RequestForbiddenException.php
+++ b/src/IMDS/Exceptions/RequestForbiddenException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use RuntimeException;
+
+class RequestForbiddenException extends RuntimeException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Exceptions/RequestNotFoundException.php
+++ b/src/IMDS/Exceptions/RequestNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class RequestNotFoundException extends RuntimeException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Exceptions/TokenExpiredException.php
+++ b/src/IMDS/Exceptions/TokenExpiredException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class TokenExpiredException extends RuntimeException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Exceptions/TokenFetchException.php
+++ b/src/IMDS/Exceptions/TokenFetchException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aws\IMDS\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class TokenFetchException extends RuntimeException
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/IMDS/Token.php
+++ b/src/IMDS/Token.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Aws\IMDS;
+
+use DateTime;
+use DateInterval;
+
+final class Token
+{
+    const DEFAULT_TOKEN_TTL = 21600;
+    const X_AWS_EC2_METADATA_TOKEN_TTL_SECONDS_KEY = 'x-aws-ec2-metadata-token-ttl-seconds';
+    const X_AWS_EC2_METADATA_TOKEN_KEY = 'x-aws-ec2-metadata-token';
+    /**
+     * @var string $value
+     */
+    private $value;
+    /**
+     * @var DateInterval $ttl
+     */
+    private $ttl;
+    /**
+     * @var DateTime $createdTime
+     */
+    private $createdTime;
+
+    /**
+     * @param $ttl
+     * @param $value
+     */
+    public function __construct($value, $ttl)
+    {
+        $this->value = $value;
+        $this->ttl = $ttl;
+        $this->createdTime = new DateTime();
+    }
+
+    /**
+     * @return string
+     */
+    public function value() {
+        return $this->value;
+    }
+
+    /**
+     * @return DateInterval
+     */
+    public function ttl() {
+        return $this->ttl;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isExpired() {
+        $now = new DateTime();
+
+        return $now > $this->createdTime->add($this->ttl);
+    }
+
+    public function __toString()
+    {
+        return "Token={value: " . $this->value . ", ttl: " . $this->ttl->s . ", createdTime: " . $this->createdTime->format("Y-m-d H:i:s") . "}";
+    }
+}

--- a/src/IMDS/Utils/ConfigFileProvider.php
+++ b/src/IMDS/Utils/ConfigFileProvider.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Aws\IMDS\Utils;
+
+class ConfigFileProvider
+{
+    public static function valueFor($key) {
+        return null;
+    }
+}

--- a/src/IMDS/Utils/HttpStatus.php
+++ b/src/IMDS/Utils/HttpStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aws\IMDS\Utils;
+
+final class HttpStatus
+{
+    public const OK = 200;
+    const MISSING_OR_INVALID_PARAMETERS = 400;
+    const FORBIDDEN = 403;
+    const UNAUTHORIZED = 401;
+    const NOT_FOUND = 404;
+
+    private function __construct() {}
+}

--- a/src/IMDS/Utils/Retry.php
+++ b/src/IMDS/Utils/Retry.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Aws\IMDS\Utils;
+
+use Exception;
+use RuntimeException;
+
+final class Retry
+{
+    public const DEFAULT_MAX_ATTEMPTS = 3;
+
+    private function __construct() {}
+
+    /**
+     *
+     * @param RetryConfig $retryConfig
+     * @param callable $fnToRetry
+     * @return mixed
+     * @throws RuntimeException
+     */
+    public static function retry($retryConfig, $fnToRetry) {
+        Validator::ifNullThrowException($retryConfig, "Retry config must be provided!");
+        Validator::ifNullThrowException($fnToRetry, "The function to be retried must be provided!");
+        Validator::ifNotInstanceOfThrowException($retryConfig, RetryConfig::class);
+        if (!is_callable($fnToRetry)) {
+            Validator::throwException('A function to be retried must be provided!');
+        }
+
+        // To avoid that any changes on the original retryConfig object interfere in the behavior of this execution.
+        $retryConfigCopy = clone $retryConfig;
+        $retryCount = 0;
+        do {
+            try {
+                return $fnToRetry();
+            } catch (RuntimeException $e) {
+                $exceptionToBeThrown = $e;
+                $isRetryable = $retryConfigCopy->retryBaseCondition()($e);
+                if (!$isRetryable) {
+                    break;
+                }
+                // Sleep
+                $retryConfigCopy->backoffStrategy()($retryCount);
+            }
+
+            $retryCount++;
+        } while ($retryCount < $retryConfigCopy->maxAttempts());
+
+        if (!is_null($exceptionToBeThrown)) {
+            throw $exceptionToBeThrown;
+        }
+
+        Validator::throwException('An unexpected error has occurred when retrying!');
+    }
+
+    /**
+     * @return callable
+     */
+    public static function defaultBackoffStrategy() {
+        return function ($numAttempts) {
+            usleep((1.2 ** $numAttempts) * 1000000);
+        };
+    }
+}

--- a/src/IMDS/Utils/RetryConfig.php
+++ b/src/IMDS/Utils/RetryConfig.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Aws\IMDS\Utils;
+
+/**
+ * This class contains the configuration for how a request should be retried.
+ */
+final class RetryConfig
+{
+    /**
+     * This is the max attempts number that an operation can be retried.
+     * @var int $maxAttempts
+     */
+    private $maxAttempts;
+    /**
+     * This is for limiting the number of seconds that we can wait for a next
+     * retry.
+     * @var int $maxBackoffTime
+     */
+    private $maxBackoffTime;
+    /**
+     * The backoff function implementation, that will sleep until next retry.
+     * @var callable $backoffStrategy
+     */
+    private $backoffStrategy;
+    /**
+     * This parameter is a function, that should decide if an error can be retried
+     * or not, by returning true or false. It should accept an instance of RuntimeException
+     * as parameter.
+     * @var callable $retryBaseCondition
+     */
+    private $retryBaseCondition;
+
+    private function __construct() {}
+
+    /**
+     * @return int
+     */
+    public function maxAttempts() {
+        return $this->maxAttempts;
+    }
+
+    /**
+     * @return int
+     */
+    public function maxBackoffTime() {
+        return $this->maxBackoffTime;
+    }
+
+    /**
+     * @return callable
+     */
+    public function backoffStrategy() {
+        return $this->backoffStrategy;
+    }
+
+    /**
+     * @return callable
+     */
+    public function retryBaseCondition() {
+        return $this->retryBaseCondition;
+    }
+
+    /**
+     * @param int $maxAttempts
+     * @return RetryConfig
+     */
+    public function withMaxAttempts($maxAttempts) {
+        $this->maxAttempts = $maxAttempts;
+
+        return $this;
+    }
+
+    /**
+     * @param int $maxBackoffTime
+     * @return RetryConfig
+     */
+    public function withMaxBackoffTime($maxBackoffTime) {
+        $this->maxBackoffTime = $maxBackoffTime;
+
+        return $this;
+    }
+
+    /**
+     * @param callable $backoffStrategy
+     * @return RetryConfig
+     */
+    public function withBackoffStrategy($backoffStrategy) {
+        $this->backoffStrategy = $backoffStrategy;
+
+        return $this;
+    }
+
+    /**
+     * @param callable $retryBaseCondition
+     * @return RetryConfig
+     */
+    public function withRetryBaseCondition($retryBaseCondition) {
+        $this->retryBaseCondition = $retryBaseCondition;
+
+        return $this;
+    }
+
+    public function __toString() {
+        return "RetryConfig={maxAttempts: $this->maxAttempts, maxBackoffTime: $this->maxBackoffTime}";
+    }
+
+    /**
+     * This method creates a new instance of retry configuration, and it resolves
+     * the default values if not provided as parameter.
+     * @param int $maxAttempts defaulted to 3.
+     * @param callable|int $backoff
+     * @param callable $retryBaseCondition
+     * @return RetryConfig
+     */
+    public static function newWithDefaults($maxAttempts, $backoff, $retryBaseCondition) {
+        $retryConfig = new RetryConfig();
+        $retryConfig->withMaxAttempts((is_null($maxAttempts) || $maxAttempts === 0) ? Retry::DEFAULT_MAX_ATTEMPTS : $maxAttempts);
+        if (is_callable($backoff)) {
+            $retryConfig->withBackoffStrategy($backoff);
+        } else if (is_int($backoff) && $backoff !== 0) {
+            $retryConfig->withBackoffStrategy(function () use ($backoff) {
+                sleep($backoff);
+            });
+        } else {
+            $retryConfig->withBackoffStrategy(Retry::defaultBackoffStrategy());
+        }
+
+        $retryConfig->withRetryBaseCondition($retryBaseCondition);
+
+        return $retryConfig;
+    }
+}

--- a/src/IMDS/Utils/Validator.php
+++ b/src/IMDS/Utils/Validator.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Aws\IMDS\Utils;
+
+use RuntimeException;
+
+final class Validator
+{
+
+    private function __construct() {}
+
+    /**
+     * @param $value
+     * @param $message
+     * @return mixed
+     */
+    public static function ifNullThrowException($value, $message) {
+        if (is_null($value)) {
+            self::throwException($message);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $value
+     * @param array $options
+     * @param string $initialMessage
+     * @return mixed
+     */
+    public static function ifNotInThrowException($value, $options, $initialMessage, $exceptionClass='RuntimeException') {
+        if (!in_array(strtolower($value), array_map('strtolower', $options))) {
+            self::throwException($initialMessage . " should be one of the following options: " . implode(",", $options), $exceptionClass);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string $value
+     * @param int $FILTER_VALIDATE_URL
+     * @param string $message
+     * @return string
+     */
+    public static function ifNotMatchesExprThrowException($value, $FILTER_VALIDATE_URL, $message) {
+        if (!filter_var($value, $FILTER_VALIDATE_URL)) {
+            self::throwException($message);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param object $obj
+     * @param string $class
+     * @return void
+     */
+    public static function ifNotInstanceOfThrowException($obj, $class)
+    {
+        if (!($obj instanceof $class)) {
+            self::throwException((is_object($obj) ? 'The object ' . get_class($obj) : 'The type ' . gettype($obj)) . ' should be an instance of ' . $class);
+        }
+    }
+
+    /**
+     * @param string $message
+     * @para
+     * @return mixed
+     */
+    public static function throwException($message, $exceptionClass='RuntimeException')
+    {
+        throw new $exceptionClass($message);
+    }
+}

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -144,6 +144,8 @@ final class Middleware
 
                 if ($signer instanceof S3ExpressSignature) {
                     $credentialPromise = $config['s3_express_identity_provider']($command);
+                } elseif (!empty($command['@context']['resolved_identity'])) {
+                    $credentialPromise = Promise\Create::promiseFor($command['@context']['resolved_identity']);
                 } else {
                     $credentialPromise = $credProvider();
                 }

--- a/src/Sts/StsClient.php
+++ b/src/Sts/StsClient.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Sts;
 
+use Aws\Arn\ArnParser;
 use Aws\AwsClient;
 use Aws\CacheInterface;
 use Aws\Credentials\Credentials;
@@ -75,15 +76,23 @@ class StsClient extends AwsClient
             throw new \InvalidArgumentException('Result contains no credentials');
         }
 
-        $c = $result['Credentials'];
+        $accountId = null;
+        if ($result->hasKey('AssumedRoleUser')) {
+            $parsedArn = ArnParser::parse($result->get('AssumedRoleUser')['Arn']);
+            $accountId = $parsedArn->getAccountId();
+        }
+
+        $credentials = $result['Credentials'];
+        $expiration = isset($credentials['Expiration']) && $credentials['Expiration'] instanceof \DateTimeInterface
+            ? (int) $credentials['Expiration']->format('U')
+            : null;
 
         return new Credentials(
-            $c['AccessKeyId'],
-            $c['SecretAccessKey'],
-            isset($c['SessionToken']) ? $c['SessionToken'] : null,
-            isset($c['Expiration']) && $c['Expiration'] instanceof \DateTimeInterface
-                ? (int) $c['Expiration']->format('U')
-                : null
+            $credentials['AccessKeyId'],
+            $credentials['SecretAccessKey'],
+            isset($credentials['SessionToken']) ? $credentials['SessionToken'] : null,
+            $expiration,
+            $accountId
         );
     }
 

--- a/tests/Api/Parser/EventParsingIteratorTest.bk.php
+++ b/tests/Api/Parser/EventParsingIteratorTest.bk.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Aws\Test\Api\Parser;
+
+use Aws\Api\Parser\EventParsingIterator;
+use Aws\Api\Parser\Exception\ParserException;
+use Aws\Api\Parser\RestJsonParser;
+use Aws\Api\Parser\RestXmlParser;
+use Aws\Api\Service;
+use Aws\Api\ShapeMap;
+use Aws\Api\StructureShape;
+use Aws\Exception\EventStreamDataException;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\StreamInterface;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers Aws\Api\Parser\EventParsingIterator
+ */
+class EventParsingIteratorTest extends TestCase
+{
+    /** @var array */
+    private static $successEventNames = [
+         'end_event',
+         'headers_event',
+         'records_event',
+         'stats_event',
+        //'lambda_invoke_event'
+    ];
+    private static $events = [
+        [
+            'shape' => 'eventstream_shape.json',
+            'protocol' => 'XML',
+            'events' => [
+                'lambda_invoke_event'
+            ]
+        ],
+        [
+            'shape' => 'lambda_invoke_shape.json',
+            'protocol' => 'JSON',
+            'events' => [
+                'lambda_invoke_event'
+            ]
+        ],
+        [
+            'shape' => 'bedrock_invoke_model_shape.json',
+            'protocol' => 'JSON',
+            'events' => [
+                'lambda_invoke_event'
+            ]
+        ]
+    ];
+    /** @var StructureShape */
+    private $eventstreamShape;
+
+    public function set_up()
+    {
+        $shape = json_decode(
+            file_get_contents(
+                __DIR__ . '/../eventstream_fixtures/eventstream_shape.json'
+            ),
+            true
+        );
+        $this->eventstreamShape = new StructureShape(
+            $shape,
+            new ShapeMap(['EventStream' => $shape])
+        );
+    }
+
+    public function getEventData()
+    {
+        $events = [];
+        foreach (self::$successEventNames as $name) {
+            $event = [];
+            $event['input'] = base64_decode(file_get_contents(
+                __DIR__ . '/../eventstream_fixtures/input/' . $name
+            ));
+            $event['output'] = [json_decode(
+                file_get_contents(
+                    __DIR__ . '/../eventstream_fixtures/output/' . $name . '.json'
+                ),
+                true
+            )];
+            $event['count'] = 1;
+            $events []= $event;
+        }
+
+        $combinedInput = '';
+        $combinedOutput = [];
+        foreach ($events as $event) {
+            $combinedInput .= $event['input'];
+            $combinedOutput []= $event['output'][0];
+        }
+
+        $events []= [
+            'input' => $combinedInput,
+            'output' => $combinedOutput,
+            'count' => count($events),
+        ];
+
+        return $events;
+    }
+
+    /**
+     * @dataProvider getEventData
+     */
+    public function testEmitsEvents($input, $output, $expectedCount)
+    {
+        $stream = Psr7\Utils::streamFor($input);
+        $iterator = new EventParsingIterator(
+            $stream,
+            $this->eventstreamShape,
+            new RestXmlParser(
+                new Service([], function () { return []; })
+            )
+        );
+
+        $count = 0;
+        foreach ($iterator as $event) {
+            if (isset($event['Records'])) {
+                $this->assertInstanceOf(
+                    StreamInterface::class,
+                    $event['Records']['Payload']
+                );
+            }
+            $this->assertEquals($output[$count], $event);
+            $count++;
+        }
+        $this->assertEquals($expectedCount, $count);
+    }
+
+    public function testThrowsOnErrorEvent()
+    {
+        $stream = Psr7\Utils::streamFor(
+            base64_decode(file_get_contents(
+                __DIR__ . '/../eventstream_fixtures/input/error_event'
+            ))
+        );
+        $iterator = new EventParsingIterator(
+            $stream,
+            $this->eventstreamShape,
+            new RestXmlParser(
+                new Service([], function () { return []; })
+            )
+        );
+
+        try {
+            $this->assertSame(0, $iterator->key());
+            $iterator->current();
+            $this->fail('Got event when error expected from stream.');
+        } catch (EventStreamDataException $e) {
+            $this->assertSame('Event Error', $e->getAwsErrorMessage());
+            $this->assertSame('FooError', $e->getAwsErrorCode());
+        } catch (\Exception $e) {
+            $this->fail('Got other exception when error expected from stream.');
+        }
+    }
+
+    public function testThrowsOnUnknownMessageType()
+    {
+        $this->expectExceptionMessage("Failed to parse unknown message type.");
+        $this->expectException(\Aws\Api\Parser\Exception\ParserException::class);
+        $stream = Psr7\Utils::streamFor(
+            base64_decode(file_get_contents(
+                __DIR__ . '/../eventstream_fixtures/input/unknown_message_type'
+            ))
+        );
+        $iterator = new EventParsingIterator(
+            $stream,
+            $this->eventstreamShape,
+            new RestXmlParser(
+                new Service([], function () { return []; })
+            )
+        );
+
+        $iterator->current();
+    }
+
+    public function testThrowsOnUnknownEventType()
+    {
+        $this->expectExceptionMessage("Failed to parse without event type.");
+        $this->expectException(\Aws\Api\Parser\Exception\ParserException::class);
+        $stream = Psr7\Utils::streamFor(
+            base64_decode(file_get_contents(
+                __DIR__ . '/../eventstream_fixtures/input/unknown_event_type'
+            ))
+        );
+        $iterator = new EventParsingIterator(
+            $stream,
+            $this->eventstreamShape,
+            new RestXmlParser(
+                new Service([], function () {
+                    return [];
+                })
+            )
+        );
+
+        $iterator->current();
+    }
+
+    /**
+     * @param string $jsonFilePath
+     *
+     * @return StructureShape
+     */
+    private function loadEventStreamShapeFromJson($jsonFilePath) {
+        $shape = json_decode(
+            file_get_contents($jsonFilePath),
+            true
+        );
+
+        return new StructureShape(
+            $shape,
+            new ShapeMap(['EventStream' => $shape])
+        );
+    }
+}


### PR DESCRIPTION
This change add account_id as part of the identity resolution, from the different credentials provider. It also validates whether an account should have been resolved based on the configure option account_id_endpoint_mode, and when this option is not disabled then, it prepends a middleware that resolves the identity, from the provided credential provider and, it validates the account id based on the account_id_endpoint_mode option. When an identity is resolved by this middleware then, this identity is carry over in a command property bag called @context, which is then reused by the signer middleware, and any other middleware that needs to resolve identity. This is done for avoiding having to resolve identity multiple times in a single request. The property is: $command['@context']['resolved_identity'];


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
