### PR TITLE
fix: set use_aws_shared_config_files opts-in

### DIFF
--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -60,6 +60,9 @@ class InstanceProfileProvider
     /** @var string */
     private $endpointMode;
 
+    /** @var array */
+    private $config;
+
     /**
      * The constructor accepts the following options:
      *
@@ -68,10 +71,12 @@ class InstanceProfileProvider
      * - retries: Optional number of retries to be attempted.
      * - ec2_metadata_v1_disabled: Optional for disabling the fallback to IMDSv1.
      * - endpoint: Optional for overriding the default endpoint to be used for fetching credentials.
-     *             The value must contain a valid URI scheme. If the URI scheme is not https, it must
-     *             resolve to a loopback address.
+     *   The value must contain a valid URI scheme. If the URI scheme is not https, it must
+     *   resolve to a loopback address.
      * - endpoint_mode: Optional for overriding the default endpoint mode (IPv4|IPv6) to be used for
      *   resolving the default endpoint.
+     * - use_aws_shared_config_files: Decides whether the shared config file should be considered when
+     *   using the ConfigurationResolver::resolve method.
      *
      * @param array $config Configuration options.
      */
@@ -88,6 +93,7 @@ class InstanceProfileProvider
         }
 
         $this->endpointMode = $config[self::CFG_EC2_METADATA_SERVICE_ENDPOINT_MODE] ?? null;
+        $this->config = $config;
     }
 
     /**
@@ -344,7 +350,7 @@ class InstanceProfileProvider
                     self::CFG_EC2_METADATA_V1_DISABLED,
                     self::DEFAULT_AWS_EC2_METADATA_V1_DISABLED,
                     'bool',
-                    ['use_aws_shared_config_files' => true]
+                    $this->config
                 )
             )
             ?? self::DEFAULT_AWS_EC2_METADATA_V1_DISABLED;
@@ -369,7 +375,7 @@ class InstanceProfileProvider
                 self::CFG_EC2_METADATA_SERVICE_ENDPOINT,
                 $this->getDefaultEndpoint(),
                 'string',
-                ['use_aws_shared_config_files' => true]
+                $this->config
             );
         }
 
@@ -420,7 +426,7 @@ class InstanceProfileProvider
                 self::CFG_EC2_METADATA_SERVICE_ENDPOINT_MODE,
                     self::ENDPOINT_MODE_IPv4,
                 'string',
-                ['use_aws_shared_config_files' => true]
+                $this->config
             );
         }
 

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -1340,6 +1340,7 @@ class InstanceProfileProviderTest extends TestCase
 
             return Promise\Create::rejectionFor(['exception' => new \Exception('Unexpected error!')]);
         };
+        $config['use_aws_shared_config_files'] = true;
         $provider = new InstanceProfileProvider(array_merge(($config ?? []), ['client' => $mockHandler]));
         try {
             $provider()->wait();
@@ -1385,7 +1386,8 @@ class InstanceProfileProviderTest extends TestCase
                     default:
                         $this->fail("The expected value for endpoint_mode should be either one of the following options[" . InstanceProfileProvider::ENDPOINT_MODE_IPv4 . ', ' . InstanceProfileProvider::ENDPOINT_MODE_IPv6 . "]");
                 }
-            })
+            }),
+            'use_aws_shared_config_files' => true
         ];
         if (!is_null($endpointModeClientConfig)) {
             $providerConfig[InstanceProfileProvider::CFG_EC2_METADATA_SERVICE_ENDPOINT_MODE] = $endpointModeClientConfig;
@@ -1498,7 +1500,8 @@ class InstanceProfileProviderTest extends TestCase
             'client' => $this->getClientForEndpointTesting(function ($uri) use ($expectedEndpoint) {
                 $endpoint = $uri->getScheme() . '://' . $uri->getHost();
                 $this->assertSame($expectedEndpoint, $endpoint);
-            })
+            }),
+            'use_aws_shared_config_files' => true
         ];
         $deferredTasks = [];
         if (!is_null($endpointEnv)) {


### PR DESCRIPTION
This change makes the ConfigurationResolver to load configuration from aws shared config files based on the configuration `use_aws_shared_config_files` either provided as provider arguments or as service client arguments.

*Issue #2887*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
