### PR TITLE
bugfix: empty header value parsing

### DIFF
--- a/.changes/nextrelease/bugfix-empty-header-values.json
+++ b/.changes/nextrelease/bugfix-empty-header-values.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Api",
+    "description": "Bugfix for #3167 where zero or `false` is skipped in header parsing."
+  }
+]

--- a/src/Api/Parser/AbstractRestParser.php
+++ b/src/Api/Parser/AbstractRestParser.php
@@ -107,7 +107,7 @@ abstract class AbstractRestParser extends AbstractParser
     ) {
         $value = $response->getHeaderLine($shape['locationName'] ?: $name);
         // Empty headers should not be deserialized
-        if (empty($value)) {
+        if ($value === null || $value === '') {
             return;
         }
 
@@ -120,6 +120,7 @@ abstract class AbstractRestParser extends AbstractParser
                 };
                 break;
             case 'long':
+            case 'integer':
                 $value = (int) $value;
                 break;
             case 'boolean':

--- a/src/Api/Parser/MetadataParserTrait.php
+++ b/src/Api/Parser/MetadataParserTrait.php
@@ -18,7 +18,7 @@ trait MetadataParserTrait
     ) {
         $value = $response->getHeaderLine($shape['locationName'] ?: $name);
         // Empty values should not be deserialized
-        if (empty($value)) {
+        if ($value === null || $value === '') {
             return;
         }
 
@@ -28,6 +28,7 @@ trait MetadataParserTrait
                 $value = (float) $value;
                 break;
             case 'long':
+            case 'integer':
                 $value = (int) $value;
                 break;
             case 'boolean':

--- a/tests/Api/ErrorParser/RestJsonErrorParserTest.php
+++ b/tests/Api/ErrorParser/RestJsonErrorParserTest.php
@@ -228,6 +228,72 @@ class RestJsonErrorParserTest extends TestCase
                     'body' => [],
                 ]
             ],
+            // Test zero value in header
+            [
+                "HTTP/1.1 400 Bad Request\r\n" .
+                "TestHeader: 0\r\n" .
+                "x-amzn-requestid: xyz\r\n\r\n" .
+                '{ "code": "TestException" }',
+                $command,
+                new RestJsonErrorParser($service),
+                [
+                    'code'       => 'TestException',
+                    'type'       => 'client',
+                    'request_id' => 'xyz',
+                    'parsed'     => ['code' => 'TestException'],
+                    'body' => [
+                        'TestHeaderMember'  => '0',  // Zero preserved
+                        'TestHeaders'       => [],   // Empty array
+                        'TestStatus'        => 400,
+                    ],
+                    'message' => null,
+                    'error_shape' => $errorShape
+                ]
+            ],
+            // Test false value in header
+            [
+                "HTTP/1.1 400 Bad Request\r\n" .
+                "TestHeader: false\r\n" .
+                "x-amzn-requestid: xyz\r\n\r\n" .
+                '{ "code": "TestException" }',
+                $command,
+                new RestJsonErrorParser($service),
+                [
+                    'code'       => 'TestException',
+                    'type'       => 'client',
+                    'request_id' => 'xyz',
+                    'parsed'     => ['code' => 'TestException'],
+                    'body' => [
+                        'TestHeaderMember'  => 'false',  // False preserved
+                        'TestHeaders'       => [],        // Empty array
+                        'TestStatus'        => 400,
+                    ],
+                    'message' => null,
+                    'error_shape' => $errorShape
+                ]
+            ],
+            // Test empty string in header (should be skipped)
+            [
+                "HTTP/1.1 400 Bad Request\r\n" .
+                "TestHeader: \r\n" .
+                "x-amzn-requestid: xyz\r\n\r\n" .
+                '{ "code": "TestException" }',
+                $command,
+                new RestJsonErrorParser($service),
+                [
+                    'code'       => 'TestException',
+                    'type'       => 'client',
+                    'request_id' => 'xyz',
+                    'parsed'     => ['code' => 'TestException'],
+                    'body' => [
+                        // TestHeaderMember should NOT be present
+                        'TestHeaders'       => [],   // Empty array
+                        'TestStatus'        => 400,
+                    ],
+                    'message' => null,
+                    'error_shape' => $errorShape
+                ]
+            ]
         ];
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #3167 

*Description of changes:*
Loosens overly restrictive check for empty values when parsing headers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
