### PR TITLE
chore: endpoint arn middleware updates

### DIFF
--- a/.changes/nextrelease/auth-selection.json
+++ b/.changes/nextrelease/auth-selection.json
@@ -1,7 +1,0 @@
-[
-  {
-    "type": "bugfix",
-    "category": "Auth",
-    "description": "Adds exception handling for invalid identities, allowing fallback behavior"
-  }
-]

--- a/.changes/nextrelease/endpoint-arn-updates.json
+++ b/.changes/nextrelease/endpoint-arn-updates.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "S3Control",
+    "description": "Disables legacy `EndpointArnMiddleware` when the dynamic endpoint provider is in use"
+  }
+]

--- a/src/S3Control/S3ControlClient.php
+++ b/src/S3Control/S3ControlClient.php
@@ -269,25 +269,26 @@ class S3ControlClient extends AwsClient
 
         if ($this->isUseEndpointV2()) {
             $this->processEndpointV2Model();
+        } else {
+            $stack = $this->getHandlerList();
+            $stack->appendBuild(
+                EndpointArnMiddleware::wrap(
+                    $this->getApi(),
+                    $this->getRegion(),
+                    [
+                        'use_arn_region' => $this->getConfig('use_arn_region'),
+                        'dual_stack' =>
+                            $this->getConfig('use_dual_stack_endpoint')->isUseDualStackEndpoint(),
+                        'endpoint' => isset($args['endpoint'])
+                            ? $args['endpoint']
+                            : null,
+                        'use_fips_endpoint' => $this->getConfig('use_fips_endpoint'),
+                    ],
+                    $this->isUseEndpointV2()
+                ),
+                's3control.endpoint_arn_middleware'
+            );
         }
-        $stack = $this->getHandlerList();
-        $stack->appendBuild(
-            EndpointArnMiddleware::wrap(
-                $this->getApi(),
-                $this->getRegion(),
-                [
-                    'use_arn_region' => $this->getConfig('use_arn_region'),
-                    'dual_stack' =>
-                        $this->getConfig('use_dual_stack_endpoint')->isUseDualStackEndpoint(),
-                    'endpoint' => isset($args['endpoint'])
-                        ? $args['endpoint']
-                        : null,
-                    'use_fips_endpoint' => $this->getConfig('use_fips_endpoint'),
-                ],
-                $this->isUseEndpointV2()
-            ),
-            's3control.endpoint_arn_middleware'
-        );
     }
 
     /**

--- a/tests/S3Control/S3ControlClientTest.php
+++ b/tests/S3Control/S3ControlClientTest.php
@@ -1,10 +1,7 @@
 <?php
 namespace Aws\Test\S3Control;
 
-use Aws\Arn\ArnParser;
-use Aws\Exception\UnresolvedEndpointException;
-use Aws\S3Control\S3ControlClient;
-use Aws\Signature\SignatureV4;
+use Aws\Endpoint\PartitionEndpointProvider;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
@@ -36,4 +33,23 @@ class S3ControlClientTest extends TestCase
         ]);
     }
 
+    public function testDoesNotUseEndpointArnMiddlewareByDefault()
+    {
+        $client = $this->getTestClient([]);
+        $list = $client->getHandlerList();
+        $this->assertStringNotContainsString(
+            's3control.endpoint_arn_middleware', $list->__toString()
+        );
+    }
+
+    public function testLegacyEndpointProviderUsesEndpointArnMiddleware()
+    {
+        $client = $this->getTestClient(
+            ['endpoint_provider' => PartitionEndpointProvider::defaultProvider()]
+        );
+        $list = $client->getHandlerList();
+        $this->assertStringContainsString(
+            's3control.endpoint_arn_middleware', $list->__toString()
+        );
+    }
 }

--- a/tests/S3Control/S3ControlTestingTrait.php
+++ b/tests/S3Control/S3ControlTestingTrait.php
@@ -18,6 +18,7 @@ trait S3ControlTestingTrait
         $params = [
             'version' => '2018-08-20',
             'region' => 'us-west-2',
+            'endpoint_provider' => $args['endpoint_provider'] ?? null
         ];
 
         return new S3ControlClient(array_merge($params, $args));


### PR DESCRIPTION
*Description of changes:*
Disables `EndpointArnMiddleware` when the (newer) dynamic endpoint provider is in use.  This middleware used to handle endpoint construction for arns provided to the `S3ControlClient`, but it is no longer necessary or useful when `EndpointProviderV2` is in use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
