### PR TITLE
bugfix: auth fallbacks

### DIFF
--- a/.changes/nextrelease/auth-selection.json
+++ b/.changes/nextrelease/auth-selection.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Auth",
+    "description": "Adds exception handling for invalid identities, allowing fallback behavior"
+  }
+]

--- a/src/Auth/AuthSchemeResolver.php
+++ b/src/Auth/AuthSchemeResolver.php
@@ -3,6 +3,8 @@
 namespace Aws\Auth;
 
 use Aws\Auth\Exception\UnresolvedAuthSchemeException;
+use Aws\Exception\CredentialsException;
+use Aws\Exception\TokenException;
 use Aws\Identity\AwsCredentialIdentity;
 use Aws\Identity\BearerTokenIdentity;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -142,7 +144,12 @@ class AuthSchemeResolver implements AuthSchemeResolverInterface
         $result = $fn();
 
         if ($result instanceof PromiseInterface) {
-            return $result->wait() instanceof AwsCredentialIdentity;
+            try {
+                $resolved = $result->wait();
+                return $resolved instanceof AwsCredentialIdentity;
+            } catch (CredentialsException $e) {
+                return false;
+            }
         }
 
         return $result instanceof AwsCredentialIdentity;
@@ -158,7 +165,12 @@ class AuthSchemeResolver implements AuthSchemeResolverInterface
             $result = $fn();
 
             if ($result instanceof PromiseInterface) {
-                return $result->wait() instanceof BearerTokenIdentity;
+                try {
+                    $resolved = $result->wait();
+                    return $resolved instanceof BearerTokenIdentity;
+                } catch (TokenException $e) {
+                    return false;
+                }
             }
 
             return $result instanceof BearerTokenIdentity;


### PR DESCRIPTION
*Description of changes:*
Adds exception handling for when an invalid (or no) identity is resolved.  For example, if no credentials are provided and no credential sources are found, an exception will be thrown from the instance profile provider- the last provider in the default chain.  If, for this same client, someone provided a bearer token and the service supported bearer auth, the `AuthSchemeResolver` should be able to fall back to this auth scheme.  These changes make that possible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
