### PR TITLE
feat: remove paragonie/random_compat dev dependency

### DIFF
--- a/.changes/nextrelease/remove-paragonie-random_compat-dev-dependency.json
+++ b/.changes/nextrelease/remove-paragonie-random_compat-dev-dependency.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Remove paragonie/random_compat dev dependency."
+    }
+]

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "andrewsville/php-token-reflection": "^1.4",
         "psr/cache": "^2.0 || ^3.0",
         "psr/simple-cache": "^2.0 || ^3.0",
-        "paragonie/random_compat": ">= 2",
         "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
         "symfony/filesystem": "^v6.4.0 || ^v7.1.0",
         "yoast/phpunit-polyfills": "^2.0",


### PR DESCRIPTION
*Issue #, if available:*
#3020

*Description of changes:*
Removing the paragonie/random_compat dev dependency, because it is unnecessary, given the fact that the AWS SDK requires PHP 7.2. PHP 7.0+ guarantees the existence of the CSPRNG.

This cleans up the list of dependencies and reduces unnecessary network traffic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
