### PR TITLE
enhancement: treat credential retrieval failures as non-terminal during auth selection

### DIFF
--- a/.changes/nextrelease/auth-selection-updates.json
+++ b/.changes/nextrelease/auth-selection-updates.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Auth",
+    "description": "Updates auth selection behavior to treat credential retrieval errors as non-terminal."
+  }
+]

--- a/tests/Auth/AuthSelectionMiddlewareTest.php
+++ b/tests/Auth/AuthSelectionMiddlewareTest.php
@@ -88,11 +88,6 @@ class AuthSelectionMiddlewareTest extends TestCase
                 ['smithy.api#noAuth'],
                 'anonymous'
             ],
-            [
-                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
-                ['aws.auth#sigv4a'],
-                'error'
-            ],
         ];
     }
 
@@ -235,43 +230,8 @@ class AuthSelectionMiddlewareTest extends TestCase
                     );
                 },
                 'bearer'
-            ],
-            [
-                ['aws.auth#sigv4', 'aws.auth#sigv4a'],
-                ['smithy.api#httpBearerAuth'],
-                function () {
-                    return Promise\Create::promiseFor(
-                        null
-                    );
-                },
-                'error'
-            ],
+            ]
         ];
-    }
-
-    public function testUnknownAuthSchemeThrows()
-    {
-        $this->expectException(UnresolvedAuthSchemeException::class);
-        $this->expectExceptionMessage(
-            'Could not resolve an authentication scheme: The service does not support `notAnAuthScheme` authentication.'
-        );
-
-        $nextHandler = function (CommandInterface $command) {
-            return null;
-        };
-        $service = $this->generateTestService(['notAnAuthScheme'], []);
-        $credentialProvider = function () {
-            return Promise\Create::promiseFor(
-               null
-            );
-        };
-        $authResolver = new AuthSchemeResolver($credentialProvider);
-        $client = $this->generateTestClient($service);
-        $command = $client->getCommand('fooOperation', ['FooParam' => 'bar']);
-
-        $middleware = new AuthSelectionMiddleware($nextHandler, $authResolver, $service);
-
-        $middleware($command);
     }
 
     public function testCommandOverrideResolver()


### PR DESCRIPTION
*Issue #, if available:*
Closes #3105, #3097 

*Description of changes:*
Update which swallows exception in the event of credential retrieval errors during auth selection.  Credentials may not always be available during this stage in the request lifecycle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
