### PR TITLE
adding return annotations to supress warnings

### DIFF
--- a/src/Api/Parser/DecodingEventStreamIterator.php
+++ b/src/Api/Parser/DecodingEventStreamIterator.php
@@ -192,6 +192,9 @@ class DecodingEventStreamIterator implements Iterator
         return $this->key;
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function next()
     {
@@ -202,6 +205,9 @@ class DecodingEventStreamIterator implements Iterator
         }
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function rewind()
     {

--- a/src/Api/Parser/EventParsingIterator.php
+++ b/src/Api/Parser/EventParsingIterator.php
@@ -50,30 +50,45 @@ class EventParsingIterator implements Iterator
         }
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->parseEvent($this->decodingIterator->current());
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->decodingIterator->key();
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function next()
     {
         $this->decodingIterator->next();
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->decodingIterator->rewind();
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function valid()
     {

--- a/src/ResultPaginator.php
+++ b/src/ResultPaginator.php
@@ -107,18 +107,27 @@ class ResultPaginator implements \Iterator
         return $this->valid() ? $this->result : false;
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->valid() ? $this->requestCount - 1 : null;
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function next()
     {
         $this->result = null;
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function valid()
     {
@@ -154,6 +163,9 @@ class ResultPaginator implements \Iterator
         return false;
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function rewind()
     {


### PR DESCRIPTION
Addresses: https://github.com/aws/aws-sdk-php/issues/2665

Some SDK classes implement only some parts of the `Iterator` interface, causing warnings for customers that are using PHP version 7.x. Adding return type annotations help mitigate those warnings.