### PR TITLE
Make nullable parameter explicity nullable for PHP 8.4

### DIFF
--- a/build/Burgomaster.php
+++ b/build/Burgomaster.php
@@ -164,7 +164,7 @@ class Burgomaster
         $sourceDir,
         $destDir,
         $extensions = array('php', 'php.gz'),
-        Iterator $files = null
+        ?Iterator $files = null
     ) {
         if (!realpath($sourceDir)) {
             throw new \InvalidArgumentException("$sourceDir not found");


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter