### PR TITLE
chore: add dev guide examples to applicable client docs

### DIFF
--- a/build/docs/classes/DocsBuilder.php
+++ b/build/docs/classes/DocsBuilder.php
@@ -415,6 +415,19 @@ EOT;
                 $latest = '';
             }
             $html .= '</ul></article>';
+
+            // Add Examples (from the developer guide) section, where applicable
+            $serviceExamples = require __DIR__ . '/../config/dev-guide-service-examples.php';
+            if (isset($serviceExamples[$service->name])) {
+                $html .= '<h2>Examples</h2>';
+                $html .= '<p>The following examples demonstrate how to use this service with the AWS SDK for PHP. These code examples are available in the <a href="' . $serviceExamples[$service->name]['landing_page'] . '">AWS SDK for PHP Developer Guide</a>.</p>';
+                $html .= '<ul>';
+                foreach ($serviceExamples[$service->name]['scenarios'] as $title => $link) {
+                    $html .= sprintf('<li><a href="%s">%s</a></li>', $link, $title);
+                }
+                $html .= '</ul>';
+            }
+
             $this->replaceInner($service->clientLink, $html, '<!-- api -->');
         }
     }

--- a/build/docs/config/dev-guide-service-examples.php
+++ b/build/docs/config/dev-guide-service-examples.php
@@ -1,0 +1,134 @@
+<?php
+
+return [
+    'cloudfront' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cf-examples.html',
+        'scenarios' => [
+            'Managing CloudFront Distributions' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cloudfront-example-distribution.html',
+            'Managing CloudFront Invalidations' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cloudfront-example-invalidation.html',
+            'Signing CloudFront URLs' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cloudfront-example-signed-url.html'
+        ]
+    ],
+    'cloudsearch' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/service_cloudsearch-custom-requests.html',
+        'scenarios' => [
+            'Signing custom Amazon CloudSearch domain requests' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/service_cloudsearch-custom-requests.html'
+        ]
+    ],
+    'monitoring' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cw-examples.html',
+        'scenarios' => [
+            'Working with Amazon CloudWatch alarms' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cw-examples-work-with-alarms.html',
+            'Getting metrics from CloudWatch' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cw-examples-getting-metrics.html',
+            'Publishing custom metrics in Amazon CloudWatch' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cw-examples-publishing-custom-metrics.html',
+            'Sending events to Amazon CloudWatch events' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cw-examples-sending-events.html',
+            'Using alarm actions with Amazon CloudWatch alarms' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/cw-examples-using-alarm-actions.html'
+        ]
+    ],
+    'ec2' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ec2-examples.html',
+        'scenarios' => [
+            'Managing Amazon EC2 instances' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ec2-examples-managing-instances.html',
+            'Using Elastic IP addresses' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ec2-examples-using-elastic-ip-addresses.html',
+            'Using regions and availability zones' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ec2-examples-using-regions-and-zones.html',
+            'Working with key pairs' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ec2-examples-working-with-key-pairs.html',
+            'Working with security groups' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ec2-examples-using-security-groups.html'
+        ]
+    ],
+    'opensearch' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/service_es-data-plane.html',
+        'scenarios' => [
+            'Signing an Amazon OpenSearch Service search request' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/service_es-data-plane.html'
+        ]
+    ],
+    'iam' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/iam-examples.html',
+        'scenarios' => [
+            'Managing IAM access keys' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/iam-examples-managing-access-keys.html',
+            'Managing IAM users' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/iam-examples-managing-users.html',
+            'Using IAM account aliases' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/iam-examples-using-account-aliases.html',
+            'Working with IAM policies' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/iam-examples-working-with-policies.html',
+            'Working with IAM server certificates' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/iam-examples-working-with-certs.html'
+        ]
+    ],
+    'kms' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kms-examples.html',
+        'scenarios' => [
+            'Working with keys' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kms-example-keys.html',
+            'Encrypting and decrypting data keys' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kms-example-encrypt.html',
+            'Working with key policies' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kms-example-key-policy.html',
+            'Working with grants' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kms-example-grants.html',
+            'Working with aliases' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kms-example-alias.html'
+        ]
+    ],
+    'kinesis' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kinesis-examples.html',
+        'scenarios' => [
+            'Kinesis data streams' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kinesis-example-data-stream.html',
+            'Kinesis shards' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kinesis-example-shard.html',
+            'Kinesis Data Firehose delivery streams' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/kinesis-firehose-example-delivery-stream.html'
+        ]
+    ],
+    'mediaconvert' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/emc-examples.html',
+        'scenarios' => [
+            'Create and manage transcoding jobs in AWS Elemental MediaConvert' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/emc-examples.html'
+        ]
+    ],
+    's3' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples.html',
+        'scenarios' => [
+            'Creating and using Amazon S3 buckets' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples-creating-buckets.html',
+            'Managing Amazon S3 bucket access permissions' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples-access-permissions.html',
+            'Configuring Amazon S3 buckets' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples-configuring-a-bucket.html',
+            'Amazon S3 multipart uploads' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-multipart-upload.html',
+            'Amazon S3 pre-signed URL' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-presigned-url.html',
+            'Creating S3 pre-signed POSTs' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-presigned-post.html',
+            'Using an Amazon S3 bucket as a static web host' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples-static-web-host.html',
+            'Working with Amazon S3 bucket policies' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples-bucket-policies.html',
+            'Using S3 access point ARNs' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples-access-point-arn.html',
+            'Use Multi-Region Access Points' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-multi-region-access-points.html'
+        ]
+    ],
+    'secretsmanager' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/secretsmanager-examples-manage-secret.html',
+        'scenarios' => [
+            'Managing secrets using the Secrets Manager API' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/secretsmanager-examples-manage-secret.html'
+        ]
+    ],
+    'email' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ses-examples.html',
+        'scenarios' => [
+            'Verifying email addresses' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ses-verify.html',
+            'Working with email templates' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ses-template.html',
+            'Managing email filters' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ses-filters.html',
+            'Using email rules' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ses-rules.html',
+            'Monitor your sending activity' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ses-send-email.html',
+            'Authorizing senders' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/ses-sender-policy.html'
+        ]
+    ],
+    'sns' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sns-examples.html',
+        'scenarios' => [
+            'Managing topics' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sns-examples-managing-topics.html',
+            'Managing subscriptions' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sns-examples-subscribing-unsubscribing-topics.html',
+            'Sending amazon SMS messages' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sns-examples-sending-sms.html'
+        ]
+    ],
+    'sqs' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sqs-examples.html',
+        'scenarios' => [
+            'Enabling long polling' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sqs-examples-enable-long-polling.html',
+            'Managing visibility timeout' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sqs-examples-managing-visibility-timeout.html',
+            'Sending and receiving messages' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sqs-examples-send-receive-messages.html',
+            'Using dead-letter queues' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sqs-examples-dead-letter-queues.html',
+            'Using queues' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/sqs-examples-using-queues.html'
+        ]
+    ],
+    'eventbridge' => [
+        'landing_page' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/eventbridge-examples.html',
+        'scenarios' => [
+            'Send events to Amazon EventBridge global endpoints' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/eventbridge-examples.html'
+        ]
+    ]
+];

--- a/src/Ec2/Ec2Client.php
+++ b/src/Ec2/Ec2Client.php
@@ -8,7 +8,7 @@ use Aws\Api\ApiProvider;
 use Aws\PresignUrlMiddleware;
 
 /**
- * Client used to interact with Amazon EC2.
+ * Client used to interact with **Amazon EC2**.
  *
  * @method \Aws\Result acceptVpcPeeringConnection(array $args = [])
  * @method \GuzzleHttp\Promise\Promise acceptVpcPeeringConnectionAsync(array $args = [])

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Psr7\UriResolver;
 use Psr\Http\Message\RequestInterface;
 
 /**
- * Client used to interact Amazon Simple Queue Service (Amazon SQS)
+ * Client used to interact with **Amazon Simple Queue Service (Amazon SQS)**.
  *
  * @method \Aws\Result addPermission(array $args = [])
  * @method \GuzzleHttp\Promise\Promise addPermissionAsync(array $args = [])


### PR DESCRIPTION
*Description of changes:*
Adds [dev guide examples](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/examples_index.html) to service client documentation pages, where applicable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
