### PR TITLE
Changing the return type of getLastRequest to include null

### DIFF
--- a/src/MockHandler.php
+++ b/src/MockHandler.php
@@ -118,7 +118,7 @@ class MockHandler implements \Countable
     /**
      * Get the last received request.
      *
-     * @return RequestInterface
+     * @return RequestInterface|null
      */
     public function getLastRequest()
     {


### PR DESCRIPTION
In this pull request, I have updated the PHPDoc return type to explicitly include `null`, reflecting that the function may return `null` in certain cases. This change helps to avoid raising PHPStan error `method.impossibleType` when asserting that the last request was `null`.