### PR TITLE
enhancement: remove smoke test for autoscaling

### DIFF
--- a/features/smoke/autoscaling.feature
+++ b/features/smoke/autoscaling.feature
@@ -5,10 +5,3 @@ Feature: Auto Scaling
   Scenario: Making a request
     When I call the "DescribeScalingProcessTypes" API
     Then the value at "Processes" should be a list
-
-  Scenario: Handing errors
-    When I attempt to call the "CreateLaunchConfiguration" API with:
-    | LaunchConfigurationName | hello, world |
-    | ImageId                 | ami-12345678 |
-    | InstanceType            | m1.small     |
-    Then I expect the response error code to be "ValidationError"


### PR DESCRIPTION
Remove smoke test for CreateLaunchConfiguration operation since it is not supported. Please see: https://docs.aws.amazon.com/autoscaling/ec2/userguide/migrate-to-launch-templates.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
