### PR TITLE
update ddb-streams smoke test

### DIFF
--- a/features/smoke/dynamodbstreams.feature
+++ b/features/smoke/dynamodbstreams.feature
@@ -9,4 +9,4 @@ Feature: Amazon DynamoDB Streams
   Scenario: Handling errors
     When I attempt to call the "DescribeStream" API with:
     | StreamArn | arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T20:51:10.252 |
-    Then I expect the response error code to be "ResourceNotFoundException"
+    Then I expect the response error code to be "AccessDeniedException"


### PR DESCRIPTION
*Description of changes:*
Updates test to account for exception change from ddb-streams.  Unknown if this change is intended from the ddb-streams side, but behavior is confirmed to be consistent regardless of account used.  The example stream arn used in the test is sourced from the [DescribeStream documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_DescribeStream.html#API_streams_DescribeStream_Example_1_Request).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
