### PR TITLE
feat: protocol selection

### DIFF
--- a/.changes/nextrelease/protocol-selection.json
+++ b/.changes/nextrelease/protocol-selection.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "feature",
+    "category": "Api",
+    "description": "Adds protocol selection behavior for services that specify the `protocols` field"
+  }
+]

--- a/src/Api/Service.php
+++ b/src/Api/Service.php
@@ -30,6 +30,9 @@ class Service extends AbstractModel
     /** @var boolean */
     private $modifiedModel = false;
 
+    /** @var string */
+    private $protocol;
+
     /**
      * @param array    $definition
      * @param callable $provider
@@ -69,6 +72,8 @@ class Service extends AbstractModel
         if (isset($definition['clientContextParams'])) {
            $this->clientContextParams = $definition['clientContextParams'];
         }
+
+        $this->protocol = $this->selectProtocol($definition);
     }
 
     /**
@@ -241,7 +246,7 @@ class Service extends AbstractModel
      */
     public function getProtocol()
     {
-        return $this->definition['metadata']['protocol'];
+        return $this->protocol;
     }
 
     /**
@@ -532,5 +537,28 @@ class Service extends AbstractModel
     public function isModifiedModel()
     {
         return $this->modifiedModel;
+    }
+
+    /**
+     * Accepts a list of protocols derived from the service model.
+     * Returns the highest priority compatible auth scheme if the `protocols` trait is present.
+     * Otherwise, returns the value of the `protocol` field, if set, or null.
+     *
+     * @param array $definition
+     *
+     * @return string|null
+     */
+    private function selectProtocol(array $definition): string | null
+    {
+        $modeledProtocols = $definition['metadata']['protocols'] ?? null;
+        if (!empty($modeledProtocols)) {
+            foreach(SupportedProtocols::cases() as $protocol) {
+                if (in_array($protocol->value, $modeledProtocols)) {
+                    return $protocol->value;
+                }
+            }
+        }
+
+        return $definition['metadata']['protocol'] ?? null;
     }
 }

--- a/src/Api/SupportedProtocols.php
+++ b/src/Api/SupportedProtocols.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Aws\Api;
+
+/**
+ * Priority ordered collection of supported AWS protocols.
+ */
+enum SupportedProtocols: string
+{
+    case JSON = 'json';
+    case REST_JSON = 'rest-json';
+    case REST_XML = 'rest-xml';
+    case QUERY = 'query';
+    case EC2 = 'ec2';
+
+    /**
+     * Check if a protocol is valid.
+     *
+     * @param string $protocol
+     * @return bool True if the protocol is supported, otherwise false.
+     */
+    public static function isSupported(string $protocol): bool
+    {
+        return self::tryFrom($protocol) !== null;
+    }
+}

--- a/tests/Api/ServiceTest.php
+++ b/tests/Api/ServiceTest.php
@@ -305,4 +305,65 @@ class ServiceTest extends TestCase
             $s->getOperation('FooOperation')->getOutput()->getMember('Expires')->getType()
         );
     }
+
+    /**
+     * @dataProvider selectsProtocolProvider
+     */
+    public function testSelectsProtocol($protocols, $expected)
+    {
+        $s = new Service(
+            [
+                'metadata' => [
+                    'serviceFullName' => 'Foo Service',
+                    'serviceIdentifier' => 'foo',
+                    'serviceId'         => 'Foo',
+                    'endpointPrefix'  => 'bar',
+                    'apiVersion'      => 'baz',
+                    'signingName'     => 'qux',
+                    'protocols'        => $protocols,
+                    'protocol'          => 'json',
+                    'uid'             => 'foo-2016-12-09'
+                ],
+                'operations' => [
+                    'FooOperation' => [
+                        'name' => 'FooOperation',
+                        'output' => [
+                            'shape' => 'FooOperationOutput'
+                        ]
+                    ]
+                ],
+                'shapes' => [
+                    'FooOperationOutput' => [
+                        'type' => 'structure',
+                        'members' => [
+                            'Expires' => [
+                                'shape' => 'Expires',
+                            ]
+                        ]
+                    ],
+                    'Expires' => [
+                        'type' => 'string'
+                    ]
+                ]
+            ],
+            function () { return []; }
+        );
+        $protocol = $s->getProtocol();
+        $this->assertEquals($expected, $protocol);
+    }
+
+    public function selectsProtocolProvider()
+    {
+        return [
+            [['smithy-rpc-v2-cbor', 'json'], 'json'],
+            //Handles failure to select by falling back to 'protocol'
+            [['smithy-rpc-v2-cbor'], 'json'],
+            [['smithy-rpc-v2-cbor', 'json', 'query'], 'json'],
+            [['json', 'query'], 'json'],
+            [['query'], 'query'],
+            [['rest-xml', 'rest-json'], 'rest-json'],
+            [['foo', 'ec2'], 'ec2'],
+            [['foo', 'bar', 'baz'], 'json']
+        ];
+    }
 }

--- a/tests/Api/SupportedProtocolsTest.php
+++ b/tests/Api/SupportedProtocolsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Api;
+
+use Aws\Api\SupportedProtocols;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class SupportedProtocolsTest extends TestCase
+{
+    /**
+     * @dataProvider validProtocolsProvider
+     */
+    public function testIsSupportedReturnsTrueForValidProtocols(string $protocol)
+    {
+        $this->assertTrue(SupportedProtocols::isSupported($protocol));
+    }
+
+    /**
+     * @dataProvider invalidProtocolsProvider
+     */
+    public function testIsSupportedReturnsFalseForInvalidProtocols(string $protocol)
+    {
+        $this->assertFalse(SupportedProtocols::isSupported($protocol));
+    }
+
+    /**
+     * Data provider for valid protocols.
+     *
+     * @return array
+     */
+    public function validProtocolsProvider(): array
+    {
+        return [
+            ['rest-json'],
+            ['rest-xml'],
+            ['json'],
+            ['query'],
+            ['ec2'],
+        ];
+    }
+
+    /**
+     * Data provider for invalid protocols.
+     *
+     * @return array
+     */
+    public function invalidProtocolsProvider(): array
+    {
+        return [
+            ['graphql'],
+            ['soap'],
+            ['grpc'],
+            [''],
+            ['REST-JSON'],
+            ['restjson'],
+        ];
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Defines a priority-ordered list of AWS protocols that are supported by the SDK.  Services have started to model a `protocols` field, which the SDK will select from, if available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
