### PR TITLE
chore: update illegal v4a headers

### DIFF
--- a/.changes/nextrelease/sigv4a-headers.json
+++ b/.changes/nextrelease/sigv4a-headers.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "Signature",
+    "description": "Adds `transfer-encoding` to list of headers to be removed prior to sigv4a signing"
+  }
+]

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -469,16 +469,17 @@ class SignatureV4 implements SignatureInterface
 
     private function removeIllegalV4aHeaders(&$request)
     {
-        $illegalV4aHeaders = [
+        static $illegalV4aHeaders = [
             self::AMZ_CONTENT_SHA256_HEADER,
-            "aws-sdk-invocation-id",
-            "aws-sdk-retry",
+            'aws-sdk-invocation-id',
+            'aws-sdk-retry',
             'x-amz-region-set',
+            'transfer-encoding'
         ];
         $storedHeaders = [];
 
         foreach ($illegalV4aHeaders as $header) {
-            if ($request->hasHeader($header)){
+            if ($request->hasHeader($header)) {
                 $storedHeaders[$header] = $request->getHeader($header);
                 $request = $request->withoutHeader($header);
             }


### PR DESCRIPTION
*Description of changes:*
Adds `transfer-encoding` to list of headers to be removed prior to v4a signing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
