### PR TITLE
enhancement: update auth scheme resolution

### DIFF
--- a/.changes/nextrelease/auth-scheme-update.json
+++ b/.changes/nextrelease/auth-scheme-update.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "ehnancement",
+    "category": "EndpointV2",
+    "description": "Updates auth scheme selection criteria"
+  }
+]

--- a/.changes/nextrelease/auth-scheme-update.json
+++ b/.changes/nextrelease/auth-scheme-update.json
@@ -1,6 +1,6 @@
 [
   {
-    "type": "ehnancement",
+    "type": "enhancement",
     "category": "EndpointV2",
     "description": "Updates auth scheme selection criteria"
   }

--- a/src/Auth/Exception/UnresolvedAuthSchemeException.php
+++ b/src/Auth/Exception/UnresolvedAuthSchemeException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Aws\Auth\Exception;
+
+use Aws\HasMonitoringEventsTrait;
+use Aws\MonitoringEventsInterface;
+
+/**
+ * Represents an error when attempting to resolve authentication.
+ */
+class UnresolvedAuthSchemeException extends \RuntimeException implements
+    MonitoringEventsInterface
+{
+    use HasMonitoringEventsTrait;
+}

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -3,6 +3,7 @@ namespace Aws\EndpointV2;
 
 use Aws\Api\Operation;
 use Aws\Api\Service;
+use Aws\Auth\Exception\UnresolvedAuthSchemeException;
 use Aws\CommandInterface;
 use Closure;
 use GuzzleHttp\Promise\Promise;
@@ -18,11 +19,11 @@ use GuzzleHttp\Promise\Promise;
 class EndpointV2Middleware
 {
     private static $validAuthSchemes = [
-        'sigv4' => true,
-        'sigv4a' => true,
-        'none' => true,
-        'bearer' => true,
-        'sigv4-s3express' => true
+        'sigv4' => 'v4',
+        'sigv4a' => 'v4a',
+        'none' => 'anonymous',
+        'bearer' => 'bearer',
+        'sigv4-s3express' => 'v4-s3express'
     ];
 
     /** @var callable */
@@ -247,19 +248,32 @@ class EndpointV2Middleware
 
         foreach($authSchemes as $authScheme) {
             if (isset(self::$validAuthSchemes[$authScheme['name']])) {
+                switch($authScheme['name']) {
+                    case 'sigv4a':
+                        if (!extension_loaded('awscrt')) {
+                            $invalidAuthSchemes[$authScheme['name']] = false;
+                            continue 2;
+                        }
+                        break;
+                }
                 return $this->normalizeAuthScheme($authScheme);
             } else {
-                $invalidAuthSchemes[] = "`{$authScheme['name']}`";
+                $invalidAuthSchemes[$authScheme['name']] = false;
             }
         }
 
-        $invalidAuthSchemesString = implode(', ', $invalidAuthSchemes);
-        $validAuthSchemesString = '`'
-            . implode('`, `', array_keys(self::$validAuthSchemes))
+        $invalidAuthSchemesString = '`' . implode(
+            '`, `',
+            array_keys($invalidAuthSchemes))
             . '`';
-        throw new \InvalidArgumentException(
+        $validAuthSchemesString = '`'
+            . implode('`, `', array_keys(
+                array_diff_key(self::$validAuthSchemes, $invalidAuthSchemes))
+            )
+            . '`';
+        throw new UnresolvedAuthSchemeException(
             "This operation requests {$invalidAuthSchemesString}"
-            . " auth schemes, but the client only supports {$validAuthSchemesString}."
+            . " auth schemes, but the client currently supports {$validAuthSchemesString}."
         );
     }
 
@@ -285,13 +299,8 @@ class EndpointV2Middleware
             && $authScheme['name'] !== 'sigv4-s3express'
         ) {
             $normalizedAuthScheme['version'] = 's3v4';
-        } elseif ($authScheme['name'] === 'none') {
-            $normalizedAuthScheme['version'] = 'anonymous';
-        }
-        else {
-            $normalizedAuthScheme['version'] = str_replace(
-                'sig', '', $authScheme['name']
-            );
+        } else {
+            $normalizedAuthScheme['version'] = self::$validAuthSchemes[$authScheme['name']];
         }
 
         $normalizedAuthScheme['name'] = isset($authScheme['signingName']) ?

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -247,19 +247,10 @@ class EndpointV2Middleware
         $invalidAuthSchemes = [];
 
         foreach($authSchemes as $authScheme) {
-            if (isset(self::$validAuthSchemes[$authScheme['name']])) {
-                switch($authScheme['name']) {
-                    case 'sigv4a':
-                        if (!extension_loaded('awscrt')) {
-                            $invalidAuthSchemes[$authScheme['name']] = false;
-                            continue 2;
-                        }
-                        break;
-                }
+            if ($this->isValidAuthScheme($authScheme['name'])) {
                 return $this->normalizeAuthScheme($authScheme);
-            } else {
-                $invalidAuthSchemes[$authScheme['name']] = false;
             }
+            $invalidAuthSchemes[$authScheme['name']] = false;
         }
 
         $invalidAuthSchemesString = '`' . implode(
@@ -311,5 +302,16 @@ class EndpointV2Middleware
             $authScheme['signingRegionSet'] : null;
 
         return $normalizedAuthScheme;
+    }
+
+    private function isValidAuthScheme($signatureVersion): bool
+    {
+        if (isset(self::$validAuthSchemes[$signatureVersion])) {
+              if ($signatureVersion === 'sigv4a') {
+                  return extension_loaded('awscrt');
+              }
+              return true;
+        }
+        return false;
     }
 }

--- a/tests/EndpointV2/EndpointProviderV2Test.php
+++ b/tests/EndpointV2/EndpointProviderV2Test.php
@@ -1,8 +1,8 @@
 <?php
 namespace Aws\Test\EndpointV2;
 
+use Aws\Auth\Exception\UnresolvedAuthSchemeException;
 use Aws\EndpointV2\EndpointDefinitionProvider;
-use Aws\CommandInterface;
 use Aws\EndpointV2\EndpointProviderV2;
 use Aws\EndpointV2\Ruleset\Ruleset;
 use Aws\EndpointV2\Ruleset\RulesetEndpoint;
@@ -10,7 +10,6 @@ use Aws\Exception\CommonRuntimeException;
 use Aws\Exception\UnresolvedEndpointException;
 use Aws\Middleware;
 use Aws\Test\UsesServiceTrait;
-use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Psr7\Uri;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
@@ -303,7 +302,7 @@ class EndpointProviderV2Test extends TestCase
         $handler = $list->resolve();
         try {
             $handler($command)->wait();
-        } catch (CommonRuntimeException $e) {
+        } catch (CommonRuntimeException | UnresolvedAuthSchemeException $e) {
             $this->markTestSkipped();
         }
     }

--- a/tests/EndpointV2/EndpointV2SerializerTraitTest.php
+++ b/tests/EndpointV2/EndpointV2SerializerTraitTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Test\EndpointV2;
 
+use Aws\Auth\Exception\UnresolvedAuthSchemeException;
 use Aws\EndpointV2\EndpointDefinitionProvider;
 use Aws\EndpointV2\EndpointProviderV2;
 use Aws\Middleware;
@@ -52,10 +53,10 @@ class EndpointV2SerializerTraitTest extends TestCase
      */
     public function testThrowsExceptionForInvalidAuthScheme()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(UnresolvedAuthSchemeException::class);
         $this->expectExceptionMessage(
            'This operation requests `sigvfoo`, `sigvbar`, `sigvbaz` auth schemes,'
-           . ' but the client only supports `sigv4`, `sigv4a`, `none`, `bearer`,'
+           . ' but the client currently supports `sigv4`, `sigv4a`, `none`, `bearer`,'
            . ' `sigv4-s3express`.'
         );
 

--- a/tests/Identity/S3Express/S3ExpressIdentityProviderTest.php
+++ b/tests/Identity/S3Express/S3ExpressIdentityProviderTest.php
@@ -4,17 +4,11 @@ namespace Aws\Test\Identity\S3Express;
 use Aws\Api\DateTimeResult;
 use Aws\Identity\S3\S3ExpressIdentityProvider;
 use Aws\Result;
-use Aws\S3\S3Client;
 use Aws\Test\UsesServiceTrait;
-use Behat\Gherkin\Exception\CacheException;
-use Composer\Cache;
-use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\RequestInterface;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
- * @covers Aws\Identity\S3Express\S3ExpressIdentityProvider
+ * @covers Aws\Identity\S3\S3ExpressIdentityProvider
  */
 class S3ExpressIdentityProviderTest extends TestCase
 {


### PR DESCRIPTION
*Description of changes:*
Updates to auth scheme resolution, which allows for multiple auth schemes to be modeled in priority order.  For example, a service might prioritize `sigv4a`, which requires the `awscrt` extension, but list `sigv4` as a fallback.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
