### PR TITLE
fix: add endpoint override flag

### DIFF
--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -1030,6 +1030,7 @@ class ClientResolver
             return;
         }
 
+        $args['endpoint_override'] = true;
         $args['endpoint'] = $value;
     }
 

--- a/src/UserAgentMiddleware.php
+++ b/src/UserAgentMiddleware.php
@@ -276,7 +276,7 @@ class UserAgentMiddleware
      */
     private function appendEndpointMetric(): void
     {
-        if (!empty($this->args['endpoint'])) {
+        if (!empty($this->args['endpoint_override'])) {
             $this->metricsBuilder->append(MetricsBuilder::ENDPOINT_OVERRIDE);
         }
     }

--- a/tests/UserAgentMiddlewareTest.php
+++ b/tests/UserAgentMiddlewareTest.php
@@ -204,7 +204,8 @@ class UserAgentMiddlewareTest extends TestCase
             'metricsWithEndpoint' => function (): array {
                 $expectedEndpoint = "https://foo-endpoint.com";
                 $args = [
-                    'endpoint' => $expectedEndpoint
+                    'endpoint' => $expectedEndpoint,
+                    'endpoint_override' => true,
                 ];
 
                 return [$args, 'm/' . MetricsBuilder::ENDPOINT_OVERRIDE];


### PR DESCRIPTION
This change is needed because the parameter `endpoint` will always be populated even if a value was not provided at client construction, and therefore we can not relay on it to determine its source.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
