### PR TITLE
fix: error matcher on booleans

### DIFF
--- a/.changes/nextrelease/fix-waiter-matcher-boolean.json
+++ b/.changes/nextrelease/fix-waiter-matcher-boolean.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Waiter",
+    "description": "Updates waiter error matching logic for boolean valuesq"
+  }
+]

--- a/src/Waiter.php
+++ b/src/Waiter.php
@@ -256,6 +256,12 @@ class Waiter implements PromisorInterface
      */
     private function matchesError($result, array $acceptor)
     {
+        // If expected is true then the $result should be an instance of
+        // AwsException, otherwise it should not.
+        if (isset($acceptor['expected']) && is_bool($acceptor['expected'])) {
+            return $acceptor['expected'] === ($result instanceof AwsException);
+        }
+
         if ($result instanceof AwsException) {
             return $result->isConnectionError()
                 || $result->getAwsErrorCode() == $acceptor['expected'];


### PR DESCRIPTION
When the expected value from acceptor is a boolean then, the matcher should:
- if expected is true then an error should be matched.
- if expected is false then no error should has been occurred.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
