### PR TITLE
PHP 8.4 support (Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead)

### DIFF
--- a/build/Burgomaster.php
+++ b/build/Burgomaster.php
@@ -164,7 +164,7 @@ class Burgomaster
         $sourceDir,
         $destDir,
         $extensions = array('php', 'php.gz'),
-        Iterator|null $files = null
+        ?Iterator $files = null
     ) {
         if (!realpath($sourceDir)) {
             throw new \InvalidArgumentException("$sourceDir not found");

--- a/build/Burgomaster.php
+++ b/build/Burgomaster.php
@@ -150,21 +150,21 @@ class Burgomaster
      *
      * Any LICENSE file is automatically copied.
      *
-     * @param string    $sourceDir  Source directory to copy from
-     * @param string    $destDir    Directory to copy the files to that is relative
-     *                              to the the stage base directory.
-     * @param array     $extensions File extensions to copy from the $sourceDir.
-     *                              Defaults to "php" files only (e.g., ['php']).
-     * @param Iterator|null  $files Files to copy from the source directory, each
-     *                              yielded out as an SplFileInfo object.
-     *                              Defaults to a recursive iterator of $sourceDir
+     * @param string        $sourceDir  Source directory to copy from
+     * @param string        $destDir    Directory to copy the files to that is relative
+     *                                  to the the stage base directory.
+     * @param array         $extensions File extensions to copy from the $sourceDir.
+     *                                  Defaults to "php" files only (e.g., ['php']).
+     * @param Iterator|null $files      Files to copy from the source directory, each
+     *                                  yielded out as an SplFileInfo object.
+     *                                  Defaults to a recursive iterator of $sourceDir
      * @throws \InvalidArgumentException if the source directory is invalid.
      */
     function recursiveCopy(
         $sourceDir,
         $destDir,
         $extensions = array('php', 'php.gz'),
-        Iterator $files = null
+        Iterator|null $files = null
     ) {
         if (!realpath($sourceDir)) {
             throw new \InvalidArgumentException("$sourceDir not found");

--- a/features/bootstrap/Aws/Test/Integ/SmokeContext.php
+++ b/features/bootstrap/Aws/Test/Integ/SmokeContext.php
@@ -393,7 +393,7 @@ class SmokeContext extends Assert implements
      * @param string $errorCode
      * @param PyStringNode|null $string
      */
-    public function theErrorCodeShouldBe($errorCode, PyStringNode|null $string = null)
+    public function theErrorCodeShouldBe($errorCode, ?PyStringNode $string = null)
     {
         $this->iExpectTheResponseErrorCodeToBe($errorCode);
 

--- a/features/bootstrap/Aws/Test/Integ/SmokeContext.php
+++ b/features/bootstrap/Aws/Test/Integ/SmokeContext.php
@@ -391,9 +391,9 @@ class SmokeContext extends Assert implements
      * @Then the error code should be :errorCode
      *
      * @param string $errorCode
-     * @param PyStringNode $string
+     * @param PyStringNode|null $string
      */
-    public function theErrorCodeShouldBe($errorCode, PyStringNode $string = null)
+    public function theErrorCodeShouldBe($errorCode, PyStringNode|null $string = null)
     {
         $this->iExpectTheResponseErrorCodeToBe($errorCode);
 

--- a/features/bootstrap/Aws/Test/UsesServiceTrait.php
+++ b/features/bootstrap/Aws/Test/UsesServiceTrait.php
@@ -59,16 +59,16 @@ trait UsesServiceTrait
      *
      * @param AwsClientInterface $client
      * @param Result[]|array[]   $results
-     * @param callable $onFulfilled Callback to invoke when the return value is fulfilled.
-     * @param callable $onRejected  Callback to invoke when the return value is rejected.
+     * @param callable|null      $onFulfilled Callback to invoke when the return value is fulfilled.
+     * @param callable|null      $onRejected  Callback to invoke when the return value is rejected.
      *
      * @return AwsClientInterface
      */
     private function addMockResults(
         AwsClientInterface $client,
         array $results,
-        callable $onFulfilled = null,
-        callable $onRejected = null
+        callable|null $onFulfilled = null,
+        callable|null $onRejected = null
     ) {
         foreach ($results as &$res) {
             if (is_array($res)) {

--- a/features/bootstrap/Aws/Test/UsesServiceTrait.php
+++ b/features/bootstrap/Aws/Test/UsesServiceTrait.php
@@ -67,8 +67,8 @@ trait UsesServiceTrait
     private function addMockResults(
         AwsClientInterface $client,
         array $results,
-        callable|null $onFulfilled = null,
-        callable|null $onRejected = null
+        ?callable $onFulfilled = null,
+        ?callable $onRejected = null
     ) {
         foreach ($results as &$res) {
             if (is_array($res)) {

--- a/src/Api/ApiProvider.php
+++ b/src/Api/ApiProvider.php
@@ -202,10 +202,10 @@ class ApiProvider
     }
 
     /**
-     * @param string $modelsDir Directory containing service models.
-     * @param array  $manifest  The API version manifest data.
+     * @param string     $modelsDir Directory containing service models.
+     * @param array|null $manifest  The API version manifest data.
      */
-    private function __construct($modelsDir, array $manifest = null)
+    private function __construct($modelsDir, array|null $manifest = null)
     {
         $this->manifest = $manifest;
         $this->modelsDir = rtrim($modelsDir, '/');

--- a/src/Api/ApiProvider.php
+++ b/src/Api/ApiProvider.php
@@ -205,7 +205,7 @@ class ApiProvider
      * @param string     $modelsDir Directory containing service models.
      * @param array|null $manifest  The API version manifest data.
      */
-    private function __construct($modelsDir, array|null $manifest = null)
+    private function __construct($modelsDir, ?array $manifest = null)
     {
         $this->manifest = $manifest;
         $this->modelsDir = rtrim($modelsDir, '/');

--- a/src/Api/ErrorParser/AbstractErrorParser.php
+++ b/src/Api/ErrorParser/AbstractErrorParser.php
@@ -21,7 +21,7 @@ abstract class AbstractErrorParser
     /**
      * @param Service $api
      */
-    public function __construct(Service $api = null)
+    public function __construct(Service|null $api = null)
     {
         $this->api = $api;
     }
@@ -47,7 +47,7 @@ abstract class AbstractErrorParser
     protected function populateShape(
         array &$data,
         ResponseInterface $response,
-        CommandInterface $command = null
+        CommandInterface|null $command = null
     ) {
         $data['body'] = [];
 

--- a/src/Api/ErrorParser/AbstractErrorParser.php
+++ b/src/Api/ErrorParser/AbstractErrorParser.php
@@ -21,7 +21,7 @@ abstract class AbstractErrorParser
     /**
      * @param Service $api
      */
-    public function __construct(Service|null $api = null)
+    public function __construct(?Service $api = null)
     {
         $this->api = $api;
     }
@@ -47,7 +47,7 @@ abstract class AbstractErrorParser
     protected function populateShape(
         array &$data,
         ResponseInterface $response,
-        CommandInterface|null $command = null
+        ?CommandInterface $command = null
     ) {
         $data['body'] = [];
 

--- a/src/Api/ErrorParser/JsonRpcErrorParser.php
+++ b/src/Api/ErrorParser/JsonRpcErrorParser.php
@@ -15,7 +15,7 @@ class JsonRpcErrorParser extends AbstractErrorParser
 
     private $parser;
 
-    public function __construct(Service $api = null, JsonParser $parser = null)
+    public function __construct(Service|null $api = null, JsonParser|null $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();
@@ -23,7 +23,7 @@ class JsonRpcErrorParser extends AbstractErrorParser
 
     public function __invoke(
         ResponseInterface $response,
-        CommandInterface $command = null
+        CommandInterface|null $command = null
     ) {
         $data = $this->genericHandler($response);
 

--- a/src/Api/ErrorParser/JsonRpcErrorParser.php
+++ b/src/Api/ErrorParser/JsonRpcErrorParser.php
@@ -15,7 +15,7 @@ class JsonRpcErrorParser extends AbstractErrorParser
 
     private $parser;
 
-    public function __construct(Service|null $api = null, JsonParser|null $parser = null)
+    public function __construct(?Service $api = null, ?JsonParser $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();
@@ -23,7 +23,7 @@ class JsonRpcErrorParser extends AbstractErrorParser
 
     public function __invoke(
         ResponseInterface $response,
-        CommandInterface|null $command = null
+        ?CommandInterface $command = null
     ) {
         $data = $this->genericHandler($response);
 

--- a/src/Api/ErrorParser/RestJsonErrorParser.php
+++ b/src/Api/ErrorParser/RestJsonErrorParser.php
@@ -16,7 +16,7 @@ class RestJsonErrorParser extends AbstractErrorParser
 
     private $parser;
 
-    public function __construct(Service|null $api = null, JsonParser|null $parser = null)
+    public function __construct(?Service $api = null, ?JsonParser $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();
@@ -24,7 +24,7 @@ class RestJsonErrorParser extends AbstractErrorParser
 
     public function __invoke(
         ResponseInterface $response,
-        CommandInterface|null $command = null
+        ?CommandInterface $command = null
     ) {
         $data = $this->genericHandler($response);
 

--- a/src/Api/ErrorParser/RestJsonErrorParser.php
+++ b/src/Api/ErrorParser/RestJsonErrorParser.php
@@ -16,7 +16,7 @@ class RestJsonErrorParser extends AbstractErrorParser
 
     private $parser;
 
-    public function __construct(Service $api = null, JsonParser $parser = null)
+    public function __construct(Service|null $api = null, JsonParser|null $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();
@@ -24,7 +24,7 @@ class RestJsonErrorParser extends AbstractErrorParser
 
     public function __invoke(
         ResponseInterface $response,
-        CommandInterface $command = null
+        CommandInterface|null $command = null
     ) {
         $data = $this->genericHandler($response);
 

--- a/src/Api/ErrorParser/XmlErrorParser.php
+++ b/src/Api/ErrorParser/XmlErrorParser.php
@@ -17,7 +17,7 @@ class XmlErrorParser extends AbstractErrorParser
 
     protected $parser;
 
-    public function __construct(Service|null $api = null, XmlParser|null $parser = null)
+    public function __construct(?Service $api = null, ?XmlParser $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new XmlParser();
@@ -25,7 +25,7 @@ class XmlErrorParser extends AbstractErrorParser
 
     public function __invoke(
         ResponseInterface $response,
-        CommandInterface|null $command = null
+        ?CommandInterface $command = null
     ) {
         $code = (string) $response->getStatusCode();
 

--- a/src/Api/ErrorParser/XmlErrorParser.php
+++ b/src/Api/ErrorParser/XmlErrorParser.php
@@ -17,7 +17,7 @@ class XmlErrorParser extends AbstractErrorParser
 
     protected $parser;
 
-    public function __construct(Service $api = null, XmlParser $parser = null)
+    public function __construct(Service|null $api = null, XmlParser|null $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new XmlParser();
@@ -25,7 +25,7 @@ class XmlErrorParser extends AbstractErrorParser
 
     public function __invoke(
         ResponseInterface $response,
-        CommandInterface $command = null
+        CommandInterface|null $command = null
     ) {
         $code = (string) $response->getStatusCode();
 

--- a/src/Api/Parser/JsonRpcParser.php
+++ b/src/Api/Parser/JsonRpcParser.php
@@ -17,10 +17,10 @@ class JsonRpcParser extends AbstractParser
     use PayloadParserTrait;
 
     /**
-     * @param Service    $api    Service description
-     * @param JsonParser $parser JSON body builder
+     * @param Service         $api    Service description
+     * @param JsonParser|null $parser JSON body builder
      */
-    public function __construct(Service $api, JsonParser $parser = null)
+    public function __construct(Service $api, JsonParser|null $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();

--- a/src/Api/Parser/JsonRpcParser.php
+++ b/src/Api/Parser/JsonRpcParser.php
@@ -20,7 +20,7 @@ class JsonRpcParser extends AbstractParser
      * @param Service         $api    Service description
      * @param JsonParser|null $parser JSON body builder
      */
-    public function __construct(Service $api, JsonParser|null $parser = null)
+    public function __construct(Service $api, ?JsonParser $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();

--- a/src/Api/Parser/QueryParser.php
+++ b/src/Api/Parser/QueryParser.php
@@ -19,15 +19,15 @@ class QueryParser extends AbstractParser
     private $honorResultWrapper;
 
     /**
-     * @param Service   $api                Service description
-     * @param XmlParser $xmlParser          Optional XML parser
-     * @param bool      $honorResultWrapper Set to false to disable the peeling
+     * @param Service        $api                Service description
+     * @param XmlParser|null $xmlParser          Optional XML parser
+     * @param bool           $honorResultWrapper Set to false to disable the peeling
      *                                      back of result wrappers from the
      *                                      output structure.
      */
     public function __construct(
         Service $api,
-        XmlParser $xmlParser = null,
+        XmlParser|null $xmlParser = null,
         $honorResultWrapper = true
     ) {
         parent::__construct($api);

--- a/src/Api/Parser/QueryParser.php
+++ b/src/Api/Parser/QueryParser.php
@@ -27,7 +27,7 @@ class QueryParser extends AbstractParser
      */
     public function __construct(
         Service $api,
-        XmlParser|null $xmlParser = null,
+        ?XmlParser $xmlParser = null,
         $honorResultWrapper = true
     ) {
         parent::__construct($api);

--- a/src/Api/Parser/RestJsonParser.php
+++ b/src/Api/Parser/RestJsonParser.php
@@ -14,10 +14,10 @@ class RestJsonParser extends AbstractRestParser
     use PayloadParserTrait;
 
     /**
-     * @param Service    $api    Service description
-     * @param JsonParser $parser JSON body builder
+     * @param Service         $api    Service description
+     * @param JsonParser|null $parser JSON body builder
      */
-    public function __construct(Service $api, JsonParser $parser = null)
+    public function __construct(Service $api, JsonParser|null $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();

--- a/src/Api/Parser/RestJsonParser.php
+++ b/src/Api/Parser/RestJsonParser.php
@@ -17,7 +17,7 @@ class RestJsonParser extends AbstractRestParser
      * @param Service         $api    Service description
      * @param JsonParser|null $parser JSON body builder
      */
-    public function __construct(Service $api, JsonParser|null $parser = null)
+    public function __construct(Service $api, ?JsonParser $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new JsonParser();

--- a/src/Api/Parser/RestXmlParser.php
+++ b/src/Api/Parser/RestXmlParser.php
@@ -14,10 +14,10 @@ class RestXmlParser extends AbstractRestParser
     use PayloadParserTrait;
 
     /**
-     * @param Service   $api    Service description
-     * @param XmlParser $parser XML body parser
+     * @param Service        $api    Service description
+     * @param XmlParser|null $parser XML body parser
      */
-    public function __construct(Service $api, XmlParser $parser = null)
+    public function __construct(Service $api, XmlParser|null $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new XmlParser();

--- a/src/Api/Parser/RestXmlParser.php
+++ b/src/Api/Parser/RestXmlParser.php
@@ -17,7 +17,7 @@ class RestXmlParser extends AbstractRestParser
      * @param Service        $api    Service description
      * @param XmlParser|null $parser XML body parser
      */
-    public function __construct(Service $api, XmlParser|null $parser = null)
+    public function __construct(Service $api, ?XmlParser $parser = null)
     {
         parent::__construct($api);
         $this->parser = $parser ?: new XmlParser();

--- a/src/Api/Serializer/JsonRpcSerializer.php
+++ b/src/Api/Serializer/JsonRpcSerializer.php
@@ -29,14 +29,14 @@ class JsonRpcSerializer
     private $contentType;
 
     /**
-     * @param Service  $api           Service description
-     * @param string   $endpoint      Endpoint to connect to
-     * @param JsonBody $jsonFormatter Optional JSON formatter to use
+     * @param Service       $api           Service description
+     * @param string        $endpoint      Endpoint to connect to
+     * @param JsonBody|null $jsonFormatter Optional JSON formatter to use
      */
     public function __construct(
         Service $api,
         $endpoint,
-        JsonBody $jsonFormatter = null
+        JsonBody|null $jsonFormatter = null
     ) {
         $this->endpoint = $endpoint;
         $this->api = $api;

--- a/src/Api/Serializer/JsonRpcSerializer.php
+++ b/src/Api/Serializer/JsonRpcSerializer.php
@@ -36,7 +36,7 @@ class JsonRpcSerializer
     public function __construct(
         Service $api,
         $endpoint,
-        JsonBody|null $jsonFormatter = null
+        ?JsonBody $jsonFormatter = null
     ) {
         $this->endpoint = $endpoint;
         $this->api = $api;

--- a/src/Api/Serializer/QuerySerializer.php
+++ b/src/Api/Serializer/QuerySerializer.php
@@ -24,7 +24,7 @@ class QuerySerializer
     public function __construct(
         Service $api,
         $endpoint,
-        callable|null $paramBuilder = null
+        ?callable $paramBuilder = null
     ) {
         $this->api = $api;
         $this->endpoint = $endpoint;

--- a/src/Api/Serializer/QuerySerializer.php
+++ b/src/Api/Serializer/QuerySerializer.php
@@ -24,7 +24,7 @@ class QuerySerializer
     public function __construct(
         Service $api,
         $endpoint,
-        callable $paramBuilder = null
+        callable|null $paramBuilder = null
     ) {
         $this->api = $api;
         $this->endpoint = $endpoint;

--- a/src/Api/Serializer/RestJsonSerializer.php
+++ b/src/Api/Serializer/RestJsonSerializer.php
@@ -17,14 +17,14 @@ class RestJsonSerializer extends RestSerializer
     private $contentType;
 
     /**
-     * @param Service  $api           Service API description
-     * @param string   $endpoint      Endpoint to connect to
-     * @param JsonBody $jsonFormatter Optional JSON formatter to use
+     * @param Service       $api           Service API description
+     * @param string        $endpoint      Endpoint to connect to
+     * @param JsonBody|null $jsonFormatter Optional JSON formatter to use
      */
     public function __construct(
         Service $api,
         $endpoint,
-        JsonBody $jsonFormatter = null
+        JsonBody|null $jsonFormatter = null
     ) {
         parent::__construct($api, $endpoint);
         $this->contentType = JsonBody::getContentType($api);

--- a/src/Api/Serializer/RestJsonSerializer.php
+++ b/src/Api/Serializer/RestJsonSerializer.php
@@ -24,7 +24,7 @@ class RestJsonSerializer extends RestSerializer
     public function __construct(
         Service $api,
         $endpoint,
-        JsonBody|null $jsonFormatter = null
+        ?JsonBody $jsonFormatter = null
     ) {
         parent::__construct($api, $endpoint);
         $this->contentType = JsonBody::getContentType($api);

--- a/src/Api/Serializer/RestXmlSerializer.php
+++ b/src/Api/Serializer/RestXmlSerializer.php
@@ -13,14 +13,14 @@ class RestXmlSerializer extends RestSerializer
     private $xmlBody;
 
     /**
-     * @param Service $api      Service API description
-     * @param string  $endpoint Endpoint to connect to
-     * @param XmlBody $xmlBody  Optional XML formatter to use
+     * @param Service      $api      Service API description
+     * @param string       $endpoint Endpoint to connect to
+     * @param XmlBody|null $xmlBody  Optional XML formatter to use
      */
     public function __construct(
         Service $api,
         $endpoint,
-        XmlBody $xmlBody = null
+        XmlBody|null $xmlBody = null
     ) {
         parent::__construct($api, $endpoint);
         $this->xmlBody = $xmlBody ?: new XmlBody($api);

--- a/src/Api/Serializer/RestXmlSerializer.php
+++ b/src/Api/Serializer/RestXmlSerializer.php
@@ -20,7 +20,7 @@ class RestXmlSerializer extends RestSerializer
     public function __construct(
         Service $api,
         $endpoint,
-        XmlBody|null $xmlBody = null
+        ?XmlBody $xmlBody = null
     ) {
         parent::__construct($api, $endpoint);
         $this->xmlBody = $xmlBody ?: new XmlBody($api);

--- a/src/Api/Service.php
+++ b/src/Api/Service.php
@@ -114,7 +114,7 @@ class Service extends AbstractModel
      * @return callable
      * @throws \UnexpectedValueException
      */
-    public static function createErrorParser($protocol, Service $api = null)
+    public static function createErrorParser($protocol, Service|null $api = null)
     {
         static $mapping = [
             'json'      => ErrorParser\JsonRpcErrorParser::class,

--- a/src/Api/Service.php
+++ b/src/Api/Service.php
@@ -114,7 +114,7 @@ class Service extends AbstractModel
      * @return callable
      * @throws \UnexpectedValueException
      */
-    public static function createErrorParser($protocol, Service|null $api = null)
+    public static function createErrorParser($protocol, ?Service $api = null)
     {
         static $mapping = [
             'json'      => ErrorParser\JsonRpcErrorParser::class,

--- a/src/Api/Validator.php
+++ b/src/Api/Validator.php
@@ -25,7 +25,7 @@ class Validator
      *                                "max", and "pattern". If a key is not
      *                                provided, the constraint will assume false.
      */
-    public function __construct(array|null $constraints = null)
+    public function __construct(?array $constraints = null)
     {
         static $assumedFalseValues = [
             'required' => false,

--- a/src/Api/Validator.php
+++ b/src/Api/Validator.php
@@ -20,12 +20,12 @@ class Validator
     ];
 
     /**
-     * @param array $constraints Associative array of constraints to enforce.
-     *                           Accepts the following keys: "required", "min",
-     *                           "max", and "pattern". If a key is not
-     *                           provided, the constraint will assume false.
+     * @param array|null $constraints Associative array of constraints to enforce.
+     *                                Accepts the following keys: "required", "min",
+     *                                "max", and "pattern". If a key is not
+     *                                provided, the constraint will assume false.
      */
-    public function __construct(array $constraints = null)
+    public function __construct(array|null $constraints = null)
     {
         static $assumedFalseValues = [
             'required' => false,

--- a/src/Auth/AuthSchemeResolver.php
+++ b/src/Auth/AuthSchemeResolver.php
@@ -37,7 +37,7 @@ class AuthSchemeResolver implements AuthSchemeResolverInterface
 
     public function __construct(
         callable $credentialProvider,
-        callable|null $tokenProvider = null,
+        ?callable $tokenProvider = null,
         array $authSchemeMap = []
     ){
         $this->credentialProvider = $credentialProvider;

--- a/src/Auth/AuthSchemeResolver.php
+++ b/src/Auth/AuthSchemeResolver.php
@@ -37,7 +37,7 @@ class AuthSchemeResolver implements AuthSchemeResolverInterface
 
     public function __construct(
         callable $credentialProvider,
-        callable $tokenProvider = null,
+        callable|null $tokenProvider = null,
         array $authSchemeMap = []
     ){
         $this->credentialProvider = $credentialProvider;

--- a/src/CloudSearchDomain/CloudSearchDomainClient.php
+++ b/src/CloudSearchDomain/CloudSearchDomainClient.php
@@ -51,7 +51,7 @@ class CloudSearchDomainClient extends AwsClient
         return static function (callable $handler) {
             return function (
                 CommandInterface $c,
-                RequestInterface|null $r = null
+                ?RequestInterface $r = null
             ) use ($handler) {
                 if ($c->getName() !== 'Search') {
                     return $handler($c, $r);

--- a/src/CloudSearchDomain/CloudSearchDomainClient.php
+++ b/src/CloudSearchDomain/CloudSearchDomainClient.php
@@ -51,7 +51,7 @@ class CloudSearchDomainClient extends AwsClient
         return static function (callable $handler) {
             return function (
                 CommandInterface $c,
-                RequestInterface $r = null
+                RequestInterface|null $r = null
             ) use ($handler) {
                 if ($c->getName() !== 'Search') {
                     return $handler($c, $r);

--- a/src/Command.php
+++ b/src/Command.php
@@ -22,11 +22,11 @@ class Command implements CommandInterface
      *
      * - @http: (array) Associative array of transfer options.
      *
-     * @param string      $name           Name of the command
-     * @param array       $args           Arguments to pass to the command
-     * @param HandlerList $list           Handler list
+     * @param string           $name           Name of the command
+     * @param array            $args           Arguments to pass to the command
+     * @param HandlerList|null $list           Handler list
      */
-    public function __construct($name, array $args = [], HandlerList $list = null)
+    public function __construct($name, array $args = [], HandlerList|null $list = null)
     {
         $this->name = $name;
         $this->data = $args;

--- a/src/Command.php
+++ b/src/Command.php
@@ -26,7 +26,7 @@ class Command implements CommandInterface
      * @param array            $args           Arguments to pass to the command
      * @param HandlerList|null $list           Handler list
      */
-    public function __construct($name, array $args = [], HandlerList|null $list = null)
+    public function __construct($name, array $args = [], ?HandlerList $list = null)
     {
         $this->name = $name;
         $this->data = $args;

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -77,7 +77,7 @@ class EndpointV2Middleware
         EndpointProviderV2 $endpointProvider,
         Service $api,
         array $args,
-        callable|null $credentialProvider = null
+        ?callable $credentialProvider = null
     )
     {
         $this->nextHandler = $nextHandler;

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -77,7 +77,7 @@ class EndpointV2Middleware
         EndpointProviderV2 $endpointProvider,
         Service $api,
         array $args,
-        callable $credentialProvider = null
+        callable|null $credentialProvider = null
     )
     {
         $this->nextHandler = $nextHandler;

--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -42,13 +42,13 @@ class AwsException extends \RuntimeException implements
      * @param string           $message Exception message
      * @param CommandInterface $command
      * @param array            $context Exception context
-     * @param \Exception       $previous  Previous exception (if any)
+     * @param \Exception|null  $previous  Previous exception (if any)
      */
     public function __construct(
         $message,
         CommandInterface $command,
         array $context = [],
-        \Exception $previous = null
+        \Exception|null $previous = null
     ) {
         $this->data = isset($context['body']) ? $context['body'] : [];
         $this->command = $command;

--- a/src/Exception/AwsException.php
+++ b/src/Exception/AwsException.php
@@ -48,7 +48,7 @@ class AwsException extends \RuntimeException implements
         $message,
         CommandInterface $command,
         array $context = [],
-        \Exception|null $previous = null
+        ?\Exception $previous = null
     ) {
         $this->data = isset($context['body']) ? $context['body'] : [];
         $this->command = $command;

--- a/src/Exception/CouldNotCreateChecksumException.php
+++ b/src/Exception/CouldNotCreateChecksumException.php
@@ -9,7 +9,7 @@ class CouldNotCreateChecksumException extends \RuntimeException implements
 {
     use HasMonitoringEventsTrait;
 
-    public function __construct($algorithm, \Exception|null $previous = null)
+    public function __construct($algorithm, ?\Exception $previous = null)
     {
         $prefix = $algorithm === 'md5' ? "An" : "A";
         parent::__construct("{$prefix} {$algorithm} checksum could not be "

--- a/src/Exception/CouldNotCreateChecksumException.php
+++ b/src/Exception/CouldNotCreateChecksumException.php
@@ -9,7 +9,7 @@ class CouldNotCreateChecksumException extends \RuntimeException implements
 {
     use HasMonitoringEventsTrait;
 
-    public function __construct($algorithm, \Exception $previous = null)
+    public function __construct($algorithm, \Exception|null $previous = null)
     {
         $prefix = $algorithm === 'md5' ? "An" : "A";
         parent::__construct("{$prefix} {$algorithm} checksum could not be "

--- a/src/Glacier/GlacierClient.php
+++ b/src/Glacier/GlacierClient.php
@@ -124,7 +124,7 @@ class GlacierClient extends AwsClient
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler) {
                 // Accept "ContentSHA256" with a lowercase "c" to match other Glacier params.
                 if (!$command['ContentSHA256'] && $command['contentSHA256']) {
@@ -195,7 +195,7 @@ class GlacierClient extends AwsClient
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler) {
                 return $handler($command, $request->withHeader(
                     'x-amz-glacier-version',

--- a/src/Glacier/GlacierClient.php
+++ b/src/Glacier/GlacierClient.php
@@ -124,7 +124,7 @@ class GlacierClient extends AwsClient
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler) {
                 // Accept "ContentSHA256" with a lowercase "c" to match other Glacier params.
                 if (!$command['ContentSHA256'] && $command['contentSHA256']) {
@@ -195,7 +195,7 @@ class GlacierClient extends AwsClient
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler) {
                 return $handler($command, $request->withHeader(
                     'x-amz-glacier-version',

--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -44,7 +44,7 @@ class GuzzleHandler
     /**
      * @param ClientInterface $client
      */
-    public function __construct(ClientInterface|null $client = null)
+    public function __construct(?ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Handler/GuzzleV5/GuzzleHandler.php
+++ b/src/Handler/GuzzleV5/GuzzleHandler.php
@@ -44,7 +44,7 @@ class GuzzleHandler
     /**
      * @param ClientInterface $client
      */
-    public function __construct(ClientInterface $client = null)
+    public function __construct(ClientInterface|null $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Handler/GuzzleV6/GuzzleHandler.php
+++ b/src/Handler/GuzzleV6/GuzzleHandler.php
@@ -21,7 +21,7 @@ class GuzzleHandler
     /**
      * @param ClientInterface $client
      */
-    public function __construct(ClientInterface $client = null)
+    public function __construct(ClientInterface|null $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/Handler/GuzzleV6/GuzzleHandler.php
+++ b/src/Handler/GuzzleV6/GuzzleHandler.php
@@ -21,7 +21,7 @@ class GuzzleHandler
     /**
      * @param ClientInterface $client
      */
-    public function __construct(ClientInterface|null $client = null)
+    public function __construct(?ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
     }

--- a/src/HandlerList.php
+++ b/src/HandlerList.php
@@ -59,9 +59,9 @@ class HandlerList implements \Countable
     ];
 
     /**
-     * @param callable $handler HTTP handler.
+     * @param callable|null $handler HTTP handler.
      */
-    public function __construct(callable $handler = null)
+    public function __construct(callable|null $handler = null)
     {
         $this->handler = $handler;
     }
@@ -277,7 +277,7 @@ class HandlerList implements \Countable
      *
      * @param callable|null $fn Pass null to remove any previously set function
      */
-    public function interpose(callable $fn = null)
+    public function interpose(callable|null $fn = null)
     {
         $this->sorted = null;
         $this->interposeFn = $fn;

--- a/src/HandlerList.php
+++ b/src/HandlerList.php
@@ -61,7 +61,7 @@ class HandlerList implements \Countable
     /**
      * @param callable|null $handler HTTP handler.
      */
-    public function __construct(callable|null $handler = null)
+    public function __construct(?callable $handler = null)
     {
         $this->handler = $handler;
     }
@@ -277,7 +277,7 @@ class HandlerList implements \Countable
      *
      * @param callable|null $fn Pass null to remove any previously set function
      */
-    public function interpose(callable|null $fn = null)
+    public function interpose(?callable $fn = null)
     {
         $this->sorted = null;
         $this->interposeFn = $fn;

--- a/src/HashingStream.php
+++ b/src/HashingStream.php
@@ -23,13 +23,13 @@ class HashingStream implements StreamInterface
     /**
      * @param StreamInterface $stream     Stream that is being read.
      * @param HashInterface   $hash       Hash used to calculate checksum.
-     * @param callable        $onComplete Optional function invoked when the
+     * @param callable|null   $onComplete Optional function invoked when the
      *                                    hash calculation is completed.
      */
     public function __construct(
         StreamInterface $stream,
         HashInterface $hash,
-        callable $onComplete = null
+        callable|null $onComplete = null
     ) {
         $this->stream = $stream;
         $this->hash = $hash;

--- a/src/HashingStream.php
+++ b/src/HashingStream.php
@@ -29,7 +29,7 @@ class HashingStream implements StreamInterface
     public function __construct(
         StreamInterface $stream,
         HashInterface $hash,
-        callable|null $onComplete = null
+        ?callable $onComplete = null
     ) {
         $this->stream = $stream;
         $this->hash = $hash;

--- a/src/IdempotencyTokenMiddleware.php
+++ b/src/IdempotencyTokenMiddleware.php
@@ -37,7 +37,7 @@ class IdempotencyTokenMiddleware
      */
     public static function wrap(
         Service $service,
-        callable|null $bytesGenerator = null
+        ?callable $bytesGenerator = null
     ) {
         return function (callable $handler) use ($service, $bytesGenerator) {
             return new self($handler, $service, $bytesGenerator);
@@ -47,7 +47,7 @@ class IdempotencyTokenMiddleware
     public function __construct(
         callable $nextHandler,
         Service $service,
-        callable|null $bytesGenerator = null
+        ?callable $bytesGenerator = null
     ) {
         $this->bytesGenerator = $bytesGenerator
             ?: $this->findCompatibleRandomSource();
@@ -57,7 +57,7 @@ class IdempotencyTokenMiddleware
 
     public function __invoke(
         CommandInterface $command,
-        RequestInterface|null $request = null
+        ?RequestInterface $request = null
     ) {
         $handler = $this->nextHandler;
         if ($this->bytesGenerator) {

--- a/src/IdempotencyTokenMiddleware.php
+++ b/src/IdempotencyTokenMiddleware.php
@@ -37,7 +37,7 @@ class IdempotencyTokenMiddleware
      */
     public static function wrap(
         Service $service,
-        callable $bytesGenerator = null
+        callable|null $bytesGenerator = null
     ) {
         return function (callable $handler) use ($service, $bytesGenerator) {
             return new self($handler, $service, $bytesGenerator);
@@ -47,7 +47,7 @@ class IdempotencyTokenMiddleware
     public function __construct(
         callable $nextHandler,
         Service $service,
-        callable $bytesGenerator = null
+        callable|null $bytesGenerator = null
     ) {
         $this->bytesGenerator = $bytesGenerator
             ?: $this->findCompatibleRandomSource();
@@ -57,7 +57,7 @@ class IdempotencyTokenMiddleware
 
     public function __invoke(
         CommandInterface $command,
-        RequestInterface $request = null
+        RequestInterface|null $request = null
     ) {
         $handler = $this->nextHandler;
         if ($this->bytesGenerator) {

--- a/src/MachineLearning/MachineLearningClient.php
+++ b/src/MachineLearning/MachineLearningClient.php
@@ -85,7 +85,7 @@ class MachineLearningClient extends AwsClient
         return static function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler) {
                 if ($command->getName() === 'Predict') {
                     $request = $request->withUri(new Uri($command['PredictEndpoint']));

--- a/src/MachineLearning/MachineLearningClient.php
+++ b/src/MachineLearning/MachineLearningClient.php
@@ -85,7 +85,7 @@ class MachineLearningClient extends AwsClient
         return static function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler) {
                 if ($command->getName() === 'Predict') {
                     $request = $request->withUri(new Uri($command['PredictEndpoint']));

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -38,7 +38,7 @@ final class Middleware
         ) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null)
+                RequestInterface|null $request = null)
             use (
                 $handler,
                 $api,
@@ -67,13 +67,13 @@ final class Middleware
      *
      * @return callable
      */
-    public static function validation(Service $api, Validator $validator = null)
+    public static function validation(Service $api, Validator|null $validator = null)
     {
         $validator = $validator ?: new Validator();
         return function (callable $handler) use ($api, $validator) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($api, $validator, $handler) {
                 if ($api->isModifiedModel()) {
                     $api = new Service(
@@ -178,7 +178,7 @@ final class Middleware
         return function (callable $handler) use ($fn) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, $fn) {
                 $fn($command, $request);
                 return $handler($command, $request);
@@ -193,19 +193,19 @@ final class Middleware
      * If no delay function is provided, a simple implementation of exponential
      * backoff will be utilized.
      *
-     * @param callable $decider Function that accepts the number of retries,
-     *                          a request, [result], and [exception] and
-     *                          returns true if the command is to be retried.
-     * @param callable $delay   Function that accepts the number of retries and
-     *                          returns the number of milliseconds to delay.
-     * @param bool $stats       Whether to collect statistics on retries and the
-     *                          associated delay.
+     * @param callable|null $decider Function that accepts the number of retries,
+     *                               a request, [result], and [exception] and
+     *                               returns true if the command is to be retried.
+     * @param callable|null $delay   Function that accepts the number of retries and
+     *                               returns the number of milliseconds to delay.
+     * @param bool $stats            Whether to collect statistics on retries and the
+     *                               associated delay.
      *
      * @return callable
      */
     public static function retry(
-        callable $decider = null,
-        callable $delay = null,
+        callable|null $decider = null,
+        callable|null $delay = null,
         $stats = false
     ) {
         $decider = $decider ?: RetryMiddleware::createDefaultDecider();
@@ -253,7 +253,7 @@ final class Middleware
         return function (callable $handler) use ($operations) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, $operations) {
                 if (!$request->hasHeader('Content-Type')
                     && in_array($command->getName(), $operations, true)
@@ -322,7 +322,7 @@ final class Middleware
         return function (callable $handler) use ($history) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, $history) {
                 $ticket = $history->start($command, $request);
                 return $handler($command, $request)
@@ -354,7 +354,7 @@ final class Middleware
         return function (callable $handler) use ($f) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, $f) {
                 return $handler($command, $f($request));
             };
@@ -375,7 +375,7 @@ final class Middleware
         return function (callable $handler) use ($f) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, $f) {
                 return $handler($f($command), $request);
             };
@@ -395,7 +395,7 @@ final class Middleware
         return function (callable $handler) use ($f) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, $f) {
                 return $handler($command, $request)->then($f);
             };
@@ -407,7 +407,7 @@ final class Middleware
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler) {
                 $start = microtime(true);
                 return $handler($command, $request)

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -38,7 +38,8 @@ final class Middleware
         ) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null)
+                ?RequestInterface $request = null
+            )
             use (
                 $handler,
                 $api,
@@ -67,13 +68,13 @@ final class Middleware
      *
      * @return callable
      */
-    public static function validation(Service $api, Validator|null $validator = null)
+    public static function validation(Service $api, ?Validator $validator = null)
     {
         $validator = $validator ?: new Validator();
         return function (callable $handler) use ($api, $validator) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($api, $validator, $handler) {
                 if ($api->isModifiedModel()) {
                     $api = new Service(
@@ -178,7 +179,7 @@ final class Middleware
         return function (callable $handler) use ($fn) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, $fn) {
                 $fn($command, $request);
                 return $handler($command, $request);
@@ -204,8 +205,8 @@ final class Middleware
      * @return callable
      */
     public static function retry(
-        callable|null $decider = null,
-        callable|null $delay = null,
+        ?callable $decider = null,
+        ?callable $delay = null,
         $stats = false
     ) {
         $decider = $decider ?: RetryMiddleware::createDefaultDecider();
@@ -253,7 +254,7 @@ final class Middleware
         return function (callable $handler) use ($operations) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, $operations) {
                 if (!$request->hasHeader('Content-Type')
                     && in_array($command->getName(), $operations, true)
@@ -322,7 +323,7 @@ final class Middleware
         return function (callable $handler) use ($history) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, $history) {
                 $ticket = $history->start($command, $request);
                 return $handler($command, $request)
@@ -354,7 +355,7 @@ final class Middleware
         return function (callable $handler) use ($f) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, $f) {
                 return $handler($command, $f($request));
             };
@@ -375,7 +376,7 @@ final class Middleware
         return function (callable $handler) use ($f) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, $f) {
                 return $handler($f($command), $request);
             };
@@ -395,7 +396,7 @@ final class Middleware
         return function (callable $handler) use ($f) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, $f) {
                 return $handler($command, $request)->then($f);
             };
@@ -407,7 +408,7 @@ final class Middleware
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler) {
                 $start = microtime(true);
                 return $handler($command, $request)

--- a/src/MockHandler.php
+++ b/src/MockHandler.php
@@ -30,8 +30,8 @@ class MockHandler implements \Countable
      */
     public function __construct(
         array $resultOrQueue = [],
-        callable|null $onFulfilled = null,
-        callable|null $onRejected = null
+        ?callable $onFulfilled = null,
+        ?callable $onRejected = null
     ) {
         $this->queue = [];
         $this->onFulfilled = $onFulfilled;

--- a/src/MockHandler.php
+++ b/src/MockHandler.php
@@ -24,14 +24,14 @@ class MockHandler implements \Countable
      * {@see AwsException} objects that acts as a queue of results or
      * exceptions to return each time the handler is invoked.
      *
-     * @param array    $resultOrQueue
-     * @param callable $onFulfilled Callback to invoke when the return value is fulfilled.
-     * @param callable $onRejected  Callback to invoke when the return value is rejected.
+     * @param array         $resultOrQueue
+     * @param callable|null $onFulfilled Callback to invoke when the return value is fulfilled.
+     * @param callable|null $onRejected  Callback to invoke when the return value is rejected.
      */
     public function __construct(
         array $resultOrQueue = [],
-        callable $onFulfilled = null,
-        callable $onRejected = null
+        callable|null $onFulfilled = null,
+        callable|null $onRejected = null
     ) {
         $this->queue = [];
         $this->onFulfilled = $onFulfilled;

--- a/src/Multipart/AbstractUploadManager.php
+++ b/src/Multipart/AbstractUploadManager.php
@@ -287,7 +287,7 @@ abstract class AbstractUploadManager implements Promise\PromisorInterface
         return function (callable $handler) use (&$errors) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, &$errors) {
                 return $handler($command, $request)->then(
                     function (ResultInterface $result) use ($command) {

--- a/src/Multipart/AbstractUploadManager.php
+++ b/src/Multipart/AbstractUploadManager.php
@@ -287,7 +287,7 @@ abstract class AbstractUploadManager implements Promise\PromisorInterface
         return function (callable $handler) use (&$errors) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, &$errors) {
                 return $handler($command, $request)->then(
                     function (ResultInterface $result) use ($command) {

--- a/src/PresignUrlMiddleware.php
+++ b/src/PresignUrlMiddleware.php
@@ -56,7 +56,7 @@ class PresignUrlMiddleware
         };
     }
 
-    public function __invoke(CommandInterface $cmd, RequestInterface $request = null)
+    public function __invoke(CommandInterface $cmd, RequestInterface|null $request = null)
     {
         if (in_array($cmd->getName(), $this->commandPool)
             && (!isset($cmd['__skip' . $cmd->getName()]))

--- a/src/PresignUrlMiddleware.php
+++ b/src/PresignUrlMiddleware.php
@@ -56,7 +56,7 @@ class PresignUrlMiddleware
         };
     }
 
-    public function __invoke(CommandInterface $cmd, RequestInterface|null $request = null)
+    public function __invoke(CommandInterface $cmd, ?RequestInterface $request = null)
     {
         if (in_array($cmd->getName(), $this->commandPool)
             && (!isset($cmd['__skip' . $cmd->getName()]))

--- a/src/ResultPaginator.php
+++ b/src/ResultPaginator.php
@@ -162,7 +162,7 @@ class ResultPaginator implements \Iterator
         $this->result = null;
     }
 
-    private function createNextCommand(array $args, array $nextToken = null)
+    private function createNextCommand(array $args, array|null $nextToken = null)
     {
         return $this->client->getCommand($this->operation, array_merge($args, ($nextToken ?: [])));
     }

--- a/src/ResultPaginator.php
+++ b/src/ResultPaginator.php
@@ -162,7 +162,7 @@ class ResultPaginator implements \Iterator
         $this->result = null;
     }
 
-    private function createNextCommand(array $args, array|null $nextToken = null)
+    private function createNextCommand(array $args, ?array $nextToken = null)
     {
         return $this->client->getCommand($this->operation, array_merge($args, ($nextToken ?: [])));
     }

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -87,7 +87,7 @@ class RetryMiddleware
             $retries,
             CommandInterface $command,
             RequestInterface $request,
-            ResultInterface $result = null,
+            ResultInterface|null $result = null,
             $error = null
         ) use ($maxRetries, $retryCurlErrors, $extraConfig) {
             // Allow command-level options to override this value
@@ -210,13 +210,13 @@ class RetryMiddleware
 
     /**
      * @param CommandInterface $command
-     * @param RequestInterface $request
+     * @param RequestInterface|null $request
      *
      * @return PromiseInterface
      */
     public function __invoke(
         CommandInterface $command,
-        RequestInterface $request = null
+        RequestInterface|null $request = null
     ) {
         $retries = 0;
         $requestStats = [];

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -87,7 +87,7 @@ class RetryMiddleware
             $retries,
             CommandInterface $command,
             RequestInterface $request,
-            ResultInterface|null $result = null,
+            ?ResultInterface $result = null,
             $error = null
         ) use ($maxRetries, $retryCurlErrors, $extraConfig) {
             // Allow command-level options to override this value
@@ -216,7 +216,7 @@ class RetryMiddleware
      */
     public function __invoke(
         CommandInterface $command,
-        RequestInterface|null $request = null
+        ?RequestInterface $request = null
     ) {
         $retries = 0;
         $requestStats = [];

--- a/src/Route53/Route53Client.php
+++ b/src/Route53/Route53Client.php
@@ -160,7 +160,7 @@ class Route53Client extends AwsClient
     private function cleanIdFn()
     {
         return function (callable $handler) {
-            return function (CommandInterface $c, RequestInterface|null $r = null) use ($handler) {
+            return function (CommandInterface $c, ?RequestInterface $r = null) use ($handler) {
                 foreach (['Id', 'HostedZoneId', 'DelegationSetId'] as $clean) {
                     if ($c->hasParam($clean)) {
                         $c[$clean] = $this->cleanId($c[$clean]);

--- a/src/Route53/Route53Client.php
+++ b/src/Route53/Route53Client.php
@@ -160,7 +160,7 @@ class Route53Client extends AwsClient
     private function cleanIdFn()
     {
         return function (callable $handler) {
-            return function (CommandInterface $c, RequestInterface $r = null) use ($handler) {
+            return function (CommandInterface $c, RequestInterface|null $r = null) use ($handler) {
                 foreach (['Id', 'HostedZoneId', 'DelegationSetId'] as $clean) {
                     if ($c->hasParam($clean)) {
                         $c[$clean] = $this->cleanId($c[$clean]);

--- a/src/S3/ExpiresParsingMiddleware.php
+++ b/src/S3/ExpiresParsingMiddleware.php
@@ -36,7 +36,7 @@ class ExpiresParsingMiddleware
         $this->nextHandler = $nextHandler;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface|null $request = null)
+    public function __invoke(CommandInterface $command, ?RequestInterface $request = null)
     {
         $next = $this->nextHandler;
         return $next($command, $request)->then(

--- a/src/S3/ExpiresParsingMiddleware.php
+++ b/src/S3/ExpiresParsingMiddleware.php
@@ -36,7 +36,7 @@ class ExpiresParsingMiddleware
         $this->nextHandler = $nextHandler;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface $request = null)
+    public function __invoke(CommandInterface $command, RequestInterface|null $request = null)
     {
         $next = $this->nextHandler;
         return $next($command, $request)->then(

--- a/src/S3/Parser/ValidateResponseChecksumResultMutator.php
+++ b/src/S3/Parser/ValidateResponseChecksumResultMutator.php
@@ -37,8 +37,8 @@ final class ValidateResponseChecksumResultMutator implements S3ResultMutator
      */
     public function __invoke(
         ResultInterface $result,
-        CommandInterface $command = null,
-        ResponseInterface $response = null
+        CommandInterface|null $command = null,
+        ResponseInterface|null $response = null
     ): ResultInterface
     {
         $operation = $this->api->getOperation($command->getName());

--- a/src/S3/Parser/ValidateResponseChecksumResultMutator.php
+++ b/src/S3/Parser/ValidateResponseChecksumResultMutator.php
@@ -37,8 +37,8 @@ final class ValidateResponseChecksumResultMutator implements S3ResultMutator
      */
     public function __invoke(
         ResultInterface $result,
-        CommandInterface|null $command = null,
-        ResponseInterface|null $response = null
+        ?CommandInterface $command = null,
+        ?ResponseInterface $response = null
     ): ResultInterface
     {
         $operation = $this->api->getOperation($command->getName());

--- a/src/S3/PermanentRedirectMiddleware.php
+++ b/src/S3/PermanentRedirectMiddleware.php
@@ -37,7 +37,7 @@ class PermanentRedirectMiddleware
         $this->nextHandler = $nextHandler;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface $request = null)
+    public function __invoke(CommandInterface $command, RequestInterface|null $request = null)
     {
         $next = $this->nextHandler;
         return $next($command, $request)->then(

--- a/src/S3/PermanentRedirectMiddleware.php
+++ b/src/S3/PermanentRedirectMiddleware.php
@@ -37,7 +37,7 @@ class PermanentRedirectMiddleware
         $this->nextHandler = $nextHandler;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface|null $request = null)
+    public function __invoke(CommandInterface $command, ?RequestInterface $request = null)
     {
         $next = $this->nextHandler;
         return $next($command, $request)->then(

--- a/src/S3/PutObjectUrlMiddleware.php
+++ b/src/S3/PutObjectUrlMiddleware.php
@@ -35,7 +35,7 @@ class PutObjectUrlMiddleware
         $this->nextHandler = $nextHandler;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface $request = null)
+    public function __invoke(CommandInterface $command, RequestInterface|null $request = null)
     {
         $next = $this->nextHandler;
         return $next($command, $request)->then(

--- a/src/S3/PutObjectUrlMiddleware.php
+++ b/src/S3/PutObjectUrlMiddleware.php
@@ -35,7 +35,7 @@ class PutObjectUrlMiddleware
         $this->nextHandler = $nextHandler;
     }
 
-    public function __invoke(CommandInterface $command, RequestInterface|null $request = null)
+    public function __invoke(CommandInterface $command, ?RequestInterface $request = null)
     {
         $next = $this->nextHandler;
         return $next($command, $request)->then(

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -628,7 +628,7 @@ class S3Client extends AwsClient implements S3ClientInterface
         return static function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler) {
                 if ($command->getName() === 'HeadObject'
                     && !isset($command['@http']['decode_content'])
@@ -729,7 +729,7 @@ class S3Client extends AwsClient implements S3ClientInterface
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler) {
                 if (!empty($command['@context']['signature_version'])
                     && $command['@context']['signature_version'] === 'v4-s3express'

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -628,7 +628,7 @@ class S3Client extends AwsClient implements S3ClientInterface
         return static function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler) {
                 if ($command->getName() === 'HeadObject'
                     && !isset($command['@http']['decode_content'])
@@ -729,7 +729,7 @@ class S3Client extends AwsClient implements S3ClientInterface
         return function (callable $handler) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler) {
                 if (!empty($command['@context']['signature_version'])
                     && $command['@context']['signature_version'] === 'v4-s3express'

--- a/src/S3/SSECMiddleware.php
+++ b/src/S3/SSECMiddleware.php
@@ -35,7 +35,7 @@ class SSECMiddleware
 
     public function __invoke(
         CommandInterface $command,
-        RequestInterface $request = null
+        RequestInterface|null $request = null
     ) {
         // Allows only HTTPS connections when using SSE-C
         if (($command['SSECustomerKey'] || $command['CopySourceSSECustomerKey'])

--- a/src/S3/SSECMiddleware.php
+++ b/src/S3/SSECMiddleware.php
@@ -35,7 +35,7 @@ class SSECMiddleware
 
     public function __invoke(
         CommandInterface $command,
-        RequestInterface|null $request = null
+        ?RequestInterface $request = null
     ) {
         // Allows only HTTPS connections when using SSE-C
         if (($command['SSECustomerKey'] || $command['CopySourceSSECustomerKey'])

--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -103,14 +103,14 @@ class StreamWrapper
     /**
      * Register the 's3://' stream wrapper
      *
-     * @param S3ClientInterface $client   Client to use with the stream wrapper
-     * @param string            $protocol Protocol to register as.
-     * @param CacheInterface    $cache    Default cache for the protocol.
+     * @param S3ClientInterface   $client   Client to use with the stream wrapper
+     * @param string              $protocol Protocol to register as.
+     * @param CacheInterface|null $cache    Default cache for the protocol.
      */
     public static function register(
         S3ClientInterface $client,
         $protocol = 's3',
-        CacheInterface $cache = null,
+        CacheInterface|null $cache = null,
         $v2Existence = false
     ) {
         self::$useV2Existence = $v2Existence;

--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -110,7 +110,7 @@ class StreamWrapper
     public static function register(
         S3ClientInterface $client,
         $protocol = 's3',
-        CacheInterface|null $cache = null,
+        ?CacheInterface $cache = null,
         $v2Existence = false
     ) {
         self::$useV2Existence = $v2Existence;

--- a/src/Script/Composer/Composer.php
+++ b/src/Script/Composer/Composer.php
@@ -8,17 +8,17 @@ use Symfony\Component\Filesystem\Filesystem;
 class Composer
 {
 
-    public static function removeUnusedServicesInDev(Event $event, Filesystem $filesystem = null)
+    public static function removeUnusedServicesInDev(Event $event, Filesystem|null $filesystem = null)
     {
         self::removeUnusedServicesWithConfig($event, $filesystem, true);
     }
 
-    public static function removeUnusedServices(Event $event, Filesystem $filesystem = null)
+    public static function removeUnusedServices(Event $event, Filesystem|null $filesystem = null)
     {
         self::removeUnusedServicesWithConfig($event, $filesystem, false);
     }
 
-    private static function removeUnusedServicesWithConfig(Event $event, Filesystem $filesystem = null, $isDev = false)
+    private static function removeUnusedServicesWithConfig(Event $event, Filesystem|null $filesystem = null, $isDev = false)
     {
         if ($isDev && !$event->isDevMode()){
             return;

--- a/src/Script/Composer/Composer.php
+++ b/src/Script/Composer/Composer.php
@@ -8,17 +8,17 @@ use Symfony\Component\Filesystem\Filesystem;
 class Composer
 {
 
-    public static function removeUnusedServicesInDev(Event $event, Filesystem|null $filesystem = null)
+    public static function removeUnusedServicesInDev(Event $event, ?Filesystem $filesystem = null)
     {
         self::removeUnusedServicesWithConfig($event, $filesystem, true);
     }
 
-    public static function removeUnusedServices(Event $event, Filesystem|null $filesystem = null)
+    public static function removeUnusedServices(Event $event, ?Filesystem $filesystem = null)
     {
         self::removeUnusedServicesWithConfig($event, $filesystem, false);
     }
 
-    private static function removeUnusedServicesWithConfig(Event $event, Filesystem|null $filesystem = null, $isDev = false)
+    private static function removeUnusedServicesWithConfig(Event $event, ?Filesystem $filesystem = null, $isDev = false)
     {
         if ($isDev && !$event->isDevMode()){
             return;

--- a/src/Signature/S3SignatureV4.php
+++ b/src/Signature/S3SignatureV4.php
@@ -58,7 +58,7 @@ class S3SignatureV4 extends SignatureV4
         CredentialsInterface $credentials,
         RequestInterface $request,
         $signingService,
-        SigningConfigAWS $signingConfig = null
+        SigningConfigAWS|null $signingConfig = null
     ){
         $this->verifyCRTLoaded();
         $credentials_provider = $this->createCRTStaticCredentialsProvider($credentials);

--- a/src/Signature/S3SignatureV4.php
+++ b/src/Signature/S3SignatureV4.php
@@ -58,7 +58,7 @@ class S3SignatureV4 extends SignatureV4
         CredentialsInterface $credentials,
         RequestInterface $request,
         $signingService,
-        SigningConfigAWS|null $signingConfig = null
+        ?SigningConfigAWS $signingConfig = null
     ){
         $this->verifyCRTLoaded();
         $credentials_provider = $this->createCRTStaticCredentialsProvider($credentials);

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -508,7 +508,7 @@ class SignatureV4 implements SignatureInterface
         CredentialsInterface $credentials,
         RequestInterface $request,
         $signingService,
-        SigningConfigAWS $signingConfig = null
+        SigningConfigAWS|null $signingConfig = null
     ){
         $this->verifyCRTLoaded();
         $signingConfig = $signingConfig ?? new SigningConfigAWS([

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -508,7 +508,7 @@ class SignatureV4 implements SignatureInterface
         CredentialsInterface $credentials,
         RequestInterface $request,
         $signingService,
-        SigningConfigAWS|null $signingConfig = null
+        ?SigningConfigAWS $signingConfig = null
     ){
         $this->verifyCRTLoaded();
         $signingConfig = $signingConfig ?? new SigningConfigAWS([

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -169,7 +169,7 @@ class SqsClient extends AwsClient
         return static function (callable $handler) {
             return function (
                 CommandInterface $c,
-                RequestInterface $r = null
+                RequestInterface|null $r = null
             ) use ($handler) {
                 if ($c->getName() !== 'ReceiveMessage') {
                     return $handler($c, $r);

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -169,7 +169,7 @@ class SqsClient extends AwsClient
         return static function (callable $handler) {
             return function (
                 CommandInterface $c,
-                RequestInterface|null $r = null
+                ?RequestInterface $r = null
             ) use ($handler) {
                 if ($c->getName() !== 'ReceiveMessage') {
                     return $handler($c, $r);

--- a/src/Token/SsoTokenProvider.php
+++ b/src/Token/SsoTokenProvider.php
@@ -37,7 +37,7 @@ class SsoTokenProvider implements RefreshableTokenProviderInterface
     public function __construct(
         $profileName,
         $configFilePath = null,
-        SSOOIDCClient $ssoOidcClient = null
+        SSOOIDCClient|null $ssoOidcClient = null
     ) {
         $this->profileName = $this->resolveProfileName($profileName);
         $this->configFilePath =  $this->resolveConfigFile($configFilePath);

--- a/src/Token/SsoTokenProvider.php
+++ b/src/Token/SsoTokenProvider.php
@@ -37,7 +37,7 @@ class SsoTokenProvider implements RefreshableTokenProviderInterface
     public function __construct(
         $profileName,
         $configFilePath = null,
-        SSOOIDCClient|null $ssoOidcClient = null
+        ?SSOOIDCClient $ssoOidcClient = null
     ) {
         $this->profileName = $this->resolveProfileName($profileName);
         $this->configFilePath =  $this->resolveConfigFile($configFilePath);

--- a/src/TraceMiddleware.php
+++ b/src/TraceMiddleware.php
@@ -61,7 +61,7 @@ class TraceMiddleware
      *   headers contained in this array will be replaced with the if
      *   "scrub_auth" is set to true.
      */
-    public function __construct(array $config = [], Service|null $service = null)
+    public function __construct(array $config = [], ?Service $service = null)
     {
         $this->config = $config + [
             'logfn'        => function ($value) { echo $value; },
@@ -179,7 +179,7 @@ class TraceMiddleware
         ]);
     }
 
-    private function responseArray(ResponseInterface|null $response = null)
+    private function responseArray(?ResponseInterface $response = null)
     {
         return !$response ? [] : [
             'instance'   => spl_object_hash($response),

--- a/src/TraceMiddleware.php
+++ b/src/TraceMiddleware.php
@@ -61,7 +61,7 @@ class TraceMiddleware
      *   headers contained in this array will be replaced with the if
      *   "scrub_auth" is set to true.
      */
-    public function __construct(array $config = [], Service $service = null)
+    public function __construct(array $config = [], Service|null $service = null)
     {
         $this->config = $config + [
             'logfn'        => function ($value) { echo $value; },
@@ -179,7 +179,7 @@ class TraceMiddleware
         ]);
     }
 
-    private function responseArray(ResponseInterface $response = null)
+    private function responseArray(ResponseInterface|null $response = null)
     {
         return !$response ? [] : [
             'instance'   => spl_object_hash($response),

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -215,7 +215,7 @@ class EcsCredentialProviderTest extends TestCase
         ];
     }
 
-    private function getTestCreds($result, Response|null $more = null)
+    private function getTestCreds($result, ?Response $more = null)
     {
         $responses = [];
         $responses[] = new Response(200, [], Psr7\Utils::streamFor(json_encode($result)));
@@ -237,7 +237,7 @@ class EcsCredentialProviderTest extends TestCase
         return $provider();
     }
 
-    private function resolveCredentials($result, Response|null $more = null)
+    private function resolveCredentials($result, ?Response $more = null)
     {
         $responses = [];
         $responses[] = new Response(200, [], Psr7\Utils::streamFor(json_encode($result)));

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -215,7 +215,7 @@ class EcsCredentialProviderTest extends TestCase
         ];
     }
 
-    private function getTestCreds($result, Response $more = null)
+    private function getTestCreds($result, Response|null $more = null)
     {
         $responses = [];
         $responses[] = new Response(200, [], Psr7\Utils::streamFor(json_encode($result)));
@@ -237,7 +237,7 @@ class EcsCredentialProviderTest extends TestCase
         return $provider();
     }
 
-    private function resolveCredentials($result, Response $more = null)
+    private function resolveCredentials($result, Response|null $more = null)
     {
         $responses = [];
         $responses[] = new Response(200, [], Psr7\Utils::streamFor(json_encode($result)));

--- a/tests/Glacier/MultipartUploaderTest.php
+++ b/tests/Glacier/MultipartUploaderTest.php
@@ -28,7 +28,7 @@ class MultipartUploaderTest extends TestCase
      */
     public function testGlacierMultipartUploadWorkflow(
         array $uploadOptions = [],
-        StreamInterface|null $source = null,
+        ?StreamInterface $source = null,
         $error = false
     ) {
         $client = $this->getTestClient('glacier');

--- a/tests/Glacier/MultipartUploaderTest.php
+++ b/tests/Glacier/MultipartUploaderTest.php
@@ -28,7 +28,7 @@ class MultipartUploaderTest extends TestCase
      */
     public function testGlacierMultipartUploadWorkflow(
         array $uploadOptions = [],
-        StreamInterface $source = null,
+        StreamInterface|null $source = null,
         $error = false
     ) {
         $client = $this->getTestClient('glacier');

--- a/tests/Integ/SmokeContext.php
+++ b/tests/Integ/SmokeContext.php
@@ -393,7 +393,7 @@ class SmokeContext extends Assert implements
      * @param string $errorCode
      * @param PyStringNode|null $string
      */
-    public function theErrorCodeShouldBe($errorCode, PyStringNode|null $string = null)
+    public function theErrorCodeShouldBe($errorCode, ?PyStringNode $string = null)
     {
         $this->iExpectTheResponseErrorCodeToBe($errorCode);
 

--- a/tests/Integ/SmokeContext.php
+++ b/tests/Integ/SmokeContext.php
@@ -391,9 +391,9 @@ class SmokeContext extends Assert implements
      * @Then the error code should be :errorCode
      *
      * @param string $errorCode
-     * @param PyStringNode $string
+     * @param PyStringNode|null $string
      */
-    public function theErrorCodeShouldBe($errorCode, PyStringNode $string = null)
+    public function theErrorCodeShouldBe($errorCode, PyStringNode|null $string = null)
     {
         $this->iExpectTheResponseErrorCodeToBe($errorCode);
 

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -254,7 +254,7 @@ class S3EncryptionClientTest extends TestCase
     public function testPutObjectValidatesCipher(
         $cipher,
         $exception = null,
-        callable $skipCheck = null
+        callable|null $skipCheck = null
     ) {
         if ($skipCheck && $skipCheck()) {
             $this->markTestSkipped(

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -254,7 +254,7 @@ class S3EncryptionClientTest extends TestCase
     public function testPutObjectValidatesCipher(
         $cipher,
         $exception = null,
-        callable|null $skipCheck = null
+        ?callable $skipCheck = null
     ) {
         if ($skipCheck && $skipCheck()) {
             $this->markTestSkipped(

--- a/tests/S3/Crypto/S3EncryptionMultipartUploaderTest.php
+++ b/tests/S3/Crypto/S3EncryptionMultipartUploaderTest.php
@@ -251,7 +251,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
     public function testPutObjectValidatesCipher(
         $cipher,
         $exception = null,
-        callable|null $skipCheck = null
+        ?callable $skipCheck = null
     ) {
         if ($skipCheck && $skipCheck()) {
             $this->markTestSkipped(

--- a/tests/S3/Crypto/S3EncryptionMultipartUploaderTest.php
+++ b/tests/S3/Crypto/S3EncryptionMultipartUploaderTest.php
@@ -251,7 +251,7 @@ class S3EncryptionMultipartUploaderTest extends TestCase
     public function testPutObjectValidatesCipher(
         $cipher,
         $exception = null,
-        callable $skipCheck = null
+        callable|null $skipCheck = null
     ) {
         if ($skipCheck && $skipCheck()) {
             $this->markTestSkipped(

--- a/tests/S3/MultipartUploaderTest.php
+++ b/tests/S3/MultipartUploaderTest.php
@@ -32,7 +32,7 @@ class MultipartUploaderTest extends TestCase
     public function testS3MultipartUploadWorkflow(
         array $clientOptions = [],
         array $uploadOptions = [],
-        StreamInterface|null $source = null,
+        ?StreamInterface $source = null,
         $error = false
     ) {
         $client = $this->getTestClient('s3', $clientOptions);

--- a/tests/S3/MultipartUploaderTest.php
+++ b/tests/S3/MultipartUploaderTest.php
@@ -32,7 +32,7 @@ class MultipartUploaderTest extends TestCase
     public function testS3MultipartUploadWorkflow(
         array $clientOptions = [],
         array $uploadOptions = [],
-        StreamInterface $source = null,
+        StreamInterface|null $source = null,
         $error = false
     ) {
         $client = $this->getTestClient('s3', $clientOptions);

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -407,7 +407,7 @@ class TransferTest extends TestCase
         return function (callable $handler) use ($fn) {
             return function (
                 CommandInterface $command,
-                RequestInterface $request = null
+                RequestInterface|null $request = null
             ) use ($handler, $fn) {
                 return Promise\Create::promiseFor($fn($command, $request));
             };

--- a/tests/S3/TransferTest.php
+++ b/tests/S3/TransferTest.php
@@ -407,7 +407,7 @@ class TransferTest extends TestCase
         return function (callable $handler) use ($fn) {
             return function (
                 CommandInterface $command,
-                RequestInterface|null $request = null
+                ?RequestInterface $request = null
             ) use ($handler, $fn) {
                 return Promise\Create::promiseFor($fn($command, $request));
             };

--- a/tests/UsesServiceTrait.php
+++ b/tests/UsesServiceTrait.php
@@ -59,16 +59,16 @@ trait UsesServiceTrait
      *
      * @param AwsClientInterface $client
      * @param Result[]|array[]   $results
-     * @param callable $onFulfilled Callback to invoke when the return value is fulfilled.
-     * @param callable $onRejected  Callback to invoke when the return value is rejected.
+     * @param callable|null      $onFulfilled Callback to invoke when the return value is fulfilled.
+     * @param callable|null      $onRejected  Callback to invoke when the return value is rejected.
      *
      * @return AwsClientInterface
      */
     private function addMockResults(
         AwsClientInterface $client,
         array $results,
-        callable $onFulfilled = null,
-        callable $onRejected = null
+        callable|null $onFulfilled = null,
+        callable|null $onRejected = null
     ) {
         foreach ($results as &$res) {
             if (is_array($res)) {

--- a/tests/UsesServiceTrait.php
+++ b/tests/UsesServiceTrait.php
@@ -67,8 +67,8 @@ trait UsesServiceTrait
     private function addMockResults(
         AwsClientInterface $client,
         array $results,
-        callable|null $onFulfilled = null,
-        callable|null $onRejected = null
+        ?callable $onFulfilled = null,
+        ?callable $onRejected = null
     ) {
         foreach ($results as &$res) {
             if (is_array($res)) {

--- a/tests/bootstrap/PHPUnit_Framework_MockObject_Generator_7.4.php
+++ b/tests/bootstrap/PHPUnit_Framework_MockObject_Generator_7.4.php
@@ -544,7 +544,7 @@ class PHPUnit_Framework_MockObject_Generator
      *
      * @return array
      */
-    public function generate($type, array|null $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false)
+    public function generate($type, ?array $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false)
     {
         if (is_array($type)) {
             sort($type);

--- a/tests/bootstrap/PHPUnit_Framework_MockObject_Generator_7.4.php
+++ b/tests/bootstrap/PHPUnit_Framework_MockObject_Generator_7.4.php
@@ -535,7 +535,7 @@ class PHPUnit_Framework_MockObject_Generator
 
     /**
      * @param array|string $type
-     * @param array        $methods
+     * @param array|null   $methods
      * @param string       $mockClassName
      * @param bool         $callOriginalClone
      * @param bool         $callAutoload
@@ -544,7 +544,7 @@ class PHPUnit_Framework_MockObject_Generator
      *
      * @return array
      */
-    public function generate($type, array $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false)
+    public function generate($type, array|null $methods = null, $mockClassName = '', $callOriginalClone = true, $callAutoload = true, $cloneArguments = true, $callOriginalMethods = false)
     {
         if (is_array($type)) {
             sort($type);


### PR DESCRIPTION
This PR adds support for PHP8.4, which has changed how we need to define nullable function parameters - they must be marked explicitly now (i.e. `Service|null $service = null` instead of just `Service $service = null`)

I've tried to minimise the code changes and stick with the code style (i.e. `Service|null` instead of `?Service`) of the original files but please let me know if there is anything you would like to to fix/revisit/explain more.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
