### PR TITLE
Fix eventstream partial read

### DIFF
--- a/.changes/nextrelease/fix-eventstream-partial-read.json
+++ b/.changes/nextrelease/fix-eventstream-partial-read.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "",
+        "description": "Fixed an issue in NonSeekableStreamDecodingEventStreamIterator where partial reads from non-seekable streams could result in truncated payloads and CRC mismatches."
+    }
+]

--- a/tests/Api/Parser/NonSeekableStreamDecodingEventStreamIteratorTest.php
+++ b/tests/Api/Parser/NonSeekableStreamDecodingEventStreamIteratorTest.php
@@ -5,6 +5,7 @@ namespace Aws\Test\Api\Parser;
 use Aws\Api\Parser\NonSeekableStreamDecodingEventStreamIterator;
 use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\StreamInterface;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class NonSeekableStreamDecodingEventStreamIteratorTest extends TestCase
@@ -67,4 +68,132 @@ EOF;
         $iterator->next();
         $this->assertFalse($iterator->valid());
     }
+
+    public function testReadAndHashBytesHandlesPartialReads()
+    {
+        $payload = str_repeat('A', 1024);
+        $stream = new NoSeekStream(new PartialReadStream($payload));
+
+        $iterator = new NonSeekableStreamDecodingEventStreamIterator($stream);
+
+        $reflect = new \ReflectionClass($iterator);
+        $hashContextProperty = $reflect->getProperty('hashContext');
+        $hashContextProperty->setAccessible(true);
+        $hashContextProperty->setValue($iterator, hash_init('crc32c'));
+
+        $method = $reflect->getMethod('readAndHashBytes');
+        $method->setAccessible(true);
+        
+        $result = $method->invoke($iterator, 1024);
+
+        $this->assertEquals($payload, $result);
+    }
 }
+/**
+ * Simulates partial reads by limiting each read() call to a maximum number of bytes,
+ * regardless of what is requested.
+ */
+class PartialReadStream implements StreamInterface
+{
+    private string $data;
+    private int $position = 0;
+    private int $maxBytesPerRead;
+
+    public function __construct(string $data, int $maxBytesPerRead = 100)
+    {
+        $this->data = $data;
+        $this->maxBytesPerRead = $maxBytesPerRead;
+    }
+
+    public function __toString(): string
+    {
+        return $this->data;
+    }
+
+    public function close(): void
+    {
+        // No resources to close
+    }
+
+    public function detach()
+    {
+        return null;
+    }
+
+    public function getSize(): ?int
+    {
+        return strlen($this->data);
+    }
+
+    public function tell(): int
+    {
+        return $this->position;
+    }
+
+    public function eof(): bool
+    {
+        return $this->position >= strlen($this->data);
+    }
+
+    public function isSeekable(): bool
+    {
+        return false;
+    }
+
+    public function seek($offset, $whence = SEEK_SET): void
+    {
+        throw new \RuntimeException("Stream is not seekable");
+    }
+
+    public function rewind(): void
+    {
+        throw new \RuntimeException("Stream is not seekable");
+    }
+
+    public function isWritable(): bool
+    {
+        return false;
+    }
+
+    public function write($string): int
+    {
+        throw new \RuntimeException("Stream is not writable");
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function read($length): string
+    {
+        if ($this->eof()) {
+            return '';
+        }
+
+        // Read only up to maxBytesPerRead
+        $readLength = min($length, $this->maxBytesPerRead);
+        $chunk = substr($this->data, $this->position, $readLength);
+        $this->position += strlen($chunk);
+
+        return $chunk;
+    }
+
+    public function getContents(): string
+    {
+        if ($this->eof()) {
+            return '';
+        }
+
+        $contents = substr($this->data, $this->position);
+        $this->position = strlen($this->data);
+
+        return $contents;
+    }
+
+    public function getMetadata($key = null): mixed
+    {
+        return null;
+    }
+}
+


### PR DESCRIPTION
*Issue #, if available*
#3110 

*Description of changes:*
This pull request fixes a bug in `NonSeekableStreamDecodingEventStreamIterator` where `readAndHashBytes()` assumed that the underlying stream would always return the full number of requested bytes in a single `read(`) call.

In cases where the stream returns fewer bytes (e.g., partial reads from network streams or large payloads), this could result in truncated payloads and CRC mismatches.

The fix updates `readAndHashBytes()` to:

- Continue reading from the stream until the expected number of bytes have been read or the stream reaches EOF.
- Prevent infinite loops on unexpected empty reads.

A new unit test `testReadAndHashBytesHandlesPartialReads` has been added to verify this behavior by simulating a non-seekable stream that returns partial data in each `read()` call.

All tests pass with `make test`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
