### PR TITLE
chore: add protocol test case for ignoring __type during union deserialization

### DIFF
--- a/tests/Api/test_cases/protocols/output/json.json
+++ b/tests/Api/test_cases/protocols/output/json.json
@@ -706,5 +706,44 @@
         }
       }
     ]
+  },
+  {
+    "description": "Ignores an unrecognized __type property",
+    "metadata": {
+      "protocol": "json"
+    },
+    "shapes": {
+      "AllTypesUnionStructure": {
+        "type": "structure",
+        "union": true,
+        "members": {
+          "StringMember": {
+            "shape": "String"
+          },
+          "UnionMember": {
+            "shape": "AllTypesUnionStructure"
+          }
+        }
+      },
+      "String":{"type":"string"}
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "AllTypesUnionStructure"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "UnionMember": {"StringMember":"foobar"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"UnionMember\": {\"StringMember\":\"foobar\", \"__type\": \"aws.protocoltests.json10#MyUnion\"}}"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
*Description of changes:*
Adds protocol test case to ensure the `__type` field is ignored during union type deserialization.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
