### PR TITLE
chore: run GHA HandleStaleDiscussions only on aws repo

### DIFF
--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   handle-stale-discussions:
+    if: github.repository_owner == 'aws'
     name: Handle stale discussions
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Running this GHA on forked repos will most likely fail and we should prevent this from happening.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
