### PR TITLE
fix: fix x-amzn-query-mode header

### DIFF
--- a/.changes/nextrelease/fix-query-header-mode.json
+++ b/.changes/nextrelease/fix-query-header-mode.json
@@ -1,7 +1,7 @@
 [
   {
-    "type": "bugfix",
+    "type": "enhancement",
     "category": "",
-    "description": "Sets the header x-amzn-query-mode to a string value instead of a boolean one."
+    "description": "Sets the header `x-amzn-query-mode` to a string value instead of a boolean."
   }
 ]

--- a/.changes/nextrelease/fix-query-header-mode.json
+++ b/.changes/nextrelease/fix-query-header-mode.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Sets the header x-amzn-query-mode to a string value instead of a boolean one."
+  }
+]

--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -540,7 +540,7 @@ class AwsClient implements AwsClientInterface
             Middleware::mapRequest(function (RequestInterface $r) {
                 return $r->withHeader(
                     'x-amzn-query-mode',
-                    true
+                    "true"
                 );
             }),
             'x-amzn-query-mode-header'

--- a/tests/AwsClientTest.php
+++ b/tests/AwsClientTest.php
@@ -994,7 +994,7 @@ EOT
         $list->setHandler(new MockHandler([new Result()]));
         $list->appendSign(Middleware::tap(function ($cmd, $req) {
             $this->assertTrue($req->hasHeader('x-amzn-query-mode'));
-            $this->assertEquals(true, $req->getHeaderLine('x-amzn-query-mode'));
+            $this->assertEquals("true", $req->getHeaderLine('x-amzn-query-mode'));
         }));
         $client->TestOperation();
     }

--- a/tests/Integ/CredentialsContext.php
+++ b/tests/Integ/CredentialsContext.php
@@ -20,6 +20,8 @@ class CredentialsContext extends Assert implements
     private static $credentialsFile;
     private static $roleName;
     private static $roleArn;
+    private $credentials;
+    private $client;
 
     /**
      * @BeforeFeature @credentials


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change makes the `x-amzn-query-mode` header to be a string value instead of a boolean one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
