### PR TITLE
bugfix: TokenProvider cache writes

### DIFF
--- a/.changes/nextrelease/bugfix-tokenprovider-cache.json
+++ b/.changes/nextrelease/bugfix-tokenprovider-cache.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Token",
+    "description": "Fixes bug in `TokenProvider::cache()` where tokens are incorrectly written to the cache."
+  }
+]

--- a/src/Token/TokenProvider.php
+++ b/src/Token/TokenProvider.php
@@ -212,7 +212,7 @@ class TokenProvider
                 ) {
                     $cache->set(
                         $cacheKey,
-                        $token,
+                        ['token' => $token],
                         null === $token->getExpiration() ?
                             0 : $token->getExpiration() - time()
                     );
@@ -269,4 +269,3 @@ class TokenProvider
         return new SsoTokenProvider($profileName, $filename, $ssoClient);
     }
 }
-


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3175 

*Description of changes:*
Fixes bug where `cache()` writes an incorrect format.

*Smoke and Integ test runs:*
```
vendor/bin/behat --format=progress --suite=smoke --tags='~@noassumerole'
...................................................................... 70
...................................................................... 140
...................................................................... 210
............

111 scenarios (111 passed)
222 steps (222 passed)
0m39.51s (95.43Mb)

vendor/bin/behat --format=progress --tags=integ
...................................................................... 70
...................................................................... 140
...................................................................... 210
......................................

66 scenarios (66 passed)
248 steps (248 passed)
5m37.38s (48.43Mb)
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
