### PR TITLE
Update type-hint for exception type change

### DIFF
--- a/.changes/nextrelease/exception-error-fix.json
+++ b/.changes/nextrelease/exception-error-fix.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "",
+        "description": "Update type-hint for exceptions to accept other throwable types"
+    }
+]

--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -48,7 +48,7 @@ class AwsException extends \RuntimeException implements
         $message,
         CommandInterface $command,
         array $context = [],
-        \Exception $previous = null
+        ?\Throwable $previous = null
     ) {
         $this->data = isset($context['body']) ? $context['body'] : [];
         $this->command = $command;


### PR DESCRIPTION
*Description of changes:*

Update type-hint for exception wrapper to allow for other php throwable types.

Fixes:
> Aws\Exception\AwsException::__construct(): Argument #4 ($previous) must be of type ?Exception, Error given, called in vendor/aws/aws-sdk-php/src/WrappedHttpHandler.php on line 196

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
