### PR TITLE
bugfix: update rds presigning

### DIFF
--- a/.changes/nextrelease/bugfix-rds-presign.json
+++ b/.changes/nextrelease/bugfix-rds-presign.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Rds",
+    "description": "Ensures `DestinationRegion` is signed during presigning."
+  }
+]

--- a/src/Rds/RdsClient.php
+++ b/src/Rds/RdsClient.php
@@ -357,6 +357,13 @@ class RdsClient extends AwsClient
                         'service' => 'rds',
                         'presign_param' => 'PreSignedUrl',
                         'require_different_region' => true,
+                        'extra_query_params' => [
+                            'CopyDBSnapshot' => ['DestinationRegion'],
+                            'CreateDBInstanceReadReplica' => ['DestinationRegion'],
+                            'CopyDBClusterSnapshot' => ['DestinationRegion'],
+                            'CreateDBCluster' => ['DestinationRegion'],
+                            'StartDBInstanceAutomatedBackupsReplication' => ['DestinationRegion']
+                        ]
                     ]
                 ),
                 'rds.presigner'


### PR DESCRIPTION
*Description of changes:*
Ensures `DestinationRegion` is signed during presigning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
