### PR TITLE
bugfix: refresh credentials that are about to expire

### DIFF
--- a/.changes/nextrelease/bugfix-refresh-credentials.json
+++ b/.changes/nextrelease/bugfix-refresh-credentials.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Credentials",
+    "description": "Updates `CredentialProvider::memoize()` to refresh credentials that within 1 minute of expiration."
+  }
+]

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -52,6 +52,7 @@ class CredentialProvider
     const ENV_SESSION = 'AWS_SESSION_TOKEN';
     const ENV_TOKEN_FILE = 'AWS_WEB_IDENTITY_TOKEN_FILE';
     const ENV_SHARED_CREDENTIALS_FILE = 'AWS_SHARED_CREDENTIALS_FILE';
+    public const REFRESH_WINDOW = 60;
 
     /**
      * Create a default credential provider that
@@ -224,10 +225,14 @@ class CredentialProvider
                         return $creds;
                     }
 
-                    // Refresh expired credentials.
-                    if (!$creds->isExpired()) {
+                    // Check if credentials are expired or will expire in 1 minute
+                    $needsRefresh = $creds->getExpiration() - time() <= self::REFRESH_WINDOW;
+
+                    // Refresh if expired or expiring soon
+                    if (!$needsRefresh && !$creds->isExpired()) {
                         return $creds;
                     }
+
                     // Refresh the result and forward the promise.
                     return $result = $provider($creds);
                 })


### PR DESCRIPTION
*Issue #, if available:*
Fixes #1714 

*Description of changes:*
Updates `CredentialProvider::memoize()` to attempt refreshes if credentials will expire within 5 minutes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
