### PR TITLE
bugfix: unserialize accountid

### DIFF
--- a/.changes/nextrelease/creds-unserialize.json
+++ b/.changes/nextrelease/creds-unserialize.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Credentials",
+    "description": "Fixes issue with unserializing cached credentials without newly added `accountId` property"
+  }
+]

--- a/src/Credentials/Credentials.php
+++ b/src/Credentials/Credentials.php
@@ -110,7 +110,7 @@ class Credentials extends AwsCredentialIdentity implements
         $this->secret = $data['secret'];
         $this->token = $data['token'];
         $this->expires = $data['expires'];
-        $this->accountId = $data['accountId'];
+        $this->accountId = $data['accountId'] ?? null;
     }
 
     /**

--- a/tests/Credentials/CredentialsTest.php
+++ b/tests/Credentials/CredentialsTest.php
@@ -71,4 +71,23 @@ class CredentialsTest extends TestCase
         $credentials = new Credentials('key-value', 'secret-value');
         $this->assertInstanceOf(AwsCredentialIdentity::class, $credentials);
     }
+
+    public function testCanUnserializeWithoutAccountId()
+    {
+        $oldSerializedData = json_encode([
+            'key'     => 'test-key',
+            'secret'  => 'test-secret',
+            'token'   => 'test-token',
+            'expires' => time() + 3600
+        ]);
+
+        $credentials = new Credentials('foo', 'bar');
+        $credentials->unserialize($oldSerializedData);
+
+        $this->assertEquals('test-key', $credentials->getAccessKeyId());
+        $this->assertEquals('test-secret', $credentials->getSecretKey());
+        $this->assertEquals('test-token', $credentials->getSecurityToken());
+        $this->assertNotNull($credentials->getExpiration());
+        $this->assertNull($credentials->getAccountId());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-php/pull/2884#discussion_r1743974113

*Description of changes:*
Fixes issue where previously cached credentials may fail to unserialize due to missing `accountId` property.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
