### PR TITLE
Fixed missing hyperlink in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Please ensure that your bug report has the following:
 
 ## Feature Requests
 
-Open an [issue][] with the following:
+Open an [issue][issues] with the following:
 
 * A short, descriptive title. Ideally, other community members should be able to get a 
    good idea of the feature just from reading the title.


### PR DESCRIPTION
*Issue #, if available:*
Under "Feature Requests" in CONTRIBUTING.md, there was a missing hyperlink associated with "issue"

*Description of changes:*
Linked the missing hyperlink for "issue" to [https://github.com/aws/aws-sdk-php/issues](https://github.com/aws/aws-sdk-php/issues)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
