### PR TITLE
fix: EC2 empty list serialization

### DIFF
--- a/.changes/nextrelease/fix-ec2-empty-list-serialization.json
+++ b/.changes/nextrelease/fix-ec2-empty-list-serialization.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Serializer",
+    "description": "Fixes empty list serialization on empty lists"
+  }
+]

--- a/src/Api/Serializer/Ec2ParamBuilder.php
+++ b/src/Api/Serializer/Ec2ParamBuilder.php
@@ -28,9 +28,7 @@ class Ec2ParamBuilder extends QueryParamBuilder
         &$query
     ) {
         // Handle empty list serialization
-        if (!$value) {
-            $query[$prefix] = false;
-        } else {
+        if (!empty($value)) {
             $items = $shape->getMember();
             foreach ($value as $k => $v) {
                 $this->format($items, $v, $prefix . '.' . ($k + 1), $query);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Empty list parameters should not be serialized when doing EC2 requests, instead the parameters must be ignored. Otherwise, the service will return an InvalidRequest exception

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
