### PR TITLE
bugfix: LocationConstraint middleware

### DIFF
--- a/.changes/nextrelease/s3-locationconstraint.json
+++ b/.changes/nextrelease/s3-locationconstraint.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Updates location constraint middleware to exclude directory buckets and retain original configuration."
+  }
+]


### PR DESCRIPTION
**Description of changes:**

Updates middleware to skip directory buckets (`LocationRestraint` is not supported) and fixes a long-running bug where the middleware would override previously configured `CreateBucketConfiguration`. See https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#AmazonS3-CreateBucket-request-LocationConstraint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
