### PR TITLE
fix: honor use_aws_shared_config_files

### DIFF
--- a/.changes/nextrelease/generic-method-for-config-resolve.json
+++ b/.changes/nextrelease/generic-method-for-config-resolve.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "feature",
+        "category": "",
+        "description": "Standarize how config from env->ini is resolved."
+    }
+]

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -1318,12 +1318,13 @@ class ClientResolver
         }
     }
 
-    public static function _default_sigv4a_signing_region_set(array &$args)
+    public static function _default_sigv4a_signing_region_set(array $args)
     {
         return ConfigurationResolver::resolve(
             'sigv4a_signing_region_set',
             '',
-            'string'
+            'string',
+            $args
         );
     }
 
@@ -1335,9 +1336,14 @@ class ClientResolver
         $args['region'] = $value;
     }
 
-    public static function _default_region(&$args)
+    public static function _default_region($args)
     {
-        return ConfigurationResolver::resolve('region', '', 'string');
+        return ConfigurationResolver::resolve(
+            'region',
+            '',
+            'string',
+            $args
+        );
     }
 
     public static function _missing_region(array $args)

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -47,6 +47,20 @@ class ClientResolver
     /** @var array */
     private $argDefinitions;
 
+    /**
+     * When using this option as default please make sure that, your config
+     * has at least one data type defined in `valid` otherwise it will be
+     * defaulted to `string`. Also, the default value will be the falsy value
+     * based on the resolved data type. For example, the default for `string`
+     * will be `''` and for bool will be `false`.
+     *
+     * @var string
+     */
+    const DEFAULT_FROM_ENV_INI = [
+        __CLASS__,
+        '_resolve_from_env_ini'
+    ];
+
     /** @var array Map of types to a corresponding function */
     private static $typeMap = [
         'resource' => 'is_resource',
@@ -91,7 +105,7 @@ class ClientResolver
             'valid'     => ['bool'],
             'doc'       => 'Set to true to disable endpoint urls configured using `AWS_ENDPOINT_URL` and `endpoint_url` shared config option.',
             'fn'        => [__CLASS__, '_apply_ignore_configured_endpoint_urls'],
-            'default'   => [__CLASS__, '_default_ignore_configured_endpoint_urls'],
+            'default'   => self::DEFAULT_FROM_ENV_INI,
         ],
         'endpoint' => [
             'type'  => 'value',
@@ -105,7 +119,7 @@ class ClientResolver
             'valid'    => ['string'],
             'doc'      => 'Region to connect to. See http://docs.aws.amazon.com/general/latest/gr/rande.html for a list of available regions.',
             'fn'       => [__CLASS__, '_apply_region'],
-            'default'  => [__CLASS__, '_default_region']
+            'default'  => self::DEFAULT_FROM_ENV_INI
         ],
         'version' => [
             'type'     => 'value',
@@ -244,7 +258,7 @@ class ClientResolver
             'valid'     => ['bool', 'callable'],
             'doc'       => 'Set to true to disable request compression for supported operations',
             'fn'        => [__CLASS__, '_apply_disable_request_compression'],
-            'default'   => [__CLASS__, '_default_disable_request_compression'],
+            'default'   => self::DEFAULT_FROM_ENV_INI,
         ],
         'request_min_compression_size_bytes' => [
             'type'      => 'value',
@@ -324,10 +338,10 @@ class ClientResolver
         ],
         'sigv4a_signing_region_set' => [
             'type' => 'value',
-            'valid' => ['array', 'string'],
+            'valid' => ['string', 'array'],
             'doc' => 'A comma-delimited list of supported regions sent in sigv4a requests.',
             'fn' => [__CLASS__, '_apply_sigv4a_signing_region_set'],
-            'default' => [__CLASS__, '_default_sigv4a_signing_region_set']
+            'default' => self::DEFAULT_FROM_ENV_INI
         ]
     ];
 
@@ -397,7 +411,15 @@ class ClientResolver
                             || $a['default'] instanceof \Closure
                         )
                     ) {
-                        $args[$key] = $a['default']($args);
+                        if ($a['default'] === self::DEFAULT_FROM_ENV_INI) {
+                            $args[$key] = $a['default'](
+                                $key,
+                                $a['valid'][0] ?? 'string',
+                                $args
+                            );
+                        } else {
+                            $args[$key] = $a['default']($args);
+                        }
                     } else {
                         $args[$key] = $a['default'];
                     }
@@ -588,15 +610,6 @@ class ClientResolver
             );
         }
         $args['config']['disable_request_compression'] = $value;
-    }
-
-    public static function _default_disable_request_compression(array &$args) {
-        return ConfigurationResolver::resolve(
-            'disable_request_compression',
-            false,
-            'bool',
-            $args
-        );
     }
 
     public static function _apply_min_compression_size($value, array &$args) {
@@ -1259,16 +1272,6 @@ class ClientResolver
         }
     }
 
-    public static function _default_ignore_configured_endpoint_urls(array &$args)
-    {
-        return ConfigurationResolver::resolve(
-            'ignore_configured_endpoint_urls',
-            false,
-            'bool',
-            $args
-        );
-    }
-
     public static function _default_endpoint(array &$args)
     {
         if ($args['config']['ignore_configured_endpoint_urls']
@@ -1318,32 +1321,12 @@ class ClientResolver
         }
     }
 
-    public static function _default_sigv4a_signing_region_set(array $args)
-    {
-        return ConfigurationResolver::resolve(
-            'sigv4a_signing_region_set',
-            '',
-            'string',
-            $args
-        );
-    }
-
     public static function _apply_region($value, array &$args)
     {
         if (empty($value)) {
             self::_missing_region($args);
         }
         $args['region'] = $value;
-    }
-
-    public static function _default_region($args)
-    {
-        return ConfigurationResolver::resolve(
-            'region',
-            '',
-            'string',
-            $args
-        );
     }
 
     public static function _missing_region(array $args)
@@ -1360,6 +1343,35 @@ A "region" configuration value is required for the "{$service}" service
 found at http://docs.aws.amazon.com/general/latest/gr/rande.html.
 EOT;
         throw new IAE($msg);
+    }
+
+    /**
+     * Resolves a value from env or config.
+     *
+     * @param $key
+     * @param $expectedType
+     * @param $args
+     *
+     * @return mixed|string
+     */
+    private static function _resolve_from_env_ini(
+        string $key,
+        string $expectedType,
+        array $args
+    ) {
+        static $typeDefaultMap = [
+            'int' => 0,
+            'bool' => false,
+            'boolean' => false,
+            'string' => '',
+        ];
+
+        return ConfigurationResolver::resolve(
+            $key,
+            $typeDefaultMap[$expectedType] ?? '',
+            $expectedType,
+            $args
+        );
     }
 
     /**


### PR DESCRIPTION
Honor the `use_aws_shared_config_files` config from `default_region` and `default_sigv4a_signing_region_set` by passing `$args` along to the `ConfigurationResolver::resolve` call.

*Issue #3026*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
