### PR TITLE
Allow configuring a different parent directory for .aws

### DIFF
--- a/src/AbstractConfigurationProvider.php
+++ b/src/AbstractConfigurationProvider.php
@@ -85,6 +85,14 @@ abstract class AbstractConfigurationProvider
      */
     protected static function getHomeDir()
     {
+        // Allow the ".aws" folder containing configuration and credentials to
+        // exist in another location. In some setups, this allows both the web
+        // server user (e.g. actions taken via a website UI) and the application
+        // user (e.g. actions taken via CLI) to properly work.
+        if ($homeDir = getenv('AWS_HOME')) {
+            return $homeDir;
+        }
+
         // On Linux/Unix-like systems, use the HOME environment variable
         if ($homeDir = getenv('HOME')) {
             return $homeDir;

--- a/src/Configuration/ConfigurationResolver.php
+++ b/src/Configuration/ConfigurationResolver.php
@@ -154,6 +154,14 @@ class ConfigurationResolver
      */
     private static function getHomeDir()
     {
+        // Allow the ".aws" folder containing configuration and credentials to
+        // exist in another location. In some setups, this allows both the web
+        // server user (e.g. actions taken via a website UI) and the application
+        // user (e.g. actions taken via CLI) to properly work.
+        if ($homeDir = getenv('AWS_HOME')) {
+            return $homeDir;
+        }
+
         // On Linux/Unix-like systems, use the HOME environment variable
         if ($homeDir = getenv('HOME')) {
             return $homeDir;

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -736,6 +736,14 @@ class CredentialProvider
      */
     private static function getHomeDir()
     {
+        // Allow the ".aws" folder containing configuration and credentials to
+        // exist in another location. In some setups, this allows both the web
+        // server user (e.g. actions taken via a website UI) and the application
+        // user (e.g. actions taken via CLI) to properly work.
+        if ($homeDir = getenv('AWS_HOME')) {
+            return $homeDir;
+        }
+
         // On Linux/Unix-like systems, use the HOME environment variable
         if ($homeDir = getenv('HOME')) {
             return $homeDir;

--- a/src/Token/ParsesIniTrait.php
+++ b/src/Token/ParsesIniTrait.php
@@ -30,6 +30,14 @@ trait ParsesIniTrait
      */
     private static function getHomeDir()
     {
+        // Allow the ".aws" folder containing configuration and credentials to
+        // exist in another location. In some setups, this allows both the web
+        // server user (e.g. actions taken via a website UI) and the application
+        // user (e.g. actions taken via CLI) to properly work.
+        if ($homeDir = getenv('AWS_HOME')) {
+            return $homeDir;
+        }
+
         // On Linux/Unix-like systems, use the HOME environment variable
         if ($homeDir = getenv('HOME')) {
             return $homeDir;


### PR DESCRIPTION
*Issue #, if available:*
3034

*Description of changes:*
Introduces a new environment variable `AWS_HOME` that takes precedence over using `HOME`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
