### PR TITLE
bugfix: xmlparser locationname resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.351.11 - 2025-07-31
+
+* `Aws\Api` - Fixes bug in resolving `locationName` properties for query services
+
 ## 3.351.10 - 2025-07-30
 
 * `Aws\Api` - Updates for deserialization in all protocols

--- a/src/Api/Parser/XmlParser.php
+++ b/src/Api/Parser/XmlParser.php
@@ -76,10 +76,15 @@ class XmlParser
 
     private function memberKey(Shape $shape, $name)
     {
-        // Only use locationName for non-structure shapes
-        // For structures referenced as members, always use the member name
-        if ($shape instanceof StructureShape) {
-            return $name;
+        // Check if locationName came from shape definition
+        if ($shape instanceof StructureShape && isset($shape['locationName'])) {
+            $originalDef = $shape->getOriginalDefinition($shape->getName());
+
+            if ($originalDef && isset($originalDef['locationName'])
+                && $originalDef['locationName'] === $shape['locationName']
+            ) {
+                return $name;
+            }
         }
 
         return $shape['locationName'] ?? $name;

--- a/src/Api/StructureShape.php
+++ b/src/Api/StructureShape.php
@@ -82,6 +82,18 @@ class StructureShape extends Shape
         return $this->shapeMap;
     }
 
+    /**
+     * Used to look up a shape's original definition.
+     *
+     * @param string $name
+     *
+     * @return array|null
+     */
+    public function getOriginalDefinition(string $name): ?array
+    {
+        return $this->shapeMap[$name] ?? null;
+    }
+
     private function generateMembersHash()
     {
         $this->members = [];

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -831,7 +831,7 @@ namespace Aws;
  */
 class Sdk
 {
-    const VERSION = '3.351.10';
+    const VERSION = '3.351.11';
 
     /** @var array Arguments for creating clients */
     private $args;

--- a/tests/Ec2/Ec2ClientTest.php
+++ b/tests/Ec2/Ec2ClientTest.php
@@ -1,9 +1,11 @@
 <?php
 namespace Aws\Test\Ec2;
 
+use Aws\Api\Parser\QueryParser;
 use Aws\Ec2\Ec2Client;
 use Aws\MockHandler;
 use Aws\Result;
+use Aws\Test\UsesServiceTrait;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -13,6 +15,8 @@ use Psr\Http\Message\RequestInterface;
  */
 class Ec2ClientTest extends TestCase
 {
+    use UsesServiceTrait;
+
     public function testAddsCopySnapshotMiddleware()
     {
         $ec2 = new Ec2Client([
@@ -111,5 +115,82 @@ EOF;
         $ec2Client->describeFleets([
             'Filters' => []
         ]);
+    }
+
+    public function testDescribeInstanceStatusParsesInstanceStateCorrectly()
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<DescribeInstanceStatusResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>3be1508e-c444-4fef-89cc-0b1223c4f02fEXAMPLE</requestId>
+    <instanceStatusSet>
+        <item>
+            <instanceId>i-1234567890abcdef0</instanceId>
+            <availabilityZone>us-east-1d</availabilityZone>
+            <instanceState>
+                <code>16</code>
+                <name>running</name>
+            </instanceState>
+            <systemStatus>
+                <status>ok</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>passed</status>
+                    </item>
+                </details>
+            </systemStatus>
+            <instanceStatus>
+                <status>ok</status>
+                <details>
+                    <item>
+                        <name>reachability</name>
+                        <status>passed</status>
+                    </item>
+                </details>
+            </instanceStatus>
+        </item>
+    </instanceStatusSet>
+</DescribeInstanceStatusResponse>
+XML;
+
+        $ec2 = new Ec2Client([
+            'region'  => 'us-east-1',
+            'version' => 'latest',
+            'credentials' => [
+                'key' => 'foo',
+                'secret' => 'bar'
+            ]
+        ]);
+
+        $command = $ec2->getCommand('DescribeInstanceStatus');
+        $parser = new QueryParser($ec2->getApi());
+        $response = new Response(200, [], $xml);
+        $this->addMockResults($ec2, [$parser($command, $response)]);
+
+        $result = $ec2->describeInstanceStatus([
+            'InstanceIds' => ['i-1234567890abcdef0']
+        ]);
+
+        $this->assertArrayHasKey('InstanceStatuses', $result);
+        $this->assertCount(1, $result['InstanceStatuses']);
+
+        $instanceStatus = $result['InstanceStatuses'][0];
+
+        // Verify basic fields
+        $this->assertEquals('i-1234567890abcdef0', $instanceStatus['InstanceId']);
+        $this->assertEquals('us-east-1d', $instanceStatus['AvailabilityZone']);
+
+        // InstanceState should be present
+        $this->assertArrayHasKey('InstanceState', $instanceStatus);
+        $this->assertEquals(16, $instanceStatus['InstanceState']['Code']);
+        $this->assertEquals('running', $instanceStatus['InstanceState']['Name']);
+
+        // Verify other nested structures work too
+        $this->assertArrayHasKey('SystemStatus', $instanceStatus);
+        $this->assertEquals('ok', $instanceStatus['SystemStatus']['Status']);
+
+        $this->assertArrayHasKey('InstanceStatus', $instanceStatus);
+        $this->assertEquals('ok', $instanceStatus['InstanceStatus']['Status']);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #3155 

*Description of changes:*
Fixes bug in `XmlParser` where a structure shape's `locationName` could be overwritten by `ShapeMap::resolve()`.  Adds a unit test on an affected operation and exposes functionality to find a structure shape's original definition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
