### PR TITLE
bugfix: update summary condition

### DIFF
--- a/build/docs/.phpdoc/template/components/summary.html.twig
+++ b/build/docs/.phpdoc/template/components/summary.html.twig
@@ -8,7 +8,7 @@
         {% endif %}
     {% endif %}
     <p class="phpdocumentor-summary">{{ new_summary ? new_summary | raw : node.summary}}</p>
-    {% if 'interact with the **' in node.summary or 'interact with **' in node.summary %}
+    {% if 'used to interact with' in node.summary %}
         <!-- api -->
     {% endif %}
 {% endif %}


### PR DESCRIPTION
*Description of changes:*
Updates condition for inserting api versions table on client documentation pages: currently missing from [Lambda](https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.Lambda.LambdaClient.html) and some other legacy services.  This is an example of how the page should look: https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.AccessAnalyzer.AccessAnalyzerClient.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
