### PR TITLE
bugfix: update deprecated command methods

### DIFF
--- a/.changes/nextrelease/multi-auth-update.json
+++ b/.changes/nextrelease/multi-auth-update.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Updates error level on deprecated `Command` methods.  Removes suppressed call to deprecated method."
+  }
+]

--- a/src/Command.php
+++ b/src/Command.php
@@ -78,7 +78,7 @@ class Command implements CommandInterface
         trigger_error(__METHOD__ . ' is deprecated.  Auth schemes '
             . 'resolved using the service `auth` trait or via endpoint resolution '
             . 'are now set in the command `@context` property.`'
-            , E_USER_DEPRECATED
+            , E_USER_WARNING
         );
 
         $this->authSchemes = $authSchemes;
@@ -99,7 +99,7 @@ class Command implements CommandInterface
         trigger_error(__METHOD__ . ' is deprecated.  Auth schemes '
         . 'resolved using the service `auth` trait or via endpoint resolution '
         . 'can now be found in the command `@context` property.`'
-        , E_USER_DEPRECATED
+        , E_USER_WARNING
         );
 
         return $this->authSchemes ?: [];

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -231,7 +231,6 @@ class EndpointV2Middleware
     ): void
     {
         $authScheme = $this->resolveAuthScheme($authSchemes);
-        @$command->setAuthSchemes($authScheme);
 
         $command['@context']['signature_version'] = $authScheme['version'];
 

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -86,10 +86,10 @@ class CommandTest extends TestCase
         $this->assertNull($c['boo']);
     }
 
-    public function testGetAuthSchemesEmitsDeprecationNotice()
+    public function testGetAuthSchemesEmitsWarning()
     {
-        $this->expectDeprecation(E_USER_DEPRECATED);
-        $this->expectDeprecationMessage(
+        $this->expectWarning();
+        $this->expectWarningMessage(
             'Aws\Command::getAuthSchemes is deprecated.  Auth schemes resolved using the service'
         .' `auth` trait or via endpoint resolution can now be found in the command `@context` property.'
         );
@@ -98,10 +98,10 @@ class CommandTest extends TestCase
         $c->getAuthSchemes();
     }
 
-    public function testSetAuthSchemesEmitsDeprecationNotice()
+    public function testSetAuthSchemesEmitsWarning()
     {
-        $this->expectDeprecation(E_USER_DEPRECATED);
-        $this->expectDeprecationMessage(
+        $this->expectWarning();
+        $this->expectWarningMessage(
             'Aws\Command::setAuthSchemes is deprecated.  Auth schemes resolved using the service'
             .' `auth` trait or via endpoint resolution are now set in the command `@context` property.'
         );


### PR DESCRIPTION
*Issue #, if available:*
#2937 

*Description of changes:*
Removes suppressed call to a deprecated method.  Lowers error level of deprecated call to `E_USER_WARNING`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
