### PR TITLE
fix: account id endpoint metric

### DIFF
--- a/src/EndpointV2/EndpointProviderV2.php
+++ b/src/EndpointV2/EndpointProviderV2.php
@@ -3,6 +3,7 @@
 namespace Aws\EndpointV2;
 
 use Aws\EndpointV2\Ruleset\Ruleset;
+use Aws\EndpointV2\Ruleset\RulesetEndpoint;
 use Aws\Exception\UnresolvedEndpointException;
 use Aws\LruArrayCache;
 

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -8,6 +8,7 @@ use Aws\CommandInterface;
 use Aws\MetricsBuilder;
 use Closure;
 use GuzzleHttp\Promise\Promise;
+use Aws\EndpointV2\Ruleset\RulesetEndpoint;
 use function JmesPath\search;
 
 /**
@@ -100,25 +101,9 @@ class EndpointV2Middleware
         $commandArgs = $command->toArray();
         $providerArgs = $this->resolveArgs($commandArgs, $operation);
 
-        // Resolved AccountId Metric
-        if (!empty($providerArgs[self::ACCOUNT_ID_PARAM])) {
-            $command->getMetricsBuilder()->append(MetricsBuilder::RESOLVED_ACCOUNT_ID);
-        }
-        // AccountIdMode Metric
-        if(!empty($providerArgs[self::ACCOUNT_ID_ENDPOINT_MODE_PARAM])) {
-            $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
-                'account_id_endpoint_mode',
-                $providerArgs[self::ACCOUNT_ID_ENDPOINT_MODE_PARAM]
-            );
-        }
-
         $endpoint = $this->endpointProvider->resolveEndpoint($providerArgs);
 
-        // AccountId Endpoint Metric
-        $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
-            'account_id_endpoint',
-            $endpoint->getUrl()
-        );
+        $this->appendEndpointMetrics($providerArgs, $endpoint, $command);
 
         if (!empty($authSchemes = $endpoint->getProperty('authSchemes'))) {
             $this->applyAuthScheme(
@@ -413,5 +398,30 @@ class EndpointV2Middleware
         $identity = $identityProviderFn()->wait();
 
         return $identity->getAccountId();
+    }
+
+    private function appendEndpointMetrics(
+        array $providerArgs,
+        RulesetEndpoint $endpoint,
+        CommandInterface $command
+    ): void
+    {
+        // Resolved AccountId Metric
+        if (!empty($providerArgs[self::ACCOUNT_ID_PARAM])) {
+            $command->getMetricsBuilder()->append(MetricsBuilder::RESOLVED_ACCOUNT_ID);
+        }
+        // AccountIdMode Metric
+        if(!empty($providerArgs[self::ACCOUNT_ID_ENDPOINT_MODE_PARAM])) {
+            $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
+                'account_id_endpoint_mode',
+                $providerArgs[self::ACCOUNT_ID_ENDPOINT_MODE_PARAM]
+            );
+        }
+
+        // AccountId Endpoint Metric
+        $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
+            'account_id_endpoint',
+            $endpoint->getUrl()
+        );
     }
 }

--- a/src/EndpointV2/EndpointV2Middleware.php
+++ b/src/EndpointV2/EndpointV2Middleware.php
@@ -99,10 +99,27 @@ class EndpointV2Middleware
         $operation = $this->api->getOperation($command->getName());
         $commandArgs = $command->toArray();
         $providerArgs = $this->resolveArgs($commandArgs, $operation);
+
+        // Resolved AccountId Metric
         if (!empty($providerArgs[self::ACCOUNT_ID_PARAM])) {
             $command->getMetricsBuilder()->append(MetricsBuilder::RESOLVED_ACCOUNT_ID);
         }
+        // AccountIdMode Metric
+        if(!empty($providerArgs[self::ACCOUNT_ID_ENDPOINT_MODE_PARAM])) {
+            $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
+                'account_id_endpoint_mode',
+                $providerArgs[self::ACCOUNT_ID_ENDPOINT_MODE_PARAM]
+            );
+        }
+
         $endpoint = $this->endpointProvider->resolveEndpoint($providerArgs);
+
+        // AccountId Endpoint Metric
+        $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
+            'account_id_endpoint',
+            $endpoint->getUrl()
+        );
+
         if (!empty($authSchemes = $endpoint->getProperty('authSchemes'))) {
             $this->applyAuthScheme(
                 $authSchemes,

--- a/src/MetricsBuilder.php
+++ b/src/MetricsBuilder.php
@@ -4,7 +4,6 @@ namespace Aws;
 
 use Aws\Credentials\CredentialsInterface;
 use Aws\Credentials\CredentialSources;
-use GuzzleHttp\Psr7\Uri;
 
 /**
  * A placeholder for gathering metrics in a request.
@@ -156,9 +155,9 @@ final class MetricsBuilder
     private function appendSignatureMetric(string $signature): void
     {
         if ($signature === 'v4-s3express') {
-            $this->append(MetricsBuilder::S3_EXPRESS_BUCKET);
+            $this->append(self::S3_EXPRESS_BUCKET);
         } elseif ($signature === 'v4a') {
-            $this->append(MetricsBuilder::SIGV4A_SIGNING);
+            $this->append(self::SIGV4A_SIGNING);
         }
     }
 
@@ -172,7 +171,7 @@ final class MetricsBuilder
     private function appendRequestCompressionMetric(string $format): void
     {
         if ($format === 'gzip') {
-            $this->append(MetricsBuilder::GZIP_REQUEST_COMPRESSION);
+            $this->append(self::GZIP_REQUEST_COMPRESSION);
         }
     }
 
@@ -186,15 +185,15 @@ final class MetricsBuilder
     private function appendRequestChecksumMetric(string $algorithm): void
     {
         if ($algorithm === 'crc32') {
-            $this->append(MetricsBuilder::FLEXIBLE_CHECKSUMS_REQ_CRC32);
+            $this->append(self::FLEXIBLE_CHECKSUMS_REQ_CRC32);
         } elseif ($algorithm === 'crc32c') {
-            $this->append(MetricsBuilder::FLEXIBLE_CHECKSUMS_REQ_CRC32C);
+            $this->append(self::FLEXIBLE_CHECKSUMS_REQ_CRC32C);
         } elseif ($algorithm === 'crc64') {
-            $this->append(MetricsBuilder::FLEXIBLE_CHECKSUMS_REQ_CRC64);
+            $this->append(self::FLEXIBLE_CHECKSUMS_REQ_CRC64);
         } elseif ($algorithm === 'sha1') {
-            $this->append(MetricsBuilder::FLEXIBLE_CHECKSUMS_REQ_SHA1);
+            $this->append(self::FLEXIBLE_CHECKSUMS_REQ_SHA1);
         } elseif ($algorithm === 'sha256') {
-            $this->append(MetricsBuilder::FLEXIBLE_CHECKSUMS_REQ_SHA256);
+            $this->append(self::FLEXIBLE_CHECKSUMS_REQ_SHA256);
         }
     }
 
@@ -218,29 +217,29 @@ final class MetricsBuilder
 
         static $credentialsMetricMapping = [
             CredentialSources::STATIC =>
-                MetricsBuilder::CREDENTIALS_CODE,
+                self::CREDENTIALS_CODE,
             CredentialSources::ENVIRONMENT =>
-                MetricsBuilder::CREDENTIALS_ENV_VARS,
+                self::CREDENTIALS_ENV_VARS,
             CredentialSources::ENVIRONMENT_STS_WEB_ID_TOKEN =>
-                MetricsBuilder::CREDENTIALS_ENV_VARS_STS_WEB_ID_TOKEN,
+                self::CREDENTIALS_ENV_VARS_STS_WEB_ID_TOKEN,
             CredentialSources::STS_ASSUME_ROLE =>
-                MetricsBuilder::CREDENTIALS_STS_ASSUME_ROLE,
+                self::CREDENTIALS_STS_ASSUME_ROLE,
             CredentialSources::STS_WEB_ID_TOKEN =>
-                MetricsBuilder::CREDENTIALS_STS_ASSUME_ROLE_WEB_ID,
+                self::CREDENTIALS_STS_ASSUME_ROLE_WEB_ID,
             CredentialSources::PROFILE =>
-                MetricsBuilder::CREDENTIALS_PROFILE,
+                self::CREDENTIALS_PROFILE,
             CredentialSources::IMDS =>
-                MetricsBuilder::CREDENTIALS_IMDS,
+                self::CREDENTIALS_IMDS,
             CredentialSources::ECS =>
-                MetricsBuilder::CREDENTIALS_HTTP,
+                self::CREDENTIALS_HTTP,
             CredentialSources::PROFILE_STS_WEB_ID_TOKEN =>
-                MetricsBuilder::CREDENTIALS_PROFILE_STS_WEB_ID_TOKEN,
+                self::CREDENTIALS_PROFILE_STS_WEB_ID_TOKEN,
             CredentialSources::PROFILE_PROCESS =>
-                MetricsBuilder::CREDENTIALS_PROFILE_PROCESS,
+                self::CREDENTIALS_PROFILE_PROCESS,
             CredentialSources::PROFILE_SSO =>
-                MetricsBuilder::CREDENTIALS_PROFILE_SSO,
+                self::CREDENTIALS_PROFILE_SSO,
             CredentialSources::PROFILE_SSO_LEGACY =>
-                MetricsBuilder::CREDENTIALS_PROFILE_SSO_LEGACY,
+                self::CREDENTIALS_PROFILE_SSO_LEGACY,
         ];
         if (isset($credentialsMetricMapping[$source])) {
             $this->append($credentialsMetricMapping[$source]);
@@ -264,11 +263,11 @@ final class MetricsBuilder
         }
 
         if ($accountIdEndpointMode === 'preferred') {
-            $this->append(MetricsBuilder::ACCOUNT_ID_MODE_PREFERRED);
+            $this->append(self::ACCOUNT_ID_MODE_PREFERRED);
         } elseif ($accountIdEndpointMode === 'disabled') {
-            $this->append(MetricsBuilder::ACCOUNT_ID_MODE_DISABLED);
+            $this->append(self::ACCOUNT_ID_MODE_DISABLED);
         } elseif ($accountIdEndpointMode === 'required') {
-            $this->append(MetricsBuilder::ACCOUNT_ID_MODE_REQUIRED);
+            $this->append(self::ACCOUNT_ID_MODE_REQUIRED);
         }
     }
 
@@ -284,7 +283,7 @@ final class MetricsBuilder
     {
         static $pattern = "/(https|http):\\/\\/\\d{12}\\.ddb/";
         if (preg_match($pattern, $endpoint)) {
-            $this->append(MetricsBuilder::ACCOUNT_ID_ENDPOINT);
+            $this->append(self::ACCOUNT_ID_ENDPOINT);
         }
     }
 

--- a/src/UserAgentMiddleware.php
+++ b/src/UserAgentMiddleware.php
@@ -30,7 +30,6 @@ class UserAgentMiddleware
 
     static $metricsFnList = [
         'appendEndpointMetric',
-        'appendAccountIdModeMetric',
         'appendRetryConfigMetric',
     ];
 
@@ -278,26 +277,6 @@ class UserAgentMiddleware
     {
         if (!empty($this->args['endpoint_override'])) {
             $this->metricsBuilder->append(MetricsBuilder::ENDPOINT_OVERRIDE);
-        }
-    }
-
-    /**
-     * Appends the account id endpoint mode metric into the metrics builder,
-     * based on the account id endpoint mode provide as client argument.
-     */
-    private function appendAccountIdModeMetric(): void
-    {
-        $accountIdMode = $this->args['account_id_endpoint_mode'] ?? null;
-        if ($accountIdMode === null) {
-            return;
-        }
-
-        if ($accountIdMode === 'preferred') {
-            $this->metricsBuilder->append(MetricsBuilder::ACCOUNT_ID_MODE_PREFERRED);
-        } elseif ($accountIdMode === 'disabled') {
-            $this->metricsBuilder->append(MetricsBuilder::ACCOUNT_ID_MODE_DISABLED);
-        } elseif ($accountIdMode === 'required') {
-            $this->metricsBuilder->append(MetricsBuilder::ACCOUNT_ID_MODE_REQUIRED);
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
- Captures the AccountIdEndpointMode metric just if the parameter is defined in the ruleset.
- Captures the account id endpoint metric whenever an account id endpoint was resolved by the endpoint middleware.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
