### PR TITLE
chore: revert empty body deserialization

### DIFF
--- a/.changes/nextrelease/rest-empty-body.json
+++ b/.changes/nextrelease/rest-empty-body.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "Api",
+    "description": "Reverts to previous behavior changed by #3146 when deserializing empty payload members."
+  }
+]

--- a/src/Api/Parser/AbstractRestParser.php
+++ b/src/Api/Parser/AbstractRestParser.php
@@ -91,7 +91,8 @@ abstract class AbstractRestParser extends AbstractParser
 
             $result[$payload] = [];
             $this->payload($response, $member, $result[$payload]);
-        } elseif (!$body->isSeekable() || $body->getSize()) {
+        } else {
+            // Always set the payload to the body stream, regardless of content
             $result[$payload] = $body;
         }
     }

--- a/tests/Api/Parser/ComplianceTest.php
+++ b/tests/Api/Parser/ComplianceTest.php
@@ -35,6 +35,11 @@ class ComplianceTest extends TestCase
         'Ec2QueryDateTimeWithFractionalSeconds' => true,
         'AwsJson11DateTimeWithFractionalSeconds' => true,
         'RestXmlDateTimeWithFractionalSeconds' => true,
+        // Certain packages depend on a non-empty payload field
+        // In particular, S3 where some packages always expect a 'Body'
+        // regardless of its contents (empty vs non-empty)
+        'HttpPayloadTraitsWithNoBlobBody' => true,
+        'RestJsonHttpPayloadTraitsWithNoBlobBody' => true,
         // previously we used a flattened list's target shape `locationName`
         // to determine flattened list location names. This contradicts the
         // behavior prescribed by Smithy, but only seems to have applied to


### PR DESCRIPTION
*Issue #, if available:*
Closes #3171, related to https://github.com/thephpleague/flysystem/issues/1875

*Description of changes:*
Reverts change to payload deserialization where empty payload members were not deserialized.  Updates protocol compliance tests and adds an S3-specific unit test ensuring `Body` is always deserialized, regardless of content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
