### PR TITLE
bugfix: rest-xml payload member serialization

### DIFF
--- a/.changes/nextrelease/fix-xml-serialiation.json
+++ b/.changes/nextrelease/fix-xml-serialiation.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Api",
+    "description": "Fixes bug caused by #3144 which causes requests with payload members to resolve the wrong root xml element"
+  }
+]

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -168,15 +168,6 @@ abstract class RestSerializer
             return;
         }
 
-        // Payload members have special rules for locationName handling
-        // they should use their member-level locationName
-        // if it differs from the member name.
-        $type = $m->getType();
-        if ($type === 'structure') {
-            // Mark this as a payload member with its member name
-            $m['__payloadMemberName'] = $name;
-        }
-
         $this->payload($m, $args[$name], $opts);
     }
 

--- a/tests/Api/Serializer/ComplianceTest.php
+++ b/tests/Api/Serializer/ComplianceTest.php
@@ -29,6 +29,14 @@ class ComplianceTest extends TestCase
         'NullAndEmptyHeaders' => true,
         'RestJsonHttpChecksumRequired' => true,
         'MediaTypeHeaderInputBase64' => true,
+        // For payload members, the behavior prescribed by Smithy
+        // contradicts expected behavior in actual AWS Services.
+        // See S3 PutBucketLifecycleConfiguration
+        'XmlAttributesOnPayload' => true,
+        'HttpPayloadWithXmlNamespaceAndPrefix' => true,
+        'HttpPayloadWithXmlNamespace' => true,
+        'RestXmlHttpPayloadWithUnion' => true,
+        'HttpPayloadWithMemberXmlName' => true
     ];
 
     /** @doesNotPerformAssertions */


### PR DESCRIPTION
*Issue #, if available:*
Closes #3153 

*Description of changes:*
Reverts to previous behavior when resolving root element names with requests that specify a payload member.  The behavior prescribed by smithy in the cases added in #3144 contradict expected behavior in actual AWS services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
