### PR TITLE
In get() method of Aws\Result, use object structure.

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -23,7 +23,7 @@ class Result implements ResultInterface, MonitoringEventsInterface
 
     public function get($key)
     {
-        return $this[$key];
+        return $this->$key;
     }
 
     public function search($expression)


### PR DESCRIPTION
*Issue #3090*

*Description of changes:*
in get function of Aws\Result use object structure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
