### PR TITLE
Update DocModel.php

### DIFF
--- a/src/Api/DocModel.php
+++ b/src/Api/DocModel.php
@@ -90,8 +90,10 @@ class DocModel
 
         $result = '';
         $d = $this->docs['shapes'][$shapeName];
-        if (isset($d['refs']["{$parentName}\${$ref}"])) {
-            $result = $d['refs']["{$parentName}\${$ref}"];
+        $refs = $d['refs'] ?? [];
+        $key = $parentName . '$' . $ref;
+        if (isset($refs[$key])) {
+            $result = $refs[$key];
         } elseif (isset($d['base'])) {
             $result = $d['base'];
         }


### PR DESCRIPTION
${} for string interpolation inside double quotes in PHP is deprecated

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
