### PR TITLE
Check based on Value 

### DIFF
--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -1190,10 +1190,15 @@ class ClientResolver
   
     public static function _apply_region($value, array &$args)
     {
+        if (isset($value)) {
+            $args['region'] = $value;
+        } else {
+            $args['region'] = self::_default_region($args);
+        }
+        
         if (empty($value)) {
             self::_missing_region($args);
         }
-        $args['region'] = $value;
     }
 
     public static function _default_region(&$args)


### PR DESCRIPTION
The modified _apply_region function now checks if the $value parameter is set. If it is set, it assigns the value to $args['region']. If $value is not set, it calls the _default_region function to retrieve the default region value and assigns it to $args['region'].

After setting the region value, the function proceeds to check if the value is empty. If it is empty, it invokes the _missing_region function, indicating that the region is missing from the arguments.

Overall, the modified function ensures that the region parameter is either explicitly set or assigned a default value, and it handles the case where the region value is empty by calling a separate function to handle the missing region scenario.