### PR TITLE
fix: adjust waiter matchers

### DIFF
--- a/.changes/.nextrelease/feature-progress-tracker.json
+++ b/.changes/.nextrelease/feature-progress-tracker.json
@@ -1,7 +1,0 @@
-[
-    {
-        "type": "enhancement",
-        "category": "S3",
-        "description": "'track_upload' configuration option added for MultipartUpload and MultipartCopy"
-    }
-]

--- a/.changes/nextrelease/fix-waiter-matchers.json
+++ b/.changes/nextrelease/fix-waiter-matchers.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "",
+        "description": "Makes the waiter matchers to be fully compatible with the SEP. \n To be more specific it does the following: \n\t- Makes matchesPath to return false when the result value does not match the same value and type as the expected value. \n\t- Makes matchesPathAll to return false when an empty array or a non-array value is resolved by the jmespath evaluator. \n\t- Makes matchesPathAny to return false when a non-array value is resolved by the jmespath evaluator."
+    }
+]

--- a/.changes/nextrelease/fix-waiter-matchers.json
+++ b/.changes/nextrelease/fix-waiter-matchers.json
@@ -2,6 +2,6 @@
     {
         "type": "bugfix",
         "category": "",
-        "description": "Makes the waiter matchers to be fully compatible with the SEP. \n To be more specific it does the following: \n\t- Makes matchesPath to return false when the result value does not match the same value and type as the expected value. \n\t- Makes matchesPathAll to return false when an empty array or a non-array value is resolved by the jmespath evaluator. \n\t- Makes matchesPathAny to return false when a non-array value is resolved by the jmespath evaluator."
+        "description": "Changes to align with current waiter specifications."
     }
 ]

--- a/src/Waiter.php
+++ b/src/Waiter.php
@@ -190,9 +190,8 @@ class Waiter implements PromisorInterface
      */
     private function matchesPath($result, array $acceptor)
     {
-        return !($result instanceof ResultInterface)
-            ? false
-            : $acceptor['expected'] == $result->search($acceptor['argument']);
+        return $result instanceof ResultInterface
+            && $acceptor['expected'] === $result->search($acceptor['argument']);
     }
 
     /**
@@ -208,6 +207,11 @@ class Waiter implements PromisorInterface
         }
 
         $actuals = $result->search($acceptor['argument']) ?: [];
+        // If is empty or not evaluates to an array it must return false.
+        if (empty($actuals) || !is_array($actuals)) {
+            return false;
+        }
+
         foreach ($actuals as $actual) {
             if ($actual != $acceptor['expected']) {
                 return false;
@@ -230,6 +234,11 @@ class Waiter implements PromisorInterface
         }
 
         $actuals = $result->search($acceptor['argument']) ?: [];
+        // If is empty or not evaluates to an array it must return false.
+        if (empty($actuals) || !is_array($actuals)) {
+            return false;
+        }
+
         return in_array($acceptor['expected'], $actuals);
     }
 

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -273,120 +273,165 @@ class WaiterTest extends TestCase
         $this->assertEquals($expected, $matcher->invoke($waiter, $result, $acceptor));
     }
 
-    public function getMatchersTestCases()
+    /**
+     * @return array
+     */
+    public function getMatchersTestCases(): array
     {
         return [
-            [
-                'matchesPath',
-                null,
-                [],
-                false
+            'matches_path_1' => [
+                'matcher' => 'matchesPath',
+                'result' => null,
+                'acceptor' => [],
+                'expected' => false
             ],
-            [
-                'matchesPath',
-                $this->getMockResult(['a' => ['b' => 'c']]),
-                ['argument' => 'a.b', 'expected' => 'c'],
-                true
+            'matches_path_2' => [
+                'matcher' => 'matchesPath',
+                'result' => $this->getMockResult(['a' => ['b' => 'c']]),
+                'acceptor' => ['argument' => 'a.b', 'expected' => 'c'],
+                'expected' => true
             ],
-            [
-                'matchesPath',
-                $this->getMockResult(['a' => ['b' => 'c']]),
-                ['argument' => 'a', 'expected' => 'z'],
-                false
+            'matches_path_3' => [
+                'matcher' => 'matchesPath',
+                'result' => $this->getMockResult(['a' => ['b' => 'c']]),
+                'acceptor' => ['argument' => 'a', 'expected' => 'z'],
+                'expected' => false
             ],
-            [
-                'matchesPathAll',
-                null,
-                [],
-                false
+            'matches_path_4_same_value_different_type' => [
+                'matcher' => 'matchesPath',
+                'result' => $this->getMockResult(['a' => ['b' => 'false']]),
+                'acceptor' => ['argument' => 'a.b', 'expected' => false],
+                'expected' => false
             ],
-            [
-                'matchesPathAll',
-                $this->getMockResult([
+            'matches_path_5_same_value_same_type' => [
+                'matcher' => 'matchesPath',
+                'result' => $this->getMockResult(['a' => ['b' => false]]),
+                'acceptor' => ['argument' => 'a.b', 'expected' => false],
+                'expected' => true
+            ],
+            'matches_path_6_same_value_same_type' => [
+                'matcher' => 'matchesPath',
+                'result' => $this->getMockResult(['a' => ['b' => 'false']]),
+                'acceptor' => ['argument' => 'a.b', 'expected' => 'false'],
+                'expected' => true
+            ],
+            'matches_path_all_1' => [
+                'matcher' => 'matchesPathAll',
+                'result' => null,
+                'acceptor' => [],
+                'expected' => false,
+            ],
+            'matches_path_all_2' => [
+                'matcher' => 'matchesPathAll',
+                'result' =>  $this->getMockResult([
                     'a' => [
                         ['b' => 'c'],
                         ['b' => 'c'],
                         ['b' => 'c']
                     ]
                 ]),
-                ['argument' => 'a[].b', 'expected' => 'c'],
-                true
+                'acceptor' => ['argument' => 'a[].b', 'expected' => 'c'],
+                'expected' => true,
             ],
-            [
-                'matchesPathAll',
-                $this->getMockResult(['a' => [
+            'matches_path_all_3' => [
+                'matcher' => 'matchesPathAll',
+                'result' =>  $this->getMockResult(['a' => [
                     ['b' => 'c'],
                     ['b' => 'z'],
                     ['b' => 'c']
                 ]]),
-                ['argument' => 'a[].b', 'expected' => 'c'],
-                false
+                'acceptor' => ['argument' => 'a[].b', 'expected' => 'c'],
+                'expected' => false,
             ],
-            [
-                'matchesPathAny',
-                null,
-                [],
-                false
+            'matches_path_all_4_empty_array_as_result' => [
+                'matcher' => 'matchesPathAll',
+                'result' =>  $this->getMockResult(),
+                'acceptor' => ['argument' => 'a', 'expected' => 'c'],
+                'expected' => false,
             ],
-            [
-                'matchesPathAny',
-                $this->getMockResult([
+            'matches_path_all_4_non_array_value_as_result' => [
+                'matcher' => 'matchesPathAll',
+                'result' =>  $this->getMockResult(['a' => 'FooValue']),
+                'acceptor' => ['argument' => 'a[].b', 'expected' => 'c'],
+                'expected' => false,
+            ],
+            'matches_path_any_1' => [
+                'matcher' => 'matchesPathAny',
+                'result' =>  null,
+                'acceptor' => [],
+                'expected' => false,
+            ],
+            'matches_path_any_2' => [
+                'matcher' => 'matchesPathAny',
+                'result' =>  $this->getMockResult([
                     'a' => [
                         ['b' => 'c'],
                         ['b' => 'd'],
                         ['b' => 'e']
                     ]
                 ]),
-                ['argument' => 'a[].b', 'expected' => 'c'],
-                true
+                'acceptor' => ['argument' => 'a[].b', 'expected' => 'c'],
+                'expected' => true,
             ],
-            [
-                'matchesPathAny',
-                $this->getMockResult([
+            'matches_path_any_3' => [
+                'matcher' => 'matchesPathAny',
+                'result' =>  $this->getMockResult([
                     'a' => [
                         ['b' => 'x'],
                         ['b' => 'y'],
                         ['b' => 'z']
                     ]
                 ]),
-                ['argument' => 'a[].b', 'expected' => 'c'],
-                false
+                'acceptor' => ['argument' => 'a[].b', 'expected' => 'c'],
+                'expected' => false,
             ],
-            [
-                'matchesStatus',
-                null,
-                [],
-                false
+            'matches_path_any_4_empty_array_as_result' => [
+                'matcher' => 'matchesPathAny',
+                'result' =>  $this->getMockResult(),
+                'acceptor' => ['argument' => 'a', 'expected' => 'c'],
+                'expected' => false,
             ],
-            [
-                'matchesStatus',
-                $this->getMockResult(),
-                ['expected' => 200],
-                true
+            'matches_path_any_5_non_array_value_as_result' => [
+                'matcher' => 'matchesPathAll',
+                'result' =>  $this->getMockResult(['a' => 'FooValue']),
+                'acceptor' => ['argument' => 'a[].b', 'expected' => 'c'],
+                'expected' => false,
             ],
-            [
-                'matchesStatus',
-                $this->getMockResult(),
-                ['expected' => 400],
-                false
+            'matches_status_1' => [
+                'matcher' => 'matchesStatus',
+                'result' =>  null,
+                'acceptor' => [],
+                'expected' => false,
             ],
-            [
-                'matchesError',
-                null,
-                [],
-                false
+            'matches_status_2' => [
+                'matcher' => 'matchesStatus',
+                'result' =>  $this->getMockResult(),
+                'acceptor' => ['expected' => 200],
+                'expected' => true,
             ],
-            [
-                'matchesError',
-                $this->getMockResult('InvalidData'),
-                ['expected' => 'InvalidData'],
-                true
+            'matches_status_3' => [
+                'matcher' => 'matchesStatus',
+                'result' =>  $this->getMockResult(),
+                'acceptor' => ['expected' => 400],
+                'expected' => false,
             ],
-            [
-                'matchesError',
-                $this->getMockResult('InvalidData'),
-                ['expected' => 'Foo'],
-                false
+            'matches_error_1' => [
+                'matcher' => 'matchesError',
+                'result' =>  null,
+                'acceptor' => [],
+                'expected' => false,
+            ],
+            'matches_error_2' => [
+                'matcher' => 'matchesError',
+                'result' =>  $this->getMockResult('InvalidData'),
+                'acceptor' => ['expected' => 'InvalidData'],
+                'expected' => true,
+            ],
+            'matches_error_3' => [
+                'matcher' => 'matchesError',
+                'result' =>  $this->getMockResult('InvalidData'),
+                'acceptor' => ['expected' => 'Foo'],
+                'expected' => false,
             ],
         ];
     }
@@ -532,6 +577,7 @@ EOXML;
     /**
      * Creates a test waiter.
      *
+     * @param array $acceptors
      * @param string $operation
      * @param array $commandArgs
      * @param AwsClientInterface $client


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Makes matchesPath to return false when the result value does not match the same value and type as the expected value.
- Makes matchesPathAll to return false when an empty array or a non-array value is resolved by the jmespath evaluator.
- Makes matchesPathAny to return false when a non-array value is resolved by the jmespath evaluator.

This change also refactor the test case providers so that they are more idiomatic by naming them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
