### PR TITLE
feat: decoded encoded URLs

### DIFF
--- a/.changes/nextrelease/feat-urldecode-location.json
+++ b/.changes/nextrelease/feat-urldecode-location.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "",
+    "description": "Decodes URL returned by CompleteMultipartUpload operation so special characters are removed."
+  }
+]

--- a/src/S3/PutObjectUrlMiddleware.php
+++ b/src/S3/PutObjectUrlMiddleware.php
@@ -49,7 +49,7 @@ class PutObjectUrlMiddleware
                             : null;
                         break;
                     case 'CompleteMultipartUpload':
-                        $result['ObjectURL'] = urldecode($result['Location']);
+                        $result['ObjectURL'] = urldecode($result['Location'] ?? '');
                         break;
                 }
                 return $result;

--- a/src/S3/PutObjectUrlMiddleware.php
+++ b/src/S3/PutObjectUrlMiddleware.php
@@ -49,7 +49,7 @@ class PutObjectUrlMiddleware
                             : null;
                         break;
                     case 'CompleteMultipartUpload':
-                        $result['ObjectURL'] = $result['Location'];
+                        $result['ObjectURL'] = urldecode($result['Location']);
                         break;
                 }
                 return $result;

--- a/tests/S3/ObjectCopierTest.php
+++ b/tests/S3/ObjectCopierTest.php
@@ -400,8 +400,8 @@ class ObjectCopierTest extends TestCase
 
     public function MultipartCopierProvider(){
         return [
-            ["中文", "%E4%B8%AD%E6%96%87"],
-            ["文件夹/文件", "%E6%96%87%E4%BB%B6%E5%A4%B9/%E6%96%87%E4%BB%B6"],
+            ["中文", "文件夹/文件"],
+            ["文件夹/文件", "中文"],
             ["first-folder/second-folder/key", "first-folder/second-folder/key"],
         ];
     }

--- a/tests/S3/PutObjectUrlMiddlewareTest.php
+++ b/tests/S3/PutObjectUrlMiddlewareTest.php
@@ -46,4 +46,27 @@ class PutObjectUrlMiddlewareTest extends TestCase
             $result['ObjectURL']
         );
     }
+
+    public function testDecodesEncodedUrl()
+    {
+        $client = $this->getTestClient('s3');
+        $this->addMockResults($client, [
+            [
+                'Location' => 'https://test.s3.amazonaws.com/testdir%2Ftestfile',
+                '@metadata' => [
+                    'effectiveUri' => 'http://foo.com',
+                ]
+            ]
+        ]);
+        $result = $client->completeMultipartUpload([
+            'Bucket'   => 'test',
+            'Key'      => 'key',
+            'UploadId' => '123'
+        ]);
+
+        $this->assertSame(
+            'https://test.s3.amazonaws.com/testdir/testfile',
+            $result['ObjectURL']
+        );
+    }
 }


### PR DESCRIPTION
When using the multipart upload option, for larger files, the returned Url in the Location parameter from CompleteMultipartUploadResponse, this URL comes with special characters due to its encoding, and therefore a decoding is needed so the URL is returned in a better readable way to the end user.

*Issue #2933*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
