### PR TITLE
Fix "X-Amz-User-Agent" in blacklist

### DIFF
--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -67,7 +67,7 @@ class SignatureV4 implements SignatureInterface
             'from'                  => true,
             'referer'               => true,
             'user-agent'            => true,
-            'X-Amz-User-Agent'      => true,
+            'x-amz-user-agent'      => true,
             'x-amzn-trace-id'       => true,
             'aws-sdk-invocation-id' => true,
             'aws-sdk-retry'         => true,


### PR DESCRIPTION
The header blacklist contains lowercase header names only, except "X-Amz-User-Agent". This causes this header not to be filtered out, leading to an error with some proxies that remove the empty header:
> There were headers present in the request which were not signed.

This commit lowercases the header, which correctly removes the header from the signature.

Related: https://github.com/aws/aws-sdk-php/pull/2259
Resolves: https://github.com/aws/aws-sdk-php/issues/3119

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
