### PR TITLE
feat: add streaming support on JSON RPC parser

### DIFF
--- a/.changes/nextrelease/json-rpc-streaming-support.json
+++ b/.changes/nextrelease/json-rpc-streaming-support.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "Parser",
+    "description": "Adds support for event streaming on JSON-RPC protocol parser"
+  }
+]

--- a/src/Api/Parser/DecodingEventStreamIterator.php
+++ b/src/Api/Parser/DecodingEventStreamIterator.php
@@ -52,19 +52,19 @@ class DecodingEventStreamIterator implements Iterator
     ];
 
     /** @var StreamInterface Stream of eventstream shape to parse. */
-    private $stream;
+    protected $stream;
 
     /** @var array Currently parsed event. */
-    private $currentEvent;
+    protected $currentEvent;
 
     /** @var int Current in-order event key. */
-    private $key;
+    protected $key;
 
     /** @var resource|\HashContext CRC32 hash context for event validation */
-    private $hashContext;
+    protected $hashContext;
 
     /** @var int $currentPosition */
-    private $currentPosition;
+    protected $currentPosition;
 
     /**
      * DecodingEventStreamIterator constructor.
@@ -77,7 +77,7 @@ class DecodingEventStreamIterator implements Iterator
         $this->rewind();
     }
 
-    private function parseHeaders($headerBytes)
+    protected function parseHeaders($headerBytes)
     {
         $headers = [];
         $bytesRead = 0;
@@ -102,7 +102,7 @@ class DecodingEventStreamIterator implements Iterator
         return [$headers, $bytesRead];
     }
 
-    private function parsePrelude()
+    protected function parsePrelude()
     {
         $prelude = [];
         $bytesRead = 0;
@@ -127,7 +127,12 @@ class DecodingEventStreamIterator implements Iterator
         return [$prelude, $bytesRead];
     }
 
-    private function parseEvent()
+    /**
+     * This method decodes an event from the stream.
+     *
+     * @return array
+     */
+    protected function parseEvent()
     {
         $event = [];
 
@@ -217,7 +222,7 @@ class DecodingEventStreamIterator implements Iterator
 
     // Decoding Utilities
 
-    private function readAndHashBytes($num)
+    protected function readAndHashBytes($num)
     {
         $bytes = $this->stream->read($num);
         hash_update($this->hashContext, $bytes);

--- a/src/Api/Parser/EventParsingIterator.php
+++ b/src/Api/Parser/EventParsingIterator.php
@@ -28,9 +28,26 @@ class EventParsingIterator implements Iterator
         StructureShape $shape,
         AbstractParser $parser
     ) {
-        $this->decodingIterator = new DecodingEventStreamIterator($stream);
+        $this->decodingIterator = $this->chooseDecodingIterator($stream);
         $this->shape = $shape;
         $this->parser = $parser;
+    }
+
+    /**
+     * This method choose a decoding iterator implementation based on if the stream
+     * is seekable or not.
+     *
+     * @param $stream
+     *
+     * @return Iterator
+     */
+    private function chooseDecodingIterator($stream)
+    {
+        if ($stream->isSeekable()) {
+            return new DecodingEventStreamIterator($stream);
+        } else {
+            return new NonSeekableStreamDecodingEventStreamIterator($stream);
+        }
     }
 
     #[\ReturnTypeWillChange]
@@ -80,8 +97,12 @@ class EventParsingIterator implements Iterator
             throw new ParserException('Failed to parse without event type.');
         }
 
-        $eventShape = $this->shape->getMember($eventType);
         $eventPayload = $event['payload'];
+        if ($eventType === 'initial-response') {
+            return $this->parseInitialResponseEvent($eventPayload);
+        }
+
+        $eventShape = $this->shape->getMember($eventType);
 
         return [
             $eventType => array_merge(
@@ -152,5 +173,10 @@ class EventParsingIterator implements Iterator
             $event['headers'][':error-code'],
             $event['headers'][':error-message']
         );
+    }
+
+    private function parseInitialResponseEvent($payload): array
+    {
+        return ['initial-response' => json_decode($payload, true)];
     }
 }

--- a/src/Api/Parser/JsonRpcParser.php
+++ b/src/Api/Parser/JsonRpcParser.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aws\Api\Parser;
 
+use Aws\Api\Operation;
 use Aws\Api\StructureShape;
 use Aws\Api\Service;
 use Aws\Result;
@@ -30,15 +31,45 @@ class JsonRpcParser extends AbstractParser
         ResponseInterface $response
     ) {
         $operation = $this->api->getOperation($command->getName());
-        $result = null === $operation['output']
-            ? null
-            : $this->parseMemberFromStream(
+
+        return $this->parseResponse($response, $operation);
+    }
+
+    /**
+     * This method parses a response based on JSON RPC protocol.
+     *
+     * @param ResponseInterface $response the response to parse.
+     * @param Operation $operation the operation which holds information for
+     *        parsing the response.
+     *
+     * @return Result
+     */
+    private function parseResponse(ResponseInterface $response, Operation $operation)
+    {
+        if (null === $operation['output']) {
+            return new Result([]);
+        }
+
+        $outputShape = $operation->getOutput();
+        foreach ($outputShape->getMembers() as $memberName => $memberProps) {
+            if (!empty($memberProps['eventstream'])) {
+                return new Result([
+                    $memberName => new EventParsingIterator(
+                        $response->getBody(),
+                        $outputShape->getMember($memberName),
+                        $this
+                    )
+                ]);
+            }
+        }
+
+        $result = $this->parseMemberFromStream(
                 $response->getBody(),
                 $operation->getOutput(),
                 $response
             );
 
-        return new Result($result ?: []);
+        return new Result(is_null($result) ? [] : $result);
     }
 
     public function parseMemberFromStream(

--- a/src/Api/Parser/NonSeekableStreamDecodingEventStreamIterator.php
+++ b/src/Api/Parser/NonSeekableStreamDecodingEventStreamIterator.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Aws\Api\Parser;
+
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\StreamInterface;
+use Aws\Api\Parser\Exception\ParserException;
+
+/**
+ * @inheritDoc
+ */
+class NonSeekableStreamDecodingEventStreamIterator extends DecodingEventStreamIterator
+{
+    /** @var array $tempBuffer */
+    private $tempBuffer;
+
+    /**
+     * NonSeekableStreamDecodingEventStreamIterator constructor.
+     *
+     * @param StreamInterface $stream
+     */
+    public function __construct(StreamInterface $stream)
+    {
+        $this->stream = $stream;
+        if ($this->stream->isSeekable()) {
+            throw new \InvalidArgumentException('The stream provided must be not seekable.');
+        }
+
+        $this->tempBuffer = [];
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return array
+     */
+    protected function parseEvent(): array
+    {
+        $event = [];
+        $this->hashContext = hash_init('crc32b');
+        $prelude = $this->parsePrelude()[0];
+        list(
+            $event[self::HEADERS],
+            $numBytes
+        ) = $this->parseHeaders($prelude[self::LENGTH_HEADERS]);
+        $event[self::PAYLOAD] = Psr7\Utils::streamFor(
+            $this->readAndHashBytes(
+                $prelude[self::LENGTH_TOTAL] - self::BYTES_PRELUDE
+                - $numBytes - self::BYTES_TRAILING
+            )
+        );
+        $calculatedCrc = hash_final($this->hashContext, true);
+        $messageCrc = $this->stream->read(4);
+        if ($calculatedCrc !== $messageCrc) {
+            throw new ParserException('Message checksum mismatch.');
+        }
+
+        return $event;
+    }
+
+    protected function readAndHashBytes($num): string
+    {
+        $bytes = '';
+        while (!empty($this->tempBuffer) && $num > 0) {
+            $byte = array_shift($this->tempBuffer);
+            $bytes .= $byte;
+            $num = $num - 1;
+        }
+
+        $bytes = $bytes . $this->stream->read($num);
+        hash_update($this->hashContext, $bytes);
+
+        return $bytes;
+    }
+
+    // Iterator Functionality
+
+    #[\ReturnTypeWillChange]
+    public function rewind()
+    {
+        $this->currentEvent = $this->parseEvent();
+    }
+
+    public function next()
+    {
+        $this->tempBuffer[] = $this->stream->read(1);
+        if ($this->valid()) {
+            $this->key++;
+            $this->currentEvent = $this->parseEvent();
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
+    public function valid()
+    {
+        return !$this->stream->eof();
+    }
+}

--- a/src/CloudWatchLogs/CloudWatchLogsClient.php
+++ b/src/CloudWatchLogs/CloudWatchLogsClient.php
@@ -2,6 +2,8 @@
 namespace Aws\CloudWatchLogs;
 
 use Aws\AwsClient;
+use Aws\CommandInterface;
+use Generator;
 
 /**
  * This client is used to interact with the **Amazon CloudWatch Logs** service.
@@ -155,4 +157,64 @@ use Aws\AwsClient;
  * @method \Aws\Result updateLogAnomalyDetector(array $args = [])
  * @method \GuzzleHttp\Promise\Promise updateLogAnomalyDetectorAsync(array $args = [])
  */
-class CloudWatchLogsClient extends AwsClient {}
+class CloudWatchLogsClient extends AwsClient {
+    static $streamingCommands = [
+        'StartLiveTail' => true
+    ];
+
+    public function __construct(array $args)
+    {
+        parent::__construct($args);
+        $this->addStreamingFlagMiddleware();
+    }
+
+    private function addStreamingFlagMiddleware()
+    {
+        $this->getHandlerList()
+            -> appendInit(
+                $this->getStreamingFlagMiddleware(),
+                'streaming-flag-middleware'
+            );
+    }
+
+    private function getStreamingFlagMiddleware(): callable
+    {
+        return function (callable $handler) {
+            return function (CommandInterface $command, $request = null) use ($handler) {
+                if (!empty(self::$streamingCommands[$command->getName()])) {
+                    $command['@http']['stream'] = true;
+                }
+
+                return $handler($command, $request);
+            };
+        };
+    }
+
+    /**
+     * Helper method for 'startLiveTail' operation that checks for results.
+     *
+     * Initiates 'startLiveTail' operation with given arguments, and continuously
+     * checks response stream for session updates or results, yielding each
+     * stream chunk when results are not empty. This method abstracts from users
+     * the need of checking if there are logs entry available to be watched, which means
+     * that users will always get a next item to be iterated when more log entries are
+     * available.
+     *
+     * @param array $args Command arguments.
+     *
+     * @return Generator Yields session update or result stream chunks.
+     */
+    public function startLiveTailCheckingForResults(array $args): Generator
+    {
+        $response = $this->startLiveTail($args);
+        foreach ($response['responseStream'] as $streamChunk) {
+            if (isset($streamChunk['sessionUpdate'])) {
+                if (!empty($streamChunk['sessionUpdate']['sessionResults'])) {
+                    yield $streamChunk;
+                }
+            } else {
+                yield $streamChunk;
+            }
+        }
+    }
+}

--- a/tests/Api/Parser/JsonRpcParserTest.php
+++ b/tests/Api/Parser/JsonRpcParserTest.php
@@ -2,12 +2,17 @@
 namespace Aws\Test\Api\Parser;
 
 use Aws\Api\Operation;
+use Aws\Api\Parser\EventParsingIterator;
 use Aws\Api\Parser\JsonParser;
 use Aws\Api\Parser\JsonRpcParser;
 use Aws\Api\Service;
 use Aws\Api\Shape;
+use Aws\Api\ShapeMap;
+use Aws\Api\StructureShape;
+use Aws\Command;
 use Aws\CommandInterface;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 
 class JsonRpcParserTest extends TestCase
@@ -53,7 +58,7 @@ class JsonRpcParserTest extends TestCase
             new Response(200, [], json_encode(null))
         );
     }
-    
+
     public function testCanHandleEmptyResponses()
     {
         $operation = $this->getMockBuilder(Operation::class)
@@ -86,5 +91,132 @@ class JsonRpcParserTest extends TestCase
             $this->getMockBuilder(CommandInterface::class)->getMock(),
             new Response(200, [])
         );
+    }
+
+    public function testCanHandleNonStreamingResponses()
+    {
+        $service = $this->getMockBuilder(Service::class)
+            -> disableOriginalConstructor()
+            -> setMethods(['getOperation'])
+            -> getMock();
+        $operation = $this->getMockBuilder(Operation::class)
+            -> disableOriginalConstructor()
+            -> setMethods(['getOutput'])
+            -> getMock();
+        $outputShape = new StructureShape([
+            'type' => 'structure',
+            'members' => [
+                'name' => [
+                    'type' => 'string'
+                ],
+                'lastName' => [
+                    'type' => 'string'
+                ],
+                'age' => [
+                    'type' => 'integer'
+                ],
+                'DOB' => [
+                    'type' => 'timestamp'
+                ]
+            ]
+        ], new ShapeMap([]));
+        $operation->method('getOutput')
+            -> willReturn($outputShape);
+        $operation['output'] = $outputShape;
+        $service->method('getOperation')
+            -> withAnyParameters()
+            -> willReturn($operation);
+        $jsonRPCParser = new JsonRpcParser($service);
+        $command = $this->getMockBuilder(Command::class)
+            -> disableOriginalConstructor()
+            -> setMethods(['getName'])
+            -> getMock();
+        $command->method('getName')
+            ->willReturn('TestCommand');
+        $body = json_encode([
+            'name' => 'foo',
+            'lastName' => 'fuzz',
+            'age' => 28
+        ]);
+        $response = new Response(200, [], $body);
+        $result = $jsonRPCParser($command, $response);
+
+        foreach ($result->toArray() as $_ => $value) {
+            $this->assertNotInstanceOf(EventParsingIterator::class, $value);
+        }
+
+        $this->assertEquals(
+            json_decode($body, true),
+            $result->toArray()
+        );
+    }
+
+    public function testCanHandleStreamingResponses()
+    {
+        $service = $this->getMockBuilder(Service::class)
+            -> disableOriginalConstructor()
+            -> setMethods(['getOperation'])
+            -> getMock();
+        $operation = $this->getMockBuilder(Operation::class)
+            -> disableOriginalConstructor()
+            -> setMethods(['getOutput'])
+            -> getMock();
+        $outputShape = new StructureShape([
+            'type' => 'structure',
+            'members' => [
+                'responseStream' => [
+                    'type' => 'structure',
+                    'eventstream' => true,
+                    'members' => [
+                        'person' => [
+                            'type' => 'structure',
+                            'members' => [
+                                'name' => [
+                                    'type' => 'string'
+                                ],
+                                'lastName' => [
+                                    'type' => 'string'
+                                ],
+                                'age' => [
+                                    'type' => 'integer'
+                                ],
+                                'DOB' => [
+                                    'type' => 'timestamp'
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+            ]
+        ], new ShapeMap([]));
+        $operation->method('getOutput')
+            -> willReturn($outputShape);
+        $operation['output'] = $outputShape;
+        $service->method('getOperation')
+            -> withAnyParameters()
+            -> willReturn($operation);
+        $jsonRPCParser = new JsonRpcParser($service);
+        $command = $this->getMockBuilder(Command::class)
+            -> disableOriginalConstructor()
+            -> setMethods(['getName'])
+            -> getMock();
+        $command->method('getName')
+            ->willReturn('TestCommand');
+        $expectedResult = [
+            'person' => [
+                'name' => 'foo',
+                'lastName' => 'fuzz',
+                'age' => 28
+            ]
+        ];
+        $body = <<<EOF
+AAAAhQAAAExjTu0wDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABnBlcnNvbg06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbnsibmFtZSI6ImZvbyIsImxhc3ROYW1lIjoiZnV6eiIsImFnZSI6Mjh9+hfixw==
+EOF;
+        $response = new Response(200, [], Utils::streamFor(base64_decode($body)));
+        $resultToArray = $jsonRPCParser($command, $response)->toArray();
+        $iterator = $resultToArray['responseStream'];
+        $this->assertInstanceOf(EventParsingIterator::class, $iterator);
+        $iterator->rewind();
+        $this->assertEquals($expectedResult, $iterator->current());
     }
 }

--- a/tests/Api/Parser/NonSeekableStreamDecodingEventStreamIteratorTest.php
+++ b/tests/Api/Parser/NonSeekableStreamDecodingEventStreamIteratorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Aws\Test\Api\Parser;
+
+use Aws\Api\Parser\NonSeekableStreamDecodingEventStreamIterator;
+use GuzzleHttp\Psr7\NoSeekStream;
+use GuzzleHttp\Psr7\Utils;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class NonSeekableStreamDecodingEventStreamIteratorTest extends TestCase
+{
+    public function testFailOnNonSeekableStream()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The stream provided must be not seekable.');
+
+        $stream = Utils::streamFor('Foo');
+        new NonSeekableStreamDecodingEventStreamIterator($stream);
+    }
+
+    public function testParseEventFromNonSeekableStream()
+    {
+        $encodedEvent = <<<EOF
+AAAAhQAAAExjTu0wDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABnBlcnNvbg06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbnsibmFtZSI6ImZvbyIsImxhc3ROYW1lIjo
+iZnV6eiIsImFnZSI6Mjh9+hfixw==
+EOF;
+        $stream = new NoSeekStream(
+            Utils::streamFor(
+                base64_decode($encodedEvent)
+            )
+        );
+        $iterator = new NonSeekableStreamDecodingEventStreamIterator($stream);
+        $iterator->rewind();
+        $expected = [
+            'headers' => [
+                ':message-type' => 'event',
+                ':event-type' => 'person',
+                ':content-type' => 'application/json'
+            ],
+            'payload' => Utils::streamFor("{\"name\":\"foo\",\"lastName\":\"fuzz\",\"age\":28}")
+        ];
+        $event = $iterator->current();
+
+        $this->assertEquals($expected['headers'], $event['headers']);
+        $this->assertEquals($expected['payload']->getContents(), $event['payload']->getContents());
+    }
+
+    /**
+     * This test will provide a single event, which means a next event can't be parsed.
+     * Therefore, valid should return false once that single event gets parsed.
+     *
+     * @return void
+     */
+    public function testValidReturnsTrueOnEOF()
+    {
+        $encodedEvent = <<<EOF
+AAAAhQAAAExjTu0wDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABnBlcnNvbg06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbnsibmFtZSI6ImZvbyIsImxhc3ROYW1lIjo
+iZnV6eiIsImFnZSI6Mjh9+hfixw==
+EOF;
+        $stream = new NoSeekStream(
+            Utils::streamFor(
+                base64_decode($encodedEvent)
+            )
+        );
+        $iterator = new NonSeekableStreamDecodingEventStreamIterator($stream);
+        $iterator->rewind();
+        $iterator->next();
+        $this->assertFalse($iterator->valid());
+    }
+}

--- a/tests/CloudWatchLogs/CloudWatchLogsClientTest.php
+++ b/tests/CloudWatchLogs/CloudWatchLogsClientTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Aws\Test\CloudWatchLogs;
+
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Aws\CommandInterface;
+use GuzzleHttp\Psr7\NoSeekStream;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\RequestInterface;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class CloudWatchLogsClientTest extends TestCase
+{
+    public function testSetStreamingFlagMiddleware()
+    {
+        $client = new CloudWatchLogsClient([
+            'region' => 'us-east-2',
+            'http_handler' => function (RequestInterface $request) {
+                return new Response(200);
+            }
+        ]);
+        $client->getHandlerList()->appendInit(function ($handler) {
+            return function (CommandInterface $command, $request=null) use ($handler) {
+                self::assertNotEmpty($command['@http']['stream']);
+                self::assertTrue($command['@http']['stream']);
+
+                return $handler($command, $request);
+            };
+        });
+        $client->startLiveTail([
+            'logGroupIdentifiers' => [
+                'arn:aws:logs:us-east-1:1234567890123:log-group:TestLogGroup'
+            ],
+            'logStreamNames' => [
+                'TestLogStream'
+            ]
+        ]);
+    }
+
+    /**
+     * This test checks whether the helper method `startLiveTailCheckingForResults` ignores
+     * any event of type sessionUpdate where its property `sessionResults` is empty.
+     * In the encoded events used here to test, there are two events of type `sessionUpdate`,
+     * where in the first one `sessionResults` is empty and in the second one `sessionResults` has
+     * one log entry, and in our validation we are not expecting the one with `sessionResults`
+     * being empty to be considered.
+     */
+    public function testStartLiveTailCheckingForResults()
+    {
+        $responseBody = <<<EOF
+AAAAaAAAAFZOaBckDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcAEGluaXRpYWwtcmVzcG9uc2UNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb25bXVB+KHcAAADfAAAAUuviBzkNOm1lc3NhZ2UtdHlwZQcABWV2ZW50CzpldmVudC10eXBlBwAMc2Vzc2lvblN0YXJ0DTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29ueyJyZXF1ZXN0SWQiOiJmb28iLCJzZXNzaW9uSWQiOiJmb28iLCJsb2dHcm91cElkZW50aWZpZXJzIjpbInRlc3RMb2dHcm91cElkZW50aWZpZXIiXSwibG9nU3RyZWFtTmFtZXMiOlsidGVzdExvZ1N0cmVhbU5hbWUiXX14FSp9AAAAmQAAAFNLVppGDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcADXNlc3Npb25VcGRhdGUNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb257InNlc3Npb25NZXRhZGF0YSI6eyJzYW1wbGVkIjoiIn0sInNlc3Npb25SZXN1bHRzIjpbXX16yBQLAAABGAAAAFMMjNDBDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcADXNlc3Npb25VcGRhdGUNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb257InNlc3Npb25NZXRhZGF0YSI6eyJzYW1wbGVkIjoiIn0sInNlc3Npb25SZXN1bHRzIjpbeyJsb2dTdHJlYW1OYW1lIjoiRm9vIiwibG9nR3JvdXBJZGVudGlmaWVyIjoiRm9vIiwibWVzc2FnZSI6IlRlc3QgbG9nIGVudHJ5IiwidGltZXN0YW1wIjoxNzE0NDc4ODU4LCJpbmdlc3Rpb25UaW1lIjoxNzE0NDc4ODU4fV19iY5vJg==
+EOF;
+        $client = new CloudWatchLogsClient([
+            'region' => 'us-east-1',
+            'http_handler' => function (RequestInterface $request) use ($responseBody) {
+                return new Response(200, [], new NoSeekStream(Utils::streamFor(base64_decode($responseBody))));
+            }
+        ]);
+        $iterator = $client->startLiveTailCheckingForResults([
+            'logGroupIdentifiers' => [
+                "arn:aws:logs:us-east-1:123456789012:log-group:testLogGroup"
+            ],
+            'logStreamNames' => [
+                'testLogStream'
+            ]
+        ]);
+        $expectedEvents = [
+            [
+                'initial-response' => []
+            ],
+            [
+                'sessionStart' => [
+                    'requestId' => 'foo',
+                    'sessionId' => 'foo',
+                    'logGroupIdentifiers' => [
+                        'testLogGroupIdentifier'
+                    ],
+                    'logStreamNames' => [
+                        'testLogStreamName'
+                    ]
+                ],
+            ],
+            [
+                'sessionUpdate' => [
+                    'sessionMetadata' => [
+                        'sampled' => ''
+                    ],
+                    'sessionResults' => [
+                        [
+                            'logStreamName' => 'Foo',
+                            'logGroupIdentifier' => 'Foo',
+                            'message' => 'Test log entry',
+                            'timestamp' => 1714478858,
+                            'ingestionTime' => 1714478858
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $eventIndex = 0;
+        foreach ($iterator as $event) {
+            $this->assertEquals($expectedEvents[$eventIndex], $event);
+            $eventIndex++;
+        }
+    }
+}


### PR DESCRIPTION
Add event streaming capabilities on the JSON RPC parser, so that operations such as StartLiveTail from CloudwatchLogs are properly handled/parsed. This change also includes an extension of the DecodingEventStreamIterator for handling streamable responses where the stream as response is not seekable, and a handling for when the `event-type` is `initial-response

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
