### PR TITLE
In a subresource the parameter value will be an empty string.

### DIFF
--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -348,6 +348,11 @@ class SignatureV4 implements SignatureInterface
         $qs = '';
         ksort($query);
         foreach ($query as $k => $v) {
+            if(is_numeric($k)){
+                $qs .= rawurlencode((string)$v) . '=&';
+                continue;
+            }
+
             if (!is_array($v)) {
                 $qs .= rawurlencode($k) . '=' . rawurlencode($v !== null ? $v : '') . '&';
             } else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The documentation explains:
when a request targets a subresource, the corresponding query parameter value will be an empty string ("").

Example:
`"http://s3.amazonaws.com/examplebucket?acl"`

The CanonicalQueryString in this case is as follows:

`UriEncode("acl") + "=" + ""`


https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
