### PR TITLE
fix: prevent duplicating metrics middleware

### DIFF
--- a/.changes/.nextrelease/fix-duplicate-metrics-middleware.json
+++ b/.changes/.nextrelease/fix-duplicate-metrics-middleware.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "",
+        "description": "Prevents metrics gathering middlewares from being added more than once."
+    }
+]

--- a/src/HandlerList.php
+++ b/src/HandlerList.php
@@ -116,6 +116,19 @@ class HandlerList implements \Countable
     }
 
     /**
+     * Checks if a middleware exists. The middleware
+     * should have been appended with a name.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasMiddleware(string $name): bool
+    {
+        return isset($this->named[$name]);
+    }
+
+    /**
      * Append a middleware to the init step.
      *
      * @param callable $middleware Middleware function to add.

--- a/src/HandlerList.php
+++ b/src/HandlerList.php
@@ -117,7 +117,8 @@ class HandlerList implements \Countable
 
     /**
      * Checks if a middleware exists. The middleware
-     * should have been appended with a name.
+     * should have been added with a name in order to
+     * use this method.
      *
      * @param string $name
      *

--- a/src/MetricsBuilder.php
+++ b/src/MetricsBuilder.php
@@ -463,15 +463,18 @@ final class MetricsBuilder
         $metric
     ): void
     {
-        $handlerList->appendBuild(
-            Middleware::tap(
-                function (CommandInterface $command) use ($metric) {
-                    self::fromCommand($command)->append(
-                        $metric
-                    );
-                }
-            ),
-            'metrics-capture-'.$metric
-        );
+        $middlewareName = 'metrics-capture-'.$metric;
+        if (!$handlerList->hasMiddleware($middlewareName)) {
+            $handlerList->appendBuild(
+                Middleware::tap(
+                    function (CommandInterface $command) use ($metric) {
+                        self::fromCommand($command)->append(
+                            $metric
+                        );
+                    }
+                ),
+                $middlewareName
+            );
+        }
     }
 }

--- a/tests/MetricsBuilderTest.php
+++ b/tests/MetricsBuilderTest.php
@@ -169,4 +169,31 @@ class MetricsBuilderTest extends TestCase
             ]
         ];
     }
+
+    /**
+     * Tests that metric middlewares are appended just once.
+     *
+     * @return void
+     */
+    public function testAppendMetricsCaptureMiddlewareJustOnce(): void {
+        $handlerList = new HandlerList(function (){});
+        MetricsBuilder::appendMetricsCaptureMiddleware(
+            $handlerList,
+            'test'
+        );
+        MetricsBuilder::appendMetricsCaptureMiddleware(
+            $handlerList,
+            'test'
+        );
+        $this->assertTrue(
+            $handlerList->hasMiddleware('metrics-capture-test')
+        );
+        $this->assertEquals(
+            1,
+            substr_count(
+                $handlerList->__toString(),
+                'metrics-capture-test'
+            )
+        );
+    }
 }


### PR DESCRIPTION
*Issue #3086*

*Description of changes:*
- Prevent adding the same metrics middleware multiple times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
