### PR TITLE
chore: remove geoplaces smoke test

### DIFF
--- a/features/smoke/geoplaces.feature
+++ b/features/smoke/geoplaces.feature
@@ -1,8 +1,0 @@
-# language: en
-@smoke @geoplaces
-Feature: Amazon Location Service Places V2
-
-  Scenario: Handling errors
-    When I attempt to call the "GetPlace" API with:
-      | PlaceId | foo |
-    Then I expect the response error code to be "ValidationException"


### PR DESCRIPTION
*Description of changes:*
Removes smoke test which suddenly started throwing `AccessDeniedException`s instead of the expected `ValidationException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
