### PR TITLE
feat: Support for PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       #for each of the following versions of PHP, with and without --prefer-lowest
       matrix:
-        php-versions: ['7.2.5', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.2.5', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         composer-options: ['', '--prefer-lowest']
     #set the name for each job
     name: PHP ${{ matrix.php-versions }} ${{ matrix.composer-options }}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "issues": "https://github.com/aws/aws-sdk-php/issues"
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.2.5 <9.0",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
         "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
         "guzzlehttp/promises": "^1.4.0 || ^2.0",
@@ -28,7 +28,7 @@
         "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer" : "^1.10.22",
+        "composer/composer": "^1.10.22",
         "ext-openssl": "*",
         "ext-dom": "*",
         "ext-pcntl": "*",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "composer/composer": "^1.10.22",
+        "composer/composer": "^2.0",
         "ext-openssl": "*",
         "ext-dom": "*",
         "ext-pcntl": "*",

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     },
     "require-dev": {
         "composer/composer": "^2.0",
+        "phpstan/phpstan": "^1.0",
         "ext-openssl": "*",
         "ext-dom": "*",
         "ext-pcntl": "*",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "require": {
         "php": ">=7.2.5 <9.0",
+        "symfony/filesystem": "^5.4 || ^6.0",
         "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
         "guzzlehttp/psr7": "^1.9.1 || ^2.4.5",
         "guzzlehttp/promises": "^1.4.0 || ^2.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

PHP 8.4 has been released and I would like it to be supported.

https://www.php.net/releases/8.4/en.php

We have therefore added PHP 8.4 to the PHP Composer action in the github actions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
