### PR TITLE
fix: clear cached path for ECS auth token file

### DIFF
--- a/.changes/nextrelease/fix-clear-cached-path-ecs.json
+++ b/.changes/nextrelease/fix-clear-cached-path-ecs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Credentials",
+    "description": "Clears cached path for authorization token when necessary on ECS credentials provider."
+  }
+]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
