### PR TITLE
bugfix: document type validation

### DIFF
--- a/.changes/nextrelease/bugfix-document-types.json
+++ b/.changes/nextrelease/bugfix-document-types.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Api",
+    "description": "Fixes bug in document type validation where unordered integer array keys are not considered."
+  }
+]

--- a/src/Api/Validator.php
+++ b/src/Api/Validator.php
@@ -248,17 +248,7 @@ class Validator
 
     private function checkArray($arr)
     {
-        return $this->isIndexed($arr) || $this->isAssociative($arr);
-    }
-
-    private function isAssociative($arr)
-    {
-        return count(array_filter(array_keys($arr), "is_string")) == count($arr);
-    }
-
-    private function isIndexed(array $arr)
-    {
-        return $arr == array_values($arr);
+        return array_is_list($arr) || Aws\is_associative($arr);
     }
 
     private function checkCanString($value)

--- a/src/functions.php
+++ b/src/functions.php
@@ -564,10 +564,5 @@ function is_associative(array $array): bool
         return false;
     }
 
-    if (function_exists('array_is_list')) {
-        return !array_is_list($array);
-    }
-
-    return array_keys($array) !== range(0, count($array) - 1);
+    return !array_is_list($array);
 }
-

--- a/tests/Api/ValidatorTest.php
+++ b/tests/Api/ValidatorTest.php
@@ -424,6 +424,21 @@ class ValidatorTest extends TestCase
                         ]
                     ]
                 ],
+                [
+                    'documentVal' => ['json' => [[1 => "Blah blah"]]]
+                ],
+                true
+            ],
+            [
+                [
+                    'type' => 'structure',
+                    'members' => [
+                        'documentVal' => [
+                            'type' => 'structure',
+                            'document' => true,
+                        ]
+                    ]
+                ],
                 ['documentVal' => null],
                 true
             ],


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3185 

*Description of changes:*
Bugfix for document type validation where unordered (integer) array keys are not considered associative.  This caused valid associative arrays to be rejected during validation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
