### PR TITLE
Code Formatting Improvements

### DIFF
--- a/compatibility-test.php
+++ b/compatibility-test.php
@@ -33,7 +33,7 @@ class CompatibilityTest
     public function title($text)
     {
         $this->lines[] = $this->isCli
-            ?  "\n" . $text . "\n" . str_repeat('-', strlen($text)) . "\n"
+            ? "\n" . $text . "\n" . str_repeat('-', strlen($text)) . "\n"
             : "<h2>{$text}</h2>";
     }
 

--- a/src/IdempotencyTokenMiddleware.php
+++ b/src/IdempotencyTokenMiddleware.php
@@ -11,8 +11,10 @@ class IdempotencyTokenMiddleware
 {
     /** @var Service */
     private $service;
+
     /** @var string */
     private $bytesGenerator;
+
     /** @var callable */
     private $nextHandler;
 
@@ -23,7 +25,7 @@ class IdempotencyTokenMiddleware
      * One of following functions needs to be available
      * in order to generate random bytes used for UUID
      * (SDK will attempt to utilize function in following order):
-     *  - random_bytes (requires PHP 7.0 or above) 
+     *  - random_bytes (requires PHP 7.0 or above)
      *  - openssl_random_pseudo_bytes (requires 'openssl' module enabled)
      *  - mcrypt_create_iv (requires 'mcrypt' module enabled)
      *

--- a/src/InputValidationMiddleware.php
+++ b/src/InputValidationMiddleware.php
@@ -10,7 +10,6 @@ use Aws\Api\Service;
  */
 class InputValidationMiddleware
 {
-
     /** @var callable */
     private $nextHandler;
 
@@ -58,7 +57,7 @@ class InputValidationMiddleware
                 if (!empty($input['required'])) {
                     foreach ($input['required'] as $key => $member) {
                         if (in_array($member, $this->mandatoryAttributeList)) {
-                            $argument = is_string($cmd[$member]) ?  trim($cmd[$member]) : $cmd[$member];
+                            $argument = is_string($cmd[$member]) ? trim($cmd[$member]) : $cmd[$member];
                             if ($argument === '' || $argument === null) {
                                 $commandName = $cmd->getName();
                                 throw new \InvalidArgumentException(

--- a/src/MonitoringEventsInterface.php
+++ b/src/MonitoringEventsInterface.php
@@ -6,7 +6,6 @@ namespace Aws;
  */
 interface MonitoringEventsInterface
 {
-
     /**
      * Get client-side monitoring events attached to this object. Each event is
      * represented as an associative array within the returned array.
@@ -28,5 +27,4 @@ interface MonitoringEventsInterface
      * @param array $event
      */
     public function appendMonitoringEvent(array $event);
-
 }

--- a/src/MultiRegionClient.php
+++ b/src/MultiRegionClient.php
@@ -12,18 +12,25 @@ class MultiRegionClient implements AwsClientInterface
 
     /** @var AwsClientInterface[] A pool of clients keyed by region. */
     private $clientPool = [];
+
     /** @var callable */
     private $factory;
+
     /** @var PartitionInterface */
     private $partition;
+
     /** @var array */
     private $args;
+
     /** @var array */
     private $config;
+
     /** @var HandlerList */
     private $handlerList;
+
     /** @var array */
     private $aliases;
+
     /** @var callable */
     private $customHandler;
 

--- a/src/QueryCompatibleInputMiddleware.php
+++ b/src/QueryCompatibleInputMiddleware.php
@@ -17,7 +17,6 @@ use Closure;
  */
 class QueryCompatibleInputMiddleware
 {
-
     /** @var callable */
     private $nextHandler;
 


### PR DESCRIPTION
Description
---
This PR introduces minor formatting adjustments to improve code consistency across the codebase. Specifically:

- Ensures only one space is used after the `?` in ternary operators, aligning with common style conventions.
- Enforces one blank line between class properties to improve readability and structure.
- Removes unnecessary blank lines after opening class braces.

These changes do not affect functionality but enhance the maintainability and consistency of the codebase.

Recommendation
---
To prevent manual inconsistencies like these in the future, I suggest integrating an automatic code formatter (e.g., PHP CS Fixer, Pint) into the CI pipeline. This ensures:

- All code is automatically formatted on every PR or push.
- Developers can focus on logic, not spacing or style issues.
- The codebase remains clean and consistent without extra manual effort.