### PR TITLE
bugfix: sso provider expiration

### DIFF
--- a/.changes/nextrelease/sso-expires-fix.json
+++ b/.changes/nextrelease/sso-expires-fix.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Credentials",
+    "description": "Updates to sso provider expiration time handling"
+  }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -919,7 +919,9 @@ class CredentialProvider
             $token->getToken(),
             $config
         );
-        $expiration = $ssoCredentials['expiration'];
+
+        //Expiration value is returned in epoch milliseconds. Conversion to seconds
+        $expiration = intdiv($ssoCredentials['expiration'], 1000);
         return Promise\Create::promiseFor(
             new Credentials(
                 $ssoCredentials['accessKeyId'],

--- a/tests/Credentials/CredentialProviderTest.php
+++ b/tests/Credentials/CredentialProviderTest.php
@@ -1151,6 +1151,7 @@ EOT;
     {
         $dir = $this->clearEnv();
         $expiration = time() + 1000;
+        $expirationMilliseconds = $expiration * 1000;
         $ini = <<<EOT
 [default]
 sso_account_id = 12345
@@ -1196,7 +1197,7 @@ EOT;
                 'accessKeyId'     => 'foo',
                 'secretAccessKey' => 'assumedSecret',
                 'sessionToken'    => null,
-                'expiration'      => $expiration
+                'expiration'      => $expirationMilliseconds
             ],
         ];
 
@@ -1220,6 +1221,7 @@ EOT;
                 DateTimeResult::fromEpoch(time())->getTimestamp(),
                 $creds->getExpiration()
             );
+            $this->assertEquals($creds->getExpiration(), $expiration);
         } finally {
             unlink($dir . '/config');
             unlink($tokenLocation);
@@ -2537,6 +2539,7 @@ EOF;
             mkdir($awsDir, 0777, true);
         }
         $expiration = time() + 1000;
+        $expirationMilliseconds = $expiration * 1000;
         $ini = <<<EOF
 [default]
 sso_account_id = 123456789012
@@ -2577,7 +2580,7 @@ EOF;
                 'accessKeyId'     => 'Foo',
                 'secretAccessKey' => 'Bazz',
                 'sessionToken'    => null,
-                'expiration'      => $expiration
+                'expiration'      => $expirationMilliseconds
             ],
         ];
         $ssoClient = new SSOClient([
@@ -2597,6 +2600,7 @@ EOF;
                 ]
             );
             $credentials = $credentialsProvider()->wait();
+            $this->assertEquals($credentials->getExpiration(), $expiration);
 
             $this->assertEquals(
                 CredentialSources::PROFILE_SSO,


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3063 

*Description of changes:*
Updates handling of expiration value sent from the `SSO` service, which returns epoch milliseconds.  Converts to epoch seconds, which is what the `Credentials` class expects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
