### PR TITLE
bugfix: sts credential provider endpoint mode

### DIFF
--- a/.changes/nextrelease/sts-providers.json
+++ b/.changes/nextrelease/sts-providers.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Credentials",
+    "description": "Fixes condition where certain STS credential providers call the regional `us-east-1` endpoint by default."
+  }
+]

--- a/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
+++ b/src/Credentials/AssumeRoleWithWebIdentityCredentialProvider.php
@@ -36,6 +36,7 @@ class AssumeRoleWithWebIdentityCredentialProvider
 
     /** @var integer */
     private $tokenFileReadAttempts;
+
     /** @var string */
     private $source;
 
@@ -72,14 +73,17 @@ class AssumeRoleWithWebIdentityCredentialProvider
         $this->tokenFileReadAttempts = 0;
         $this->session = $config['SessionName']
             ?? 'aws-sdk-php-' . round(microtime(true) * 1000);
-        $region = $config['region'] ?? 'us-east-1';
+        $region = $config['region'] ?? null;
         if (isset($config['client'])) {
             $this->client = $config['client'];
         } else {
             $this->client = new StsClient([
                 'credentials' => false,
-                'region' => $region,
-                'version' => 'latest'
+                'region' => $region ?? 'us-east-1',
+                'version' => 'latest',
+                'sts_regional_endpoints' => $region
+                    ? 'regional'
+                    : 'legacy'
             ]);
         }
 

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -708,9 +708,7 @@ class CredentialProvider
         }
 
         if (empty($stsClient)) {
-            $sourceRegion = isset($profiles[$sourceProfileName]['region'])
-                ? $profiles[$sourceProfileName]['region']
-                : 'us-east-1';
+            $sourceRegion = $profiles[$sourceProfileName]['region'] ?? null;
             $config['preferStaticCredentials'] = true;
             $sourceCredentials = null;
             if (!empty($roleProfile['source_profile'])){
@@ -725,8 +723,11 @@ class CredentialProvider
             }
             $stsClient = new StsClient([
                 'credentials' => $sourceCredentials,
-                'region' => $sourceRegion,
+                'region' => $sourceRegion ?? 'us-east-1',
                 'version' => '2011-06-15',
+                'sts_regional_endpoints' => $sourceRegion
+                    ? 'regional'
+                    : 'legacy'
             ]);
         }
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3197 

*Description of changes:*
Fixes condition where a default client created by certain STS credential providers would call the `us-east-1` regional endpoint rather than the global endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
