### PR TITLE
chore: update changelong with breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -425,7 +425,7 @@
 * `Aws\BedrockRuntime` - Added converse support for custom imported models
 * `Aws\EC2` - RequestSpotInstances and RequestSpotFleet feature release.
 * `Aws\Bedrock` - Adding converse support to CMI API's
-* `Aws\Athena` - Removing FEDERATED from Create/List/Delete/GetDataCatalog API
+* `Aws\Athena` - **Breaking Change**: Remove DataCatalog from Create/DeleteDataCatalog. Remove Status, ConnectionType, and Error from DataCatalog and DataCatalogSummary. These were released inadvertently with no functionality. They were not populated or populated with a default value. Code related to these changes can be safely removed.
 * `Aws\DataZone` - Adding the following project member designations: PROJECT_CATALOG_VIEWER, PROJECT_CATALOG_CONSUMER and PROJECT_CATALOG_STEWARD in the CreateProjectMembership API and PROJECT_CATALOG_STEWARD designation in the AddPolicyGrant API.
 
 ## 3.324.5 - 2024-10-17


### PR DESCRIPTION
Update changelong for `3.324.6 - 2024-10-18` with a more detailed breaking change message for the Athena service model change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
