### PR TITLE
enhancement: stop service method generation on client classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ api: api-get-phpdocumentor
 	[ -d build/artifacts/staging ] || make package
 	# Delete a previously built API build to avoid the prompt.
 	rm -rf build/artifacts/docs
+	php build/remove-method-annotations.php
 	php build/artifacts/phpDocumentor.phar run --config build/docs/phpdoc.dist.xml
 	php build/normalize-docs-files.php
 	make api-models

--- a/build/remove-method-annotations.php
+++ b/build/remove-method-annotations.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ *   This script removes `@method` annotations on service client classes prior to doc generation.
+ *   Removing these annotations prevents phpDocumentor from generating documentation for service methods
+ *   on the client class.
+ */
+
+function removeMethodAnnotations($dir, $fileSuffix) {
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
+
+    foreach ($iterator as $file) {
+        if ($file->isDir()) {
+            continue;
+        }
+
+        if (str_ends_with($file->getPathname(), $fileSuffix)) {
+            $filePath = $file->getRealPath();
+            $content = file_get_contents($filePath);
+
+            // Regular expression to match @method annotations
+            // This pattern assumes @method annotations may span multiple lines and are within comment blocks
+            $pattern = '/\*\s+@method\s+[^\n]+\n/';
+
+            if (preg_match($pattern, $content)) {
+                // Remove @method annotations
+                $newContent = preg_replace($pattern, '', $content);
+
+                // Write the clean content back to the file
+                file_put_contents($filePath, $newContent);
+                echo "Method annotations removed from: $filePath\n";
+            }
+        }
+    }
+}
+
+$directoryPath = __DIR__ . '/artifacts/staging/Aws';
+$fileSuffix = 'Client.php';
+removeMethodAnnotations($directoryPath, $fileSuffix);


### PR DESCRIPTION
*Description of changes:*
Removes `@method` annotations on client classes prior to doc generation.  The documentation generated by these methods does not provide useful information— service methods are documented in their respective api version pages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
