### PR TITLE
Support for parsing both config and credentials files

### DIFF
--- a/src/Token/TokenProvider.php
+++ b/src/Token/TokenProvider.php
@@ -254,13 +254,13 @@ class TokenProvider
      * Token provider that creates a token from cached sso credentials
      *
      * @param string $profileName the name of the ini profile name
-     * @param string $filename the location of the ini file
+     * @param string|null $filename If provided, also load from a custom config file.
      * @param array $config configuration options
      *
      * @return SsoTokenProvider
      * @see Aws\Token\SsoTokenProvider for $config details.
      */
-    public static function sso($profileName, $filename, $config = [])
+    public static function sso($profileName, $filename = null, $config = [])
     {
         $ssoClient = isset($config['ssoClient']) ? $config['ssoClient'] : null;
 

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -288,7 +288,7 @@ EOT;
 
     public function testEnsuresIniFileIsValid()
     {
-        $this->expectExceptionMessage("Invalid credentials file:");
+        $this->expectExceptionMessage("'default' not found in config or credentials files");
         $this->expectException(\Aws\Exception\CredentialsException::class);
         $dir = $this->clearEnv();
         file_put_contents($dir . '/credentials', "wef \n=\nwef");
@@ -477,7 +477,7 @@ EOT;
 
     public function testEnsuresProcessCredentialIsPresent()
     {
-        $this->expectExceptionMessage("No credential_process present in INI profile");
+        $this->expectExceptionMessage("No credential_process present in config or credentials files with profile");
         $this->expectException(\Aws\Exception\CredentialsException::class);
         $dir = $this->clearEnv();
         $ini = <<<EOT
@@ -991,7 +991,7 @@ EOT;
 
     public function testEnsuresSourceProfileHasCredentials()
     {
-        $this->expectExceptionMessage("No credentials present in INI profile 'default'");
+        $this->expectExceptionMessage("No credentials present in config or credentials files with profile 'default'");
         $this->expectException(\Aws\Exception\CredentialsException::class);
         $dir = $this->clearEnv();
         $ini = <<<EOT
@@ -1344,7 +1344,7 @@ EOT;
 
     public function testSsoProfileProviderBadFile()
     {
-        $this->expectExceptionMessage("Cannot read credentials from");
+        $this->expectExceptionMessage("Profile default does not exist in config or credentials files.");
         $this->expectException(\Aws\Exception\CredentialsException::class);
         $dir = $this->clearEnv();
 


### PR DESCRIPTION
*Issue #, if available:* #2794

*Description of changes:*
AWS CLI as well as `boto3` implementation handle config & credentials files by reading the contents of both and consolidating them into a single associative array, prior to doing any processing. `aws-sdk-php`, on the other hand, only reads in one file when processing. This causes an issue when using assumed roles while organizing credentials the way recommended in the AWS CLI docs (the "IAM Role" tab [here](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html#:r2l:)).

The current `aws-sdk-php` implementation looks like it has set up a workaround to the situation by allowing a specific filename to be passed into several of the functions, so that the developer can choose between the config or credentials file. However this would not work in the aforementioned situation where data is split between both files.

Note that `aws-sdk-php` does actually have a segment of code which combines the files into a single associative array; however there are a few issues:
1. It's only used by `WebIdentity Credentials`; it cannot be used by regular configuration file
2. It doesn't properly merge sections which exist in both files (as is done in `boto3`)
3. It doesn't respect the `AWS_CONFIG_FILE` environment variable which can be used to override the `~/.aws/config` file path. (Note this issue seems to be present in many other locations as well)

This PR has two commits:
1. The first commit fixes the problem in the most minimal way. It replaces the single-ini-file handler `CredentialProvider::loadProfiles()` with a call to the multi-ini-file handler `CredentialProvider::loadDefaultProfiles()`. It also updates the latter to fix the two additional issues mentioned above. There was an additional modification added to handle the legacy filename workaround.
2. The second commit applies the same fix to `TokenProvider` / `SsoTokenProvider`.  Additionally it updates the `CredentialProvider::ini()`, `CredentialProvider::process()` and `CredentialProvider::sso()` functions to support a null value for the filename override.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
