### PR TITLE
Revert bad changes to Guzzle version constraints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
     - if:  ${{ matrix.composer-options == '' }}
       name: Package generation
       run: |
-        composer require guzzlehttp/psr7 "^1.9.1" -W
+        composer config platform.php 7.2.5
         composer update
         make package
 

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     },
     "require": {
         "php": ">=7.2.5",
-        "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5 <7.9.0",
-        "guzzlehttp/psr7": "^1.9.1 || ^2.4.5 <2.7.0",
+        "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
+        "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
         "guzzlehttp/promises": "^1.4.0 || ^2.0",
         "mtdowling/jmespath.php": "^2.6",
         "ext-pcre": "*",


### PR DESCRIPTION
The [earlier changes](https://github.com/aws/aws-sdk-php/commit/d550c5e7f704f155fca85e1be52898c1b1407c7f) were silently included without an explanation and have important consequences for everyone else who uses Guzzle for reasons unrelated to this SDK. This may result in people simply not upgrading to the newer version of the SDK, or worse, cause downgrades to Guzzle. Only Guzzle 7.9.x is currently supported for security fixes. None of the versions of Guzzle you currently allow are supported. It's important that people can use Guzzle 7.9.x.