### PR TITLE
fix: prevent 200 error parsing

### DIFF
--- a/.changes/nextrelease/fix-skip-non-seekable-responses.json
+++ b/.changes/nextrelease/fix-skip-non-seekable-responses.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "",
+        "description": "Avoid evaluating 200 errors for responses where its body is not seekable."
+    }
+]

--- a/src/S3/Parser/S3Parser.php
+++ b/src/S3/Parser/S3Parser.php
@@ -10,8 +10,6 @@ use Aws\Api\StructureShape;
 use Aws\CommandInterface;
 use Aws\Exception\AwsException;
 use Aws\ResultInterface;
-use GuzzleHttp\Psr7\NoSeekStream;
-use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 

--- a/src/S3/Parser/S3Parser.php
+++ b/src/S3/Parser/S3Parser.php
@@ -10,6 +10,7 @@ use Aws\Api\StructureShape;
 use Aws\CommandInterface;
 use Aws\Exception\AwsException;
 use Aws\ResultInterface;
+use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -101,9 +102,10 @@ final class S3Parser extends AbstractParser
     {
         // This error parsing should be just for 200 error responses
         // and operations where its output shape does not have a streaming
-        // member.
+        // member and the body of the response is seekable.
         if (200 !== $response->getStatusCode()
-            || !$this->shouldBeConsidered200Error($command->getName())) {
+            || !$this->shouldBeConsidered200Error($command->getName())
+            || !$response->getBody()->isSeekable()) {
             return;
         }
 

--- a/tests/S3/Parser/S3ParserTest.php
+++ b/tests/S3/Parser/S3ParserTest.php
@@ -11,8 +11,11 @@ use Aws\HandlerList;
 use Aws\ResultInterface;
 use Aws\S3\Parser\S3Parser;
 use Aws\S3\Parser\S3ResultMutator;
+use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class S3ParserTest extends TestCase
@@ -244,6 +247,56 @@ EOXML;
         $s3Parser->removeS3ResultMutator($s3MutatorName);
         $mutators = $s3Parser->getS3ResultMutators();
         $this->assertFalse(isset($mutators[$s3MutatorName]));
+    }
+
+    /**
+     * @param StreamInterface $stream
+     * @param bool $expectValidation
+     *
+     * @dataProvider validate200ErrorValidationJustInSeekableStreamsProvider
+     *
+     * @return void
+     */
+    public function testValidate200ErrorValidationJustInSeekableStreams(
+        StreamInterface $stream,
+        bool $expectValidation
+    ): void {
+        if ($expectValidation) {
+            $this->expectException(AwsException::class);
+            $this->expectExceptionMessage(
+                'We encountered an internal error. Please try again.'
+            );
+        } else {
+            $this->assertTrue(true);
+        }
+
+        $s3Parser = $this->getS3Parser();
+        $command = new Command('HeadObject', [], new HandlerList());
+        $response = new Response(
+            200,
+            [],
+            $stream
+        );
+        $s3Parser($command, $response);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function validate200ErrorValidationJustInSeekableStreamsProvider(): array
+    {
+        return [
+            'seekable_stream_1' => [
+                'stream' => Utils::streamFor(self::INTERNAL_S3200_ERROR),
+                'expectValidation' => true,
+            ],
+            'no_seekable_stream_1' => [
+                'stream' => new NoSeekStream(
+                    Utils::streamFor(self::INTERNAL_S3200_ERROR)
+                ),
+                'expectValidation' => false,
+            ]
+        ];
     }
 
     private function getS3Parser(): S3Parser

--- a/tests/S3/Parser/S3ParserTest.php
+++ b/tests/S3/Parser/S3ParserTest.php
@@ -260,7 +260,8 @@ EOXML;
     public function testValidate200ErrorValidationJustInSeekableStreams(
         StreamInterface $stream,
         bool $expectValidation
-    ): void {
+    ): void
+    {
         if ($expectValidation) {
             $this->expectException(AwsException::class);
             $this->expectExceptionMessage(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prevent 200 errors parsing in responses where its body stream is not seekable. By specification streamable operations should be skipped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
