### PR TITLE
fix: remove static declaration

### DIFF
--- a/src/S3/Parser/GetBucketLocationResultMutator.php
+++ b/src/S3/Parser/GetBucketLocationResultMutator.php
@@ -28,7 +28,7 @@ final class GetBucketLocationResultMutator implements S3ResultMutator
             return $result;
         }
 
-        static $location = 'us-east-1';
+        $location = 'us-east-1';
         static $pattern = '/>(.+?)<\/LocationConstraint>/';
         if (preg_match($pattern, $response->getBody(), $matches)) {
             $location = $matches[1] === 'EU' ? 'eu-west-1' : $matches[1];


### PR DESCRIPTION
*Issue #3134*

*Description of changes:*
- By making `$location` static we were forcing the field `LocationConstraint` in the result to be always `us-east-1`. Therefore, we are removing the static declaration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
