### PR TITLE
chore: update auth token generator default expiry time

### DIFF
--- a/.changes/nextrelease/update-token-generator.json
+++ b/.changes/nextrelease/update-token-generator.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "DSQL",
+    "description": "Updates default `AuthTokenGenerator` token expiration time from 700 to 900 seconds."
+  }
+]

--- a/src/DSQL/AuthTokenGenerator.php
+++ b/src/DSQL/AuthTokenGenerator.php
@@ -18,7 +18,7 @@ class AuthTokenGenerator
     private const DB_CONNECT = 'DbConnect';
     private const DB_CONNECT_ADMIN = 'DbConnectAdmin';
     private const SIGNING_NAME = 'dsql';
-    private const DEFAULT_EXPIRATION_TIME_SECONDS = 700;
+    private const DEFAULT_EXPIRATION_TIME_SECONDS = 900;
 
     /**
      * @var Credentials|callable

--- a/tests/DSQL/AuthTokenGeneratorTest.php
+++ b/tests/DSQL/AuthTokenGeneratorTest.php
@@ -143,4 +143,20 @@ class AuthTokenGeneratorTest extends TestCase
             $expiration
         );
     }
+
+    public function testTokenGenerationDefaultExpiration()
+    {
+        $accessKeyId = 'AKID';
+        $secretKeyId = 'SECRET';
+        $credentials = new Credentials($accessKeyId, $secretKeyId);
+        $tokenGenerator = new AuthTokenGenerator($credentials);
+        $token = $tokenGenerator->generateDbConnectAuthToken(
+            'peccy.dsql.us-east-1.on.aws',
+            'us-east-1'
+        );
+
+        $this->assertStringContainsString('X-Amz-Credential=AKID', $token);
+        $this->assertStringContainsString('X-Amz-Expires=900', $token);
+        $this->assertStringContainsString('us-east-1%2Fdsql', $token);
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Updates default expiration time from 700 to 900 seconds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
