### PR TITLE
Update ConfigurationProvider.php

### DIFF
--- a/.changes/nextrelease/csm-config-update.json
+++ b/.changes/nextrelease/csm-config-update.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "ClientSideMonitoring",
+    "description": "Updates handling of `csm_port` value if provided in ini file"
+  }
+]

--- a/src/ClientSideMonitoring/ConfigurationProvider.php
+++ b/src/ClientSideMonitoring/ConfigurationProvider.php
@@ -182,7 +182,7 @@ class ConfigurationProvider extends AbstractConfigurationProvider
             }
 
             // port is optional
-            if (empty($data[$profile]['csm_port'])) {
+            if (!filter_var($data[$profile]['csm_port'] ?? null, FILTER_VALIDATE_INT)) {
                 $data[$profile]['csm_port'] = self::DEFAULT_PORT;
             }
 


### PR DESCRIPTION
*Issue #, if available:*
{"message":"CSM 'port' value must be an integer!","line":24,"file":"\/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/ClientSideMonitoring\/Configuration.php","trace":"#0 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/ClientSideMonitoring\/ConfigurationProvider.php(187): Aws\\ClientSideMonitoring\\Configuration->__construct()\n#1 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/Promise.php(204): Aws\\ClientSideMonitoring\\ConfigurationProvider::Aws\\ClientSideMonitoring\\{closure}()\n#2 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/Promise.php(169): GuzzleHttp\\Promise\\Promise::callHandler()\n#3 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/RejectedPromise.php(42): GuzzleHttp\\Promise\\Promise::GuzzleHttp\\Promise\\{closure}()\n#4 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/TaskQueue.php(48): GuzzleHttp\\Promise\\RejectedPromise::GuzzleHttp\\Promise\\{closure}()\n#5 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/Promise.php(248): GuzzleHttp\\Promise\\TaskQueue->run()\n#6 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/Promise.php(224): GuzzleHttp\\Promise\\Promise->invokeWaitFn()\n#7 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/Promise.php(269): GuzzleHttp\\Promise\\Promise->waitIfPending()\n#8 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/Promise.php(226): GuzzleHttp\\Promise\\Promise->invokeWaitList()\n#9 \/var\/app\/current\/vendor\/guzzlehttp\/promises\/src\/Promise.php(62): GuzzleHttp\\Promise\\Promise->waitIfPending()\n#10 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/ClientSideMonitoring\/ConfigurationProvider.php(327): GuzzleHttp\\Promise\\Promise->wait()\n#11 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/ClientSideMonitoring\/AbstractMonitoringMiddleware.php(271): Aws\\ClientSideMonitoring\\ConfigurationProvider::unwrap()\n#12 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/ClientSideMonitoring\/AbstractMonitoringMiddleware.php(176): Aws\\ClientSideMonitoring\\AbstractMonitoringMiddleware->unwrappedOptions()\n#13 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/ClientSideMonitoring\/AbstractMonitoringMiddleware.php(97): Aws\\ClientSideMonitoring\\AbstractMonitoringMiddleware->isEnabled()\n#14 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/ClientResolver.php(605): Aws\\ClientSideMonitoring\\AbstractMonitoringMiddleware->__invoke()\n#15 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/Middleware.php(96): Aws\\ClientResolver::Aws\\{closure}()\n#16 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/Middleware.php(80): Aws\\Middleware::Aws\\{closure}()\n#17 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/IdempotencyTokenMiddleware.php(77): Aws\\Middleware::Aws\\{closure}()\n#18 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/AwsClientTrait.php(64): Aws\\IdempotencyTokenMiddleware->__invoke()\n#19 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/AwsClientTrait.php(58): Aws\\AwsClient->executeAsync()\n#20 \/var\/app\/current\/vendor\/aws\/aws-sdk-php\/src\/AwsClientTrait.php(77): Aws\\AwsClient->execute()\n#21 \/var\/app\/current\/consumer.php(555): Aws\\AwsClient->__call()\n#22 {main}"}

*Description of changes:*
csm port requires an integer and will throw an error if a non-integer is provided


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
