### PR TITLE
fix: account_id resolution in ecs

### DIFF
--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -93,10 +93,6 @@ class EcsCredentialProvider
                                 $result['AccountId'] = $parsedArn->getAccountId();
                             } catch (\Exception $e) {
                                 // AccountId will be null
-                                trigger_error(
-                                    "An error occured while parsing the ARN string: " . $e->getMessage(),
-                                    E_USER_WARNING
-                                );
                             }
                         }
 

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -384,7 +384,6 @@ EOF;
         } catch (GuzzleException $e) {
             self::fail($e->getMessage());
         }
-
     }
 
     /**


### PR DESCRIPTION
*Issue #3056*

*Description of changes:*
In order to support account id endpoint resolution on ECS when ECS does not return an AccountId field as part of its response. What is being done in this change is trying to populate the AccountId field from the RoleArn returned in the response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
