### PR TITLE
chore: yield dynamic test cases

### DIFF
--- a/tests/Api/Parser/DecodingEventStreamIteratorTest.php
+++ b/tests/Api/Parser/DecodingEventStreamIteratorTest.php
@@ -13,10 +13,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 class DecodingEventStreamIteratorTest extends TestCase
 {
-    public function complianceTests()
+    public function complianceTests(): \Generator
     {
-        $cases = [];
-
         $dataFilesIterator = \Aws\recursive_dir_iterator(
             realpath(__DIR__ . '/../test_cases/eventstream/encoded/')
         );
@@ -25,7 +23,7 @@ class DecodingEventStreamIteratorTest extends TestCase
                 continue;
             }
 
-            $case = [
+            yield [
                 Psr7\Utils::streamFor(
                     file_get_contents($file)
                 ),
@@ -36,11 +34,7 @@ class DecodingEventStreamIteratorTest extends TestCase
                 ),
                 stripos($file, 'negative') !== false
             ];
-
-            $cases []= $case;
         }
-
-        return $cases;
     }
 
     /**

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -6,7 +6,6 @@ use Aws\Auth\AuthSchemeResolverInterface;
 use Aws\ClientResolver;
 use Aws\ClientSideMonitoring\Configuration;
 use Aws\ClientSideMonitoring\ConfigurationProvider;
-use Aws\CommandInterface;
 use Aws\Configuration\ConfigurationResolver;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
@@ -18,7 +17,6 @@ use Aws\Exception\InvalidRegionException;
 use Aws\LruArrayCache;
 use Aws\S3\S3Client;
 use Aws\HandlerList;
-use Aws\Sdk;
 use Aws\Result;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
@@ -1510,7 +1508,6 @@ EOF;
             }
         } finally {
             unlink($configFile);
-            rmdir($awsDir);
             if ($currentEnvConfigFile) {
                 putenv(
                     ConfigurationResolver::ENV_CONFIG_FILE

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -193,14 +193,16 @@ class EcsCredentialProviderTest extends TestCase
         }
     }
 
-    public function uriAndTokenResolutionProvider()
+    public function uriAndTokenResolutionProvider(): \Generator
     {
         $cases = json_decode(file_get_contents(
             __DIR__ . '/fixtures/ecs/uri-token-resolution.json')
             , true
         );
 
-        return array_map(function ($case) { return [$case]; }, $cases);
+        foreach ($cases as $case) {
+            yield [$case];
+        }
     }
 
     private function getCredentialArray(

--- a/tests/EndpointV2/EndpointProviderV2Test.php
+++ b/tests/EndpointV2/EndpointProviderV2Test.php
@@ -4,7 +4,6 @@ namespace Aws\Test\EndpointV2;
 use Aws\Api\Service;
 use Aws\Auth\Exception\UnresolvedAuthSchemeException;
 use Aws\AwsClient;
-use Aws\Credentials\Credentials;
 use Aws\EndpointV2\EndpointDefinitionProvider;
 use Aws\EndpointV2\EndpointProviderV2;
 use Aws\EndpointV2\Ruleset\Ruleset;
@@ -13,7 +12,6 @@ use Aws\Exception\CommonRuntimeException;
 use Aws\Exception\UnresolvedEndpointException;
 use Aws\Middleware;
 use Aws\Test\UsesServiceTrait;
-use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Uri;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
@@ -28,7 +26,7 @@ class EndpointProviderV2Test extends TestCase
      * Iterates through test cases located in ../test-cases and
      * ../valid-rules, parses into parameters used for endpoint and error tests
      */
-    public function basicTestCaseProvider()
+    public function basicTestCaseProvider(): \Generator
     {
         $testfileNames = [
             "aws-region",
@@ -45,7 +43,6 @@ class EndpointProviderV2Test extends TestCase
             "valid-hostlabel",
             "string-array"
         ];
-        $providerCases = [];
 
         foreach ($testfileNames as $testFile) {
             $casesPath = __DIR__ . '/test-cases/' . $testFile . '.json';
@@ -64,11 +61,10 @@ class EndpointProviderV2Test extends TestCase
                     $providerCase[] = 'false';
                 }
                 array_push($providerCase, $inputParams, $expected);
-                $providerCases[] = $providerCase;
+
+                yield $providerCase;
             }
         }
-
-        return $providerCases;
     }
 
     /**
@@ -107,9 +103,8 @@ class EndpointProviderV2Test extends TestCase
      * Iterates through test cases located in each service's endpoint test file.
      * Parses into parameters used for endpoint and error tests
      */
-    public function serviceTestCaseProvider()
+    public function serviceTestCaseProvider(): \Generator
     {
-        $serviceTestCases = [];
         $services = \Aws\Manifest();
 
         foreach($services as $service => $data) {
@@ -128,11 +123,10 @@ class EndpointProviderV2Test extends TestCase
                     $testCase[] = 'false';
                 }
                 array_push($testCase, $inputParams, $expected);
-                $serviceTestCases[] = $testCase;
+
+                yield $testCase;
             }
         }
-
-        return $serviceTestCases;
     }
 
     /**
@@ -441,19 +435,17 @@ class EndpointProviderV2Test extends TestCase
         }
     }
 
-    public function stringArrayOperationInputsProvider()
+    public function stringArrayOperationInputsProvider(): \Generator
     {
         $cases = json_decode(
             file_get_contents(__DIR__ . '/test-cases/string-array.json'),
             true
         );
-        $providerCases = [];
 
         foreach ($cases['testCases'] as $case) {
             unset($case['documentation']);
-            $providerCases[] = $case;
-        }
 
-        return $providerCases;
+            yield $case;
+        }
     }
 }


### PR DESCRIPTION
*Description of changes:*

Switches over to generator-based yields for test cases constructed from fixture files; Removes unnecessary `rmdir()` call causing errors. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
