### PR TITLE
chore: retry CURLE_SSL_CONNECT_ERROR failures

### DIFF
--- a/.changes/nextrelease/retry_curl35.json
+++ b/.changes/nextrelease/retry_curl35.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "",
+    "description": "Enables retries of the CURLE_SSL_CONNECT_ERROR (35) failure."
+  }
+]

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -80,6 +80,7 @@ class RetryMiddleware
     ) {
         $retryCurlErrors = [];
         if (extension_loaded('curl')) {
+            $retryCurlErrors[CURLE_SSL_CONNECT_ERROR] = true;
             $retryCurlErrors[CURLE_RECV_ERROR] = true;
         }
 


### PR DESCRIPTION
This PR enables retries of the `CURLE_SSL_CONNECT_ERROR` failure.

Our application randomly encounters these errors:
```
AWS HTTP error: cURL error 35: Send failure: Connection reset by peer (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)
```
After a retry, it works. Since this failure should be safe to retry, I think it's a good idea to make the AWS SDK automatically retry this failure using the existing logic.

This could also fix https://github.com/aws/aws-sdk-php/issues/1546.