### PR TITLE
feat: multi-auth

### DIFF
--- a/.changes/nextrelease/multi-auth.json
+++ b/.changes/nextrelease/multi-auth.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "Auth",
+    "description": "Adds support for the `auth` service trait.  This allows for auth scheme selection at both the service and operation level."
+  }
+]

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./tests/bootstrap.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         convertDeprecationsToExceptions="true"
+>
   <coverage>
     <include>
       <directory suffix=".php">src</directory>

--- a/src/Auth/AuthSchemeResolver.php
+++ b/src/Auth/AuthSchemeResolver.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Aws\Auth;
+
+use Aws\Auth\Exception\UnresolvedAuthSchemeException;
+use Aws\Identity\AwsCredentialIdentity;
+use Aws\Identity\BearerTokenIdentity;
+use GuzzleHttp\Promise\PromiseInterface;
+
+/**
+ * Houses logic for selecting an auth scheme modeled in a service's `auth` trait.
+ * The `auth` trait can be modeled either in a service's metadata, or at the operation level.
+ */
+class AuthSchemeResolver implements AuthSchemeResolverInterface
+{
+    const UNSIGNED_BODY = '-unsigned-body';
+
+    /**
+     * @var string[] Default mapping of modeled auth trait auth schemes
+     *               to the SDK's supported signature versions.
+     */
+    private static $defaultAuthSchemeMap = [
+        'aws.auth#sigv4' => 'v4',
+        'aws.auth#sigv4a' => 'v4a',
+        'smithy.api#httpBearerAuth' => 'bearer',
+        'smithy.auth#noAuth' => 'anonymous'
+    ];
+
+    /**
+     * @var array Mapping of auth schemes to signature versions used in
+     *            resolving a signature version.
+     */
+    private $authSchemeMap;
+    private $tokenProvider;
+    private $credentialProvider;
+
+
+    public function __construct(
+        callable $credentialProvider,
+        callable $tokenProvider = null,
+        array $authSchemeMap = []
+    ){
+        $this->credentialProvider = $credentialProvider;
+        $this->tokenProvider = $tokenProvider;
+        $this->authSchemeMap = empty($authSchemeMap)
+            ? self::$defaultAuthSchemeMap
+            : $authSchemeMap;
+    }
+
+    /**
+     * Accepts a priority-ordered list of auth schemes and an Identity
+     * and selects the first compatible auth schemes, returning a normalized
+     * signature version.  For example, based on the default auth scheme mapping,
+     * if `aws.auth#sigv4` is selected, `v4` will be returned.
+     *
+     * @param array $authSchemes
+     * @param $identity
+     *
+     * @return string
+     * @throws UnresolvedAuthSchemeException
+     */
+    public function selectAuthScheme(
+        array $authSchemes,
+        array $args = []
+    ): string
+    {
+        $failureReasons = [];
+
+        foreach($authSchemes as $authScheme) {
+            $normalizedAuthScheme = $this->authSchemeMap[$authScheme] ?? $authScheme;
+
+            if ($this->isCompatibleAuthScheme($normalizedAuthScheme)) {
+                if ($normalizedAuthScheme === 'v4' && !empty($args['unsigned_payload'])) {
+                    return $normalizedAuthScheme . self::UNSIGNED_BODY;
+                }
+
+                return $normalizedAuthScheme;
+            } else {
+                $failureReasons[] = $this->getIncompatibilityMessage($normalizedAuthScheme);
+            }
+        }
+
+        throw new UnresolvedAuthSchemeException(
+            'Could not resolve an authentication scheme: '
+            . implode('; ', $failureReasons)
+        );
+    }
+
+    /**
+     * Determines compatibility based on either Identity or the availability
+     * of the CRT extension.
+     *
+     * @param $authScheme
+     *
+     * @return bool
+     */
+    private function isCompatibleAuthScheme($authScheme): bool
+    {
+        switch ($authScheme) {
+            case 'v4':
+            case 'anonymous':
+                return $this->hasAwsCredentialIdentity();
+            case 'v4a':
+                return extension_loaded('awscrt') && $this->hasAwsCredentialIdentity();
+            case 'bearer':
+                return $this->hasBearerTokenIdentity();
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Provides incompatibility messages in the event an incompatible auth scheme
+     * is encountered.
+     *
+     * @param $authScheme
+     *
+     * @return string
+     */
+    private function getIncompatibilityMessage($authScheme): string
+    {
+        switch ($authScheme) {
+            case 'v4':
+                return 'Signature V4 requires AWS credentials for request signing';
+            case 'anonymous':
+                return 'Anonymous signatures require AWS credentials for request signing';
+            case 'v4a':
+                return 'The aws-crt-php extension and AWS credentials are required to use Signature V4A';
+            case 'bearer':
+                return 'Bearer token credentials must be provided to use Bearer authentication';
+            default:
+                return "The service does not support `{$authScheme}` authentication.";
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function hasAwsCredentialIdentity(): bool
+    {
+        $fn = $this->credentialProvider;
+        $result = $fn();
+
+        if ($result instanceof PromiseInterface) {
+            return $result->wait() instanceof AwsCredentialIdentity;
+        }
+
+        return $result instanceof AwsCredentialIdentity;
+    }
+
+    /**
+     * @return bool
+     */
+    private function hasBearerTokenIdentity(): bool
+    {
+        if ($this->tokenProvider) {
+            $fn = $this->tokenProvider;
+            $result = $fn();
+
+            if ($result instanceof PromiseInterface) {
+                return $result->wait() instanceof BearerTokenIdentity;
+            }
+
+            return $result instanceof BearerTokenIdentity;
+        }
+
+        return false;
+    }
+}

--- a/src/Auth/AuthSchemeResolverInterface.php
+++ b/src/Auth/AuthSchemeResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Aws\Auth;
+
+use Aws\Identity\IdentityInterface;
+
+/**
+ * An AuthSchemeResolver object determines which auth scheme will be used for request signing.
+ */
+interface AuthSchemeResolverInterface
+{
+    /**
+     * Selects an auth scheme for request signing.
+     *
+     * @param array $authSchemes a priority-ordered list of authentication schemes.
+     * @param IdentityInterface $identity Credentials to be used in request signing.
+     *
+     * @return string
+     */
+    public function selectAuthScheme(
+        array $authSchemes,
+        array $args
+    ): ?string;
+}

--- a/src/Auth/AuthSelectionMiddleware.php
+++ b/src/Auth/AuthSelectionMiddleware.php
@@ -1,0 +1,99 @@
+<?php
+namespace Aws\Auth;
+
+use Aws\Api\Service;
+use Aws\CommandInterface;
+use Closure;
+use GuzzleHttp\Promise\Promise;
+
+/**
+ * Handles auth scheme resolution. If a service models and auth scheme using
+ * the `auth` trait and the operation or metadata levels, this middleware will
+ * attempt to select the first compatible auth scheme it encounters and apply its
+ * signature version to the command's `@context` property bag.
+ *
+ * IMPORTANT: this middleware must be added to the "build" step.
+ *
+ * @internal
+ */
+class AuthSelectionMiddleware
+{
+    /** @var callable */
+    private $nextHandler;
+
+    /** @var AuthSchemeResolverInterface */
+    private $authResolver;
+
+    /** @var Service */
+    private $api;
+
+    /**
+     * Create a middleware wrapper function
+     *
+     * @param AuthSchemeResolverInterface $authResolver
+     * @param Service $api
+     * @return Closure
+     */
+    public static function wrap(
+        AuthSchemeResolverInterface $authResolver,
+        Service $api
+    ): Closure
+    {
+        return function (callable $handler) use ($authResolver, $api) {
+            return new self($handler, $authResolver, $api);
+        };
+    }
+
+    /**
+     * @param callable $nextHandler
+     * @param $authResolver
+     * @param callable $identityProvider
+     * @param Service $api
+     */
+    public function __construct(
+        callable $nextHandler,
+        AuthSchemeResolverInterface $authResolver,
+        Service $api
+    )
+    {
+        $this->nextHandler = $nextHandler;
+        $this->authResolver = $authResolver;
+        $this->api = $api;
+    }
+
+    /**
+     * @param CommandInterface $command
+     *
+     * @return Promise
+     */
+    public function __invoke(CommandInterface $command)
+    {
+        $nextHandler = $this->nextHandler;
+        $serviceAuth = $this->api->getMetadata('auth') ?: [];
+        $operation = $this->api->getOperation($command->getName());
+        $operationAuth = $operation['auth'] ?? [];
+        $unsignedPayload = $operation['unsignedpayload'] ?? false;
+        $resolvableAuth = $operationAuth ?: $serviceAuth;
+
+        if (!empty($resolvableAuth)) {
+            if (isset($command['@context']['auth_scheme_resolver'])
+                && $command['@context']['auth_scheme_resolver'] instanceof AuthSchemeResolverInterface
+            ){
+                $resolver = $command['@context']['auth_scheme_resolver'];
+            } else {
+                $resolver = $this->authResolver;
+            }
+
+            $selectedAuthScheme = $resolver->selectAuthScheme(
+                $resolvableAuth,
+                ['unsigned_payload' => $unsignedPayload]
+            );
+
+            if (!empty($selectedAuthScheme)) {
+                $command['@context']['signature_version'] = $selectedAuthScheme;
+            }
+        }
+
+        return $nextHandler($command);
+    }
+}

--- a/src/Command.php
+++ b/src/Command.php
@@ -66,10 +66,21 @@ class Command implements CommandInterface
      *
      * @param array $authSchemes
      *
+     * @deprecated In favor of using the @context property bag.
+     *             Auth Schemes are now accessible via the `signature_version` key
+     *             in a Command's context, if applicable. Auth Schemes set using
+     *             This method are no longer consumed.
+     *
      * @internal
      */
     public function setAuthSchemes(array $authSchemes)
     {
+        trigger_error(__METHOD__ . ' is deprecated.  Auth schemes '
+            . 'resolved using the service `auth` trait or via endpoint resolution '
+            . 'are now set in the command `@context` property.`'
+            , E_USER_DEPRECATED
+        );
+
         $this->authSchemes = $authSchemes;
     }
 
@@ -78,9 +89,19 @@ class Command implements CommandInterface
      * for endpoint resolution
      *
      * @returns array
+     *
+     * @deprecated In favor of using the @context property bag.
+     *             Auth schemes are now accessible via the `signature_version` key
+     *             in a Command's context, if applicable.
      */
     public function getAuthSchemes()
     {
+        trigger_error(__METHOD__ . ' is deprecated.  Auth schemes '
+        . 'resolved using the service `auth` trait or via endpoint resolution '
+        . 'can now be found in the command `@context` property.`'
+        , E_USER_DEPRECATED
+        );
+
         return $this->authSchemes ?: [];
     }
 

--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -1,11 +1,15 @@
 <?php
 namespace Aws\Credentials;
 
+use Aws\Identity\AwsCredentialIdentity;
+
 /**
  * Basic implementation of the AWS Credentials interface that allows callers to
  * pass in the AWS Access Key and AWS Secret Access Key in the constructor.
  */
-class Credentials implements CredentialsInterface, \Serializable
+class Credentials extends AwsCredentialIdentity implements
+    CredentialsInterface,
+    \Serializable
 {
     private $key;
     private $secret;

--- a/src/Identity/AwsCredentialIdentity.php
+++ b/src/Identity/AwsCredentialIdentity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Aws\Identity;
+
+/**
+ * Denotes the use of standard AWS credentials.
+ *
+ * @internal
+ */
+abstract class AwsCredentialIdentity implements IdentityInterface
+{
+    /**
+     * Returns a UNIX timestamp, if available, representing the expiration
+     * time of the AWS Credential object. Returns null if no expiration is provided.
+     *
+     * @return int|null
+     */
+    abstract public function getExpiration();
+}

--- a/src/Identity/BearerTokenIdentity.php
+++ b/src/Identity/BearerTokenIdentity.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Aws\Identity;
+
+/**
+ * Denotes the use of Bearer Token credentials.
+ *
+ * @internal
+ */
+abstract class BearerTokenIdentity implements IdentityInterface
+{
+    /**
+     * Returns a UNIX timestamp, if available, representing the expiration
+     * time of the Bearer Token object. Returns null if no expiration is provided.
+     *
+     * @return int|null
+     */
+    abstract public function getExpiration();
+}

--- a/src/Identity/IdentityInterface.php
+++ b/src/Identity/IdentityInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Aws\Identity;
+
+/**
+ * An Identity object is used in identifying credential types and determining how
+ * the SDK authenticates with a service API for requests that require a signature.
+ *
+ * @internal
+ */
+interface IdentityInterface
+{
+    /**
+     * Returns a UNIX timestamp, if available, representing
+     * the expiration time of the identity object.  Returns null
+     * if no expiration is provided.
+     *
+     * @return int|null
+     */
+    public function getExpiration();
+}

--- a/src/Identity/S3/S3ExpressIdentityProvider.php
+++ b/src/Identity/S3/S3ExpressIdentityProvider.php
@@ -7,11 +7,11 @@ use GuzzleHttp\Promise;
 
 class S3ExpressIdentityProvider
 {
-
     private $cache;
     private $region;
     private $config;
     private $s3Client;
+
     public function __construct($clientRegion, array $config = [])
     {
         $this->cache = new LruArrayCache(100);
@@ -42,9 +42,8 @@ class S3ExpressIdentityProvider
     private function getS3Client()
     {
         if (is_null($this->s3Client)) {
-            $this->s3Client = isset($this->config['client'])
-                ? $this->config['client'] // internal use only
-                : new Aws\S3\S3Client([
+            $this->s3Client = $this->config['client']
+                ?? new Aws\S3\S3Client([
                     'region' => $this->region,
                     'disable_express_session_auth' => true
                 ]);

--- a/src/S3/ApplyChecksumMiddleware.php
+++ b/src/S3/ApplyChecksumMiddleware.php
@@ -56,21 +56,15 @@ class ApplyChecksumMiddleware
         $body = $request->getBody();
 
         //Checks if AddContentMD5 has been specified for PutObject or UploadPart
-        $addContentMD5 = isset($command['AddContentMD5'])
-            ?  $command['AddContentMD5']
-            : null;
+        $addContentMD5 = $command['AddContentMD5'] ?? null;
 
         $op = $this->api->getOperation($command->getName());
 
-        $checksumInfo = isset($op['httpChecksum'])
-            ? $op['httpChecksum']
-            : [];
+        $checksumInfo = $op['httpChecksum'] ?? [];
         $checksumMemberName = array_key_exists('requestAlgorithmMember', $checksumInfo)
             ? $checksumInfo['requestAlgorithmMember']
             : "";
-        $requestedAlgorithm = isset($command[$checksumMemberName])
-            ? $command[$checksumMemberName]
-            : null;
+        $requestedAlgorithm = $command[$checksumMemberName] ?? null;
         if (!empty($checksumMemberName) && !empty($requestedAlgorithm)) {
             $requestedAlgorithm = strtolower($requestedAlgorithm);
             $checksumMember = $op->getInput()->getMember($checksumMemberName);
@@ -93,9 +87,7 @@ class ApplyChecksumMiddleware
 
         if (!empty($checksumInfo)) {
         //if the checksum member is absent, check if it's required
-        $checksumRequired = isset($checksumInfo['requestChecksumRequired'])
-            ? $checksumInfo['requestChecksumRequired']
-            : null;
+        $checksumRequired = $checksumInfo['requestChecksumRequired'] ?? null;
             if ((!empty($checksumRequired))
                 || (in_array($name, self::$sha256AndMd5) && $addContentMD5)
             ) {
@@ -147,9 +139,9 @@ class ApplyChecksumMiddleware
      * @param CommandInterface $command
      * @return bool
      */
-    private function isS3Express($command): bool
+    private function isS3Express(CommandInterface $command): bool
     {
-        $authSchemes = $command->getAuthSchemes();
-        return isset($authSchemes['name']) && $authSchemes['name'] == 's3express';
+        return isset($command['@context']['signing_service'])
+            && $command['@context']['signing_service'] === 's3express';
     }
 }

--- a/src/Token/SsoTokenProvider.php
+++ b/src/Token/SsoTokenProvider.php
@@ -219,7 +219,7 @@ class SsoTokenProvider implements RefreshableTokenProviderInterface
     {
         return self::getHomeDir()
             . '/.aws/sso/cache/'
-            . utf8_encode(sha1($sso_session))
+            . mb_convert_encoding(sha1($sso_session), "UTF-8")
             . ".json";
     }
 

--- a/src/Token/Token.php
+++ b/src/Token/Token.php
@@ -1,13 +1,14 @@
 <?php
 namespace Aws\Token;
 
+use Aws\Identity\BearerTokenIdentity;
 use Aws\Token\TokenInterface;
 
 /**
  * Basic implementation of the AWS Token interface that allows callers to
  * pass in an AWS token in the constructor.
  */
-class Token implements TokenInterface, \Serializable
+class Token extends BearerTokenIdentity implements TokenInterface, \Serializable
 {
     protected $token;
     protected $expires;

--- a/tests/Auth/AuthSchemeResolverTest.php
+++ b/tests/Auth/AuthSchemeResolverTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Aws\Test\Auth;
+
+use Aws\Auth\Exception\UnresolvedAuthSchemeException;
+use Aws\Auth\AuthSchemeResolver;
+use Aws\Identity\AwsCredentialIdentity;
+use Aws\Identity\BearerTokenIdentity;
+use GuzzleHttp\Promise;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class AuthSchemeResolverTest extends TestCase
+{
+    public function testUsesDefaultSchemeMapWhenNoneProvided()
+    {
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider);
+        $this->assertEquals('v4', $resolver->selectAuthScheme(['aws.auth#sigv4']));
+    }
+
+    public function testAcceptsCustomSchemeMap()
+    {
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $customMap = ['custom.auth#example' => 'v4'];
+        $resolver = new AuthSchemeResolver($credentialProvider, null, $customMap);
+        $this->assertEquals('v4', $resolver->selectAuthScheme(['custom.auth#example']));
+    }
+
+    /**
+     * @dataProvider schemeForIdentityProvider
+     */
+    public function testSelectAuthSchemeReturnsCorrectSchemeForIdentity(
+        $authScheme,
+        $expectedSignatureVersion,
+        $args = []
+    ){
+        if ($expectedSignatureVersion === 'v4a'
+            && !extension_loaded('awscrt')
+        ) {
+            $this->markTestSkipped();
+        }
+
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $tokenProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(BearerTokenIdentity::class)
+            );
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider, $tokenProvider);
+        $this->assertEquals($expectedSignatureVersion, $resolver->selectAuthScheme($authScheme, $args));
+    }
+
+    public function schemeForIdentityProvider()
+    {
+        return [
+          [
+              ['smithy.api#httpBearerAuth'],
+              'bearer'
+          ] ,
+          [
+              ['aws.auth#sigv4'],
+              'v4'
+          ],
+          [
+              ['aws.auth#sigv4'],
+              'v4-unsigned-body',
+              ['unsigned_payload' => true]
+          ],
+          [
+              ['aws.auth#sigv4a'],
+              'v4a'
+          ],
+          [
+              ['smithy.auth#noAuth'],
+              'anonymous'
+          ],
+        ];
+    }
+
+    public function testSelectAuthSchemeThrowsExceptionWhenNoCompatibleScheme()
+    {
+        $this->expectException(UnresolvedAuthSchemeException::class);
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider);
+        $resolver->selectAuthScheme(['non.existent#scheme']);
+    }
+
+    public function testSelectAuthSchemePrioritizesFirstCompatibleScheme()
+    {
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider);
+        $this->assertEquals('v4', $resolver->selectAuthScheme(['aws.auth#sigv4', 'aws.auth#sigv4a']));
+    }
+
+    public function testSelectAuthSchemeSkipsIncompatible()
+    {
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider);
+        $this->assertEquals(
+            'v4',
+            $resolver->selectAuthScheme(['smithy.api#httpBearerAuth', 'aws.auth#sigv4'])
+        );
+    }
+
+    public function testIsCompatibleAuthSchemeReturnsTrueForValidScheme()
+    {
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider);
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('isCompatibleAuthScheme');
+        $method->setAccessible(true);
+        $this->assertTrue($method->invokeArgs($resolver, ['v4']));
+    }
+
+    public function testIsCompatibleAuthSchemeReturnsFalseForInvalidScheme()
+    {
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider);
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('isCompatibleAuthScheme');
+        $method->setAccessible(true);
+        $this->assertFalse($method->invokeArgs($resolver, ['invalidScheme']));
+    }
+
+    public function testMissingRequiredIdentityThrows()
+    {
+        $this->expectException(UnresolvedAuthSchemeException::class);
+        $this->expectExceptionMessage(
+            'Could not resolve an authentication scheme: Signature V4 requires AWS credentials '
+            . 'for request signing; Anonymous signatures require AWS credentials for request '
+            . 'signing; Bearer token credentials must be provided to use Bearer authentication'
+        );
+
+        $credentialProvider = function () {
+            return null;
+        };
+        $tokenProvider = $credentialProvider;
+
+        $resolver = new AuthSchemeResolver($credentialProvider, $tokenProvider);
+        $resolver->selectAuthScheme(['aws.auth#sigv4', 'smithy.auth#noAuth', 'smithy.api#httpBearerAuth']);
+    }
+
+    public function testUnmetV4aRequirementsThrows()
+    {
+        $this->expectException(UnresolvedAuthSchemeException::class);
+        $this->expectExceptionMessage(
+           'The aws-crt-php extension and AWS credentials are required to use Signature V4A'
+        );
+
+        $credentialProvider = function () {
+            if (!extension_loaded('awscrt')) {
+                return Promise\Create::promiseFor(
+                    $this->createMock(AwsCredentialIdentity::class)
+                );
+            }
+            return null;
+        };
+        $resolver = new AuthSchemeResolver($credentialProvider);
+        $resolver->selectAuthScheme(['aws.auth#sigv4a']);
+    }
+}

--- a/tests/Auth/AuthSelectionMiddlewareTest.php
+++ b/tests/Auth/AuthSelectionMiddlewareTest.php
@@ -1,0 +1,356 @@
+<?php
+
+namespace Aws\Test\Auth;
+
+use Aws\Api\Service;
+use Aws\Auth\AuthSelectionMiddleware;
+use Aws\Auth\AuthSchemeResolver;
+use Aws\Auth\Exception\UnresolvedAuthSchemeException;
+use Aws\AwsClient;
+use Aws\CommandInterface;
+use Aws\Identity\AwsCredentialIdentity;
+use Aws\Identity\BearerTokenIdentity;
+use Aws\MockHandler;
+use Aws\Result;
+use GuzzleHttp\Promise;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class AuthSelectionMiddlewareTest extends TestCase
+{
+    /**
+     * @param $serviceAuth
+     * @param $operationAuth
+     * @param $expected
+     *
+     * @dataProvider resolvesAuthSchemeWithoutCRTProvider
+     */
+    public function testResolvesAuthSchemeWithoutCRT(
+        $serviceAuth,
+        $operationAuth,
+        $expected,
+        $unsignedPayload = null
+    )
+    {
+        if (extension_loaded('awscrt')) {
+            $this->markTestSkipped();
+        }
+
+        $nextHandler = function (CommandInterface $command) use ($expected) {
+            $this->assertEquals($expected, $command['@context']['signature_version']);
+        };
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $authResolver = new AuthSchemeResolver($credentialProvider);
+        $service = $this->generateTestService($serviceAuth, $operationAuth, $unsignedPayload);
+        $client = $this->generateTestClient($service);
+        $command = $client->getCommand('fooOperation', ['FooParam' => 'bar']);
+
+        $middleware = new AuthSelectionMiddleware($nextHandler, $authResolver, $service);
+
+        if ($expected === 'error') {
+            $this->expectException(UnresolvedAuthSchemeException::class);
+            $this->expectExceptionMessage(
+               'The aws-crt-php extension and AWS credentials are required to use Signature V4A'
+            );
+        }
+        $middleware($command);
+    }
+
+    public function ResolvesAuthSchemeWithoutCRTProvider()
+    {
+        return [
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                [],
+                'v4',
+            ],
+            [
+                ['aws.auth#sigv4a', 'aws.auth#sigv4'],
+                [],
+                'v4'
+            ],
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                ['aws.auth#sigv4a', 'aws.auth#sigv4'],
+                'v4'
+            ],
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                ['aws.auth#sigv4a', 'aws.auth#sigv4'],
+                'v4-unsigned-body',
+                true
+            ],
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                ['smithy.auth#noAuth'],
+                'anonymous'
+            ],
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                ['aws.auth#sigv4a'],
+                'error'
+            ],
+        ];
+    }
+
+    /**
+     * @param $serviceAuth
+     * @param $operationAuth
+     * @param $expected
+     *
+     * @dataProvider ResolvesAuthSchemeWithCRTprovider
+     */
+    public function testResolvesAuthSchemeWithCRT(
+        $serviceAuth,
+        $operationAuth,
+        $expected,
+        $unsignedPayload = null
+    )
+    {
+        if (!extension_loaded('awscrt')) {
+            $this->markTestSkipped();
+        }
+
+        $nextHandler = function (CommandInterface $command) use ($expected) {
+            $this->assertEquals($expected, $command['@context']['signature_version']);
+        };
+        $service = $this->generateTestService($serviceAuth, $operationAuth, $unsignedPayload);
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $authResolver = new AuthSchemeResolver($credentialProvider);
+        $client = $this->generateTestClient($service);
+        $command = $client->getCommand('fooOperation', ['FooParam' => 'bar']);
+
+        $middleware = new AuthSelectionMiddleware($nextHandler, $authResolver, $service);
+
+        $middleware($command);
+    }
+
+    public function ResolvesAuthSchemeWithCRTprovider()
+    {
+        return [
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                [],
+                'v4'
+            ],
+            [
+                ['aws.auth#sigv4a', 'aws.auth#sigv4'],
+                [],
+                'v4a'
+            ],
+            [
+                ['aws.auth#sigv4'],
+                ['aws.auth#sigv4a'],
+                'v4a'
+            ],
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                ['smithy.auth#noAuth'],
+                'anonymous'
+            ],
+            [
+                ['aws.auth#sigv4a'],
+                ['aws.auth#sigv4'],
+                'v4-unsigned-body',
+                true
+            ]
+        ];
+    }
+
+    /**
+     * @param $serviceAuth
+     * @param $operationAuth
+     * @param $identity
+     * @param $expected
+     *
+     * @dataProvider resolvesBearerAuthSchemeProvider
+     */
+    public function testResolvesBearerAuthScheme(
+        $serviceAuth,
+        $operationAuth,
+        $tokenProvider,
+        $expected
+    ){
+        $nextHandler = function (CommandInterface $command) use ($expected) {
+            $this->assertEquals($expected, $command['@context']['signature_version']);
+        };
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $authResolver = new AuthSchemeResolver($credentialProvider, $tokenProvider);
+        $service = $this->generateTestService($serviceAuth, $operationAuth);
+        $client = $this->generateTestClient($service);
+        $command = $client->getCommand('fooOperation', ['FooParam' => 'bar']);
+
+        $middleware = new AuthSelectionMiddleware($nextHandler, $authResolver, $service);
+
+        if ($expected === 'error') {
+            $this->expectException(UnresolvedAuthSchemeException::class);
+            $this->expectExceptionMessage(
+                'Could not resolve an authentication scheme: Bearer token credentials must be provided to use Bearer authentication'
+            );
+        }
+
+        $middleware($command);
+    }
+
+    public function resolvesBearerAuthSchemeProvider()
+    {
+        return [
+            [
+                ['smithy.api#httpBearerAuth', 'aws.auth#sigv4'],
+                [],
+                function () {
+                    return Promise\Create::promiseFor(
+                        $this->createMock(BearerTokenIdentity::class)
+                    );
+                },
+                'bearer'
+            ],
+            [
+                ['smithy.api#httpBearerAuth', 'aws.auth#sigv4'],
+                [],
+                function () {
+                    return Promise\Create::promiseFor(
+                        null
+                    );
+                },
+                'v4'
+            ],
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                ['smithy.api#httpBearerAuth'],
+                function () {
+                    return Promise\Create::promiseFor(
+                        $this->createMock(BearerTokenIdentity::class)
+                    );
+                },
+                'bearer'
+            ],
+            [
+                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
+                ['smithy.api#httpBearerAuth'],
+                function () {
+                    return Promise\Create::promiseFor(
+                        null
+                    );
+                },
+                'error'
+            ],
+        ];
+    }
+
+    public function testUnknownAuthSchemeThrows()
+    {
+        $this->expectException(UnresolvedAuthSchemeException::class);
+        $this->expectExceptionMessage(
+            'Could not resolve an authentication scheme: The service does not support `notAnAuthScheme` authentication.'
+        );
+
+        $nextHandler = function (CommandInterface $command) {
+            return null;
+        };
+        $service = $this->generateTestService(['notAnAuthScheme'], []);
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+               null
+            );
+        };
+        $authResolver = new AuthSchemeResolver($credentialProvider);
+        $client = $this->generateTestClient($service);
+        $command = $client->getCommand('fooOperation', ['FooParam' => 'bar']);
+
+        $middleware = new AuthSelectionMiddleware($nextHandler, $authResolver, $service);
+
+        $middleware($command);
+    }
+
+    public function testCommandOverrideResolver()
+    {
+        $nextHandler = function (CommandInterface $command) {
+            $this->assertEquals('v4', $command['@context']['signature_version']);
+        };
+        $service = $this->generateTestService(['v4'], []);
+        $credentialProvider = function () {
+            return Promise\Create::promiseFor(
+                $this->createMock(AwsCredentialIdentity::class)
+            );
+        };
+        $authResolver = new AuthSchemeResolver($credentialProvider, null, ['notanauthscheme' => 'foo']);
+        $client = $this->generateTestClient($service);
+        $command = $client->getCommand('fooOperation', ['FooParam' => 'bar']);
+        $command['@context']['auth_scheme_resolver'] = new AuthSchemeResolver($credentialProvider);
+
+        $middleware = new AuthSelectionMiddleware($nextHandler, $authResolver, $service);
+
+        $middleware($command);
+    }
+
+    public function testMiddlewareAppliedAtInitialization()
+    {
+        $service = $this->generateTestService([], []);
+        $client = $this->generateTestClient($service);
+        $list = $client->getHandlerList();
+        $this->assertStringContainsString('auth-selection', $list->__toString());
+    }
+
+    private function generateTestClient(Service $service, $args = [])
+    {
+        return new AwsClient(
+            array_merge(
+                [
+                    'service'      => 'foo',
+                    'api_provider' => function () use ($service) {
+                        return $service->toArray();
+                    },
+                    'region'       => 'us-east-1',
+                    'version'      => 'latest',
+                    'handler' => new MockHandler([new Result([])])
+                ],
+                $args
+            )
+        );
+    }
+
+    private function generateTestService($serviceAuth, $operationAuth, $unsignedPayload = false)
+    {
+        return new Service(
+            [
+                'metadata' => [
+                    "protocol" => "json",
+                    "apiVersion" => "1989-08-05",
+                    "jsonVersion" => "1.1",
+                    "auth" => $serviceAuth
+                ],
+                'operations' => [
+                    'FooOperation' => [
+                        'http' => [
+                            'requestUri' => '/',
+                            'httpMethod' => 'POST'
+                        ],
+                        'input' => [
+                            'type' => 'structure',
+                            'members' => [
+                                'FooParam' => [
+                                    'type' => 'string',
+                                ],
+                            ]
+                        ],
+                        'auth' => $operationAuth,
+                        'unsignedpayload' => $unsignedPayload
+                    ],
+                ]
+            ],
+            function () { return []; }
+        );
+    }
+}

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -2,6 +2,8 @@
 namespace Aws\Test;
 
 use Aws\Api\Service;
+use Aws\Auth\AuthSchemeResolver;
+use Aws\Auth\AuthSchemeResolverInterface;
 use Aws\ClientResolver;
 use Aws\ClientSideMonitoring\Configuration;
 use Aws\ClientSideMonitoring\ConfigurationProvider;
@@ -1659,5 +1661,20 @@ EOF;
         } finally {
             $deferTask();
         }
+    }
+
+    public function testAppliesAuthSchemeResolver()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $conf = $r->resolve([
+            'service' => 'dynamodb',
+            'region' => 'x',
+            'version' => 'latest',
+        ], new HandlerList());
+        $this->assertArrayHasKey('auth_scheme_resolver', $conf);
+        $this->assertInstanceOf(
+            AuthSchemeResolverInterface::class,
+            $conf['auth_scheme_resolver']
+        );
     }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -3,7 +3,7 @@ namespace Aws\Test;
 
 use Aws\Command;
 use Aws\HandlerList;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * @covers Aws\Command
@@ -84,5 +84,29 @@ class CommandTest extends TestCase
         unset($c['boo']);
         $this->assertArrayNotHasKey('boo', $c);
         $this->assertNull($c['boo']);
+    }
+
+    public function testGetAuthSchemesEmitsDeprecationNotice()
+    {
+        $this->expectDeprecation(E_USER_DEPRECATED);
+        $this->expectDeprecationMessage(
+            'Aws\Command::getAuthSchemes is deprecated.  Auth schemes resolved using the service'
+        .' `auth` trait or via endpoint resolution can now be found in the command `@context` property.'
+        );
+
+        $c = new Command('foo', ['bar' => 'baz', 'qux' => 'boo']);
+        $c->getAuthSchemes();
+    }
+
+    public function testSetAuthSchemesEmitsDeprecationNotice()
+    {
+        $this->expectDeprecation(E_USER_DEPRECATED);
+        $this->expectDeprecationMessage(
+            'Aws\Command::setAuthSchemes is deprecated.  Auth schemes resolved using the service'
+            .' `auth` trait or via endpoint resolution are now set in the command `@context` property.'
+        );
+
+        $c = new Command('foo', ['bar' => 'baz', 'qux' => 'boo']);
+        $c->setAuthSchemes([]);
     }
 }

--- a/tests/Credentials/CredentialsTest.php
+++ b/tests/Credentials/CredentialsTest.php
@@ -2,6 +2,9 @@
 namespace Aws\Test\Credentials;
 
 use Aws\Credentials\Credentials;
+use Aws\Identity\AwsCredentialIdentity;
+use Aws\Identity\AwsCredentialIdentityInterface;
+use Aws\Identity\IdentityInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -56,5 +59,11 @@ class CredentialsTest extends TestCase
             'token'   => 'token-value',
             'expires' => 10,
         ], $actual);
+    }
+
+    public function testIsInstanceOfIdentity()
+    {
+        $credentials = new Credentials('key-value', 'secret-value');
+        $this->assertInstanceOf(AwsCredentialIdentity::class, $credentials);
     }
 }

--- a/tests/EndpointV2/EndpointProviderV2Test.php
+++ b/tests/EndpointV2/EndpointProviderV2Test.php
@@ -275,23 +275,22 @@ class EndpointProviderV2Test extends TestCase
                         $expectedVersion = str_replace('sig', '', $expectedAuthScheme['name']);
                     }
                     $this->assertEquals(
-                        $expectedVersion,
-                        $cmd->getAuthSchemes()['version']
+                        $cmd['@context']['signature_version'],
+                        $expectedVersion
                     );
                     $this->assertEquals(
-                        $expectedAuthScheme['signingName'],
-                        $cmd->getAuthSchemes()['name']
+                        $cmd['@context']['signing_service'],
+                        $expectedAuthScheme['signingName']
                     );
-                    if (isset($cmd->getAuthSchemes()['region'])) {
+                    if (isset($cmd['@context']['signing_region'])) {
                         $this->assertEquals(
-                            $expectedAuthScheme['signingRegion'],
-                            $cmd->getAuthSchemes()['region']
+                            $cmd['@context']['signing_region'],
+                            $expectedAuthScheme['signingRegion']
                         );
-                    } elseif (isset($cmd->getAuthSchemes['signingRegionSet'])) {
+                    } elseif (isset($cmd['@context']['signing_region_set'])) {
                         $this->assertEquals(
-                            $expectedAuthScheme['signingRegionSet'],
-                            $cmd->getAuthSchemes()['region']
-                        );
+                            $cmd['@context']['signing_region_set'],
+                            $expectedAuthScheme['signingRegionSet']);
                     }
                 }
             }

--- a/tests/EndpointV2/EndpointV2MiddlewareTest.php
+++ b/tests/EndpointV2/EndpointV2MiddlewareTest.php
@@ -3,7 +3,6 @@ namespace Aws\Test\EndpointV2;
 
 use Aws\Api\Service;
 use Aws\Auth\Exception\UnresolvedAuthSchemeException;
-use Aws\Endpoint\PartitionEndpointProvider;
 use Aws\EndpointV2\EndpointProviderV2;
 use Aws\EndpointV2\EndpointV2Middleware;
 use Aws\EndpointV2\Ruleset\RulesetEndpoint;
@@ -35,10 +34,6 @@ class EndpointV2MiddlewareTest extends TestCase
         $nextHandler = function ($command, $endpoint) use ($service, $expectedUri) {
             $this->assertInstanceOf(RulesetEndpoint::class, $endpoint);
             $this->assertEquals($expectedUri, $endpoint->getUrl());
-
-            if (!empty($endpoint->getProperty('authSchemes'))) {
-                self::assertNotEmpty($command->getAuthSchemes());
-            }
         };
 
         $client = $this->getTestClient($service, $clientArgs);
@@ -273,19 +268,5 @@ class EndpointV2MiddlewareTest extends TestCase
 
         $middleware = new EndpointV2Middleware($nextHandler, $endpointProvider, $api, $args);
         $middleware('not_a_command');
-    }
-
-    public function testMiddlewareAppliedForEndpointV2Clients()
-    {
-        $client = $this->getTestClient('s3');
-        $list = $client->getHandlerList();
-        $this->assertStringContainsString('endpoint-resolution', $list->__toString());
-    }
-
-    public function testMiddlewareNotAppliedForNonEndpointV2Clients()
-    {
-        $client = $this->getTestClient('s3', ['endpoint_provider' => PartitionEndpointProvider::defaultProvider()]);
-        $list = $client->getHandlerList();
-        $this->assertStringNotContainsString('endpoint-resolution', $list->__toString());
     }
 }

--- a/tests/Token/SsoTokenProviderTest.php
+++ b/tests/Token/SsoTokenProviderTest.php
@@ -18,6 +18,10 @@ class SsoTokenProviderTest extends TestCase
 {
     use UsesServiceTrait;
 
+    private $home;
+    private $homedrive;
+    private $homepath;
+
     private function clearEnv() {
         putenv('AWS_SHARED_CREDENTIALS_FILE');
         putenv('HOME');

--- a/tests/Token/TokenProviderTest.php
+++ b/tests/Token/TokenProviderTest.php
@@ -298,7 +298,7 @@ EOT;
     "startUrl": "https://d-abc123.awsapps.com/start"
 }
 EOT;
-        $cachedFileName = $this->getHomeDir() . '/.aws/sso/cache/' . utf8_encode(sha1($ssoSessionName)) . '.json';
+        $cachedFileName = $this->getHomeDir() . '/.aws/sso/cache/' . mb_convert_encoding(sha1($ssoSessionName), "UTF-8") . '.json';
         $dir = sys_get_temp_dir() . '/.aws';
         $iniFileName = $dir . '/config';
 

--- a/tests/Token/TokenTest.php
+++ b/tests/Token/TokenTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace Aws\Test\Token;
+
+use Aws\Identity\BearerTokenIdentity;
+use Aws\Identity\BearerTokenIdentityInterface;
+use Aws\Token\Token;
+use Aws\Identity\IdentityInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Aws\Token\Token
+ */
+class CredentialsTest extends TestCase
+{
+    public function testHasGetters()
+    {
+        $exp = time() + 500;
+        $token = new Token('foo', $exp);
+        $this->assertSame('foo', $token->getToken());
+        $this->assertSame($exp, $token->getExpiration());
+        $this->assertEquals([
+            'token'     => 'foo',
+            'expires' => $exp
+        ], $token->toArray());
+    }
+
+    public function testDeterminesIfExpired()
+    {
+        $this->assertFalse((new Token('foo'))->isExpired());
+        $this->assertFalse(
+            (new Token('foo', time() + 100))->isExpired()
+        );
+        $this->assertTrue(
+            (new Token('foo', time() - 1000))->isExpired()
+        );
+    }
+
+    public function testSerialization()
+    {
+        $token = new Token('token-value');
+        $actual = unserialize(serialize($token))->toArray();
+        $this->assertEquals([
+            'token'     => 'token-value',
+            'expires' => null,
+        ], $actual);
+
+        $token = new Token('token-value',  10);
+        $actual = unserialize(serialize($token))->toArray();
+
+        $this->assertEquals([
+            'token'     => 'token-value',
+            'expires' => 10,
+        ], $actual);
+    }
+
+    public function testIsInstanceOfIdentity()
+    {
+        $token = new Token('token-value');
+        $this->assertInstanceOf(BearerTokenIdentity::class, $token);
+    }
+}


### PR DESCRIPTION
**Description of changes**:

Adds support for the service and operation-level auth trait, which allows a service to model multiple signature versions. When modeled, this trait will contain a non-empty priority-ordered list of signature versions to select from.  Selection is dependent on a few different factors: e.g. `v4a` signatures require installation of the crt extension; `bearer` signatures require that you are using bearer token credentials.  Selection will be performed on a per-request basis, with the operation-level modeled `auth` taking precedence over the service level modeled `auth`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
