### PR TITLE
bugfix: Ensure SignatureV4 sorts query parameters by their URL-encoded names …

### DIFF
--- a/.changes/nextrelease/fix-signature-ordering.json
+++ b/.changes/nextrelease/fix-signature-ordering.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "Signature",
+    "description": "Ensure SignatureV4 sorts query parameters by their URL-encoded names before canonicalization, so array-style keys like param[10] no longer disrupt the canonical order and break signature validation."
+  }
+]

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -346,7 +346,9 @@ class SignatureV4 implements SignatureInterface
         }
 
         $qs = '';
-        ksort($query);
+        uksort($query, static function (string $a, string $b): int {
+            return strcmp(rawurlencode($a), rawurlencode($b));
+        });
         foreach ($query as $k => $v) {
             if (!is_array($v)) {
                 $qs .= rawurlencode($k) . '=' . rawurlencode($v !== null ? $v : '') . '&';

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -107,6 +107,21 @@ class SignatureV4Test extends TestCase
         return array($request, $credentials, $signature);
     }
 
+    private function decodeQueryPairs(string $query): array
+    {
+        if ($query === '') {
+            return [];
+        }
+
+        $pairs = [];
+        foreach (explode('&', $query) as $pair) {
+            $parts = explode('=', $pair, 2);
+            $pairs[] = array_map('rawurldecode', $parts + ['', '']);
+        }
+
+        return $pairs;
+    }
+
     public function getExpiresDateTimeInterfaceInputs()
     {
         return [
@@ -310,6 +325,57 @@ class SignatureV4Test extends TestCase
         $this->assertStringNotContainsString('X-Amz-User-Agent', (string)$presigned->getUri());
         $this->assertStringNotContainsString('content-length', (string)$presigned->getUri());
         $this->assertStringNotContainsString('Content-Type', (string)$presigned->getUri());
+    }
+
+    public function testCanonicalQuerySortingOccursAfterEncoding()
+    {
+        $_SERVER['aws_time'] = '20110909T233600Z';
+
+        $signature = new SignatureV4('service', 'region');
+        $credentials = new Credentials(self::DEFAULT_KEY, self::DEFAULT_SECRET);
+        $query = 'param[0]=1111&param[1]=1111&param[10]=1111&param[2]=1111&param[3]=1111&param[4]=1111&param[5]=1111&param[6]=1111&param[7]=1111&param[8]=1111&param[9]=1111';
+        $request = new Request('GET', 'https://example.com/service?' . $query);
+
+        $parseRequest = new \ReflectionMethod($signature, 'parseRequest');
+        $parseRequest->setAccessible(true);
+        $parsedRequest = $parseRequest->invoke($signature, $request);
+
+        $getPayload = new \ReflectionMethod($signature, 'getPayload');
+        $getPayload->setAccessible(true);
+        $payload = $getPayload->invoke($signature, $request);
+
+        $createContext = new \ReflectionMethod($signature, 'createContext');
+        $createContext->setAccessible(true);
+        $context = $createContext->invoke($signature, $parsedRequest, $payload);
+
+        $canonicalQuery = explode("\n", $context['creq'])[2];
+        $expectedPairs = [
+            ['param[0]', '1111'],
+            ['param[1]', '1111'],
+            ['param[10]', '1111'],
+            ['param[2]', '1111'],
+            ['param[3]', '1111'],
+            ['param[4]', '1111'],
+            ['param[5]', '1111'],
+            ['param[6]', '1111'],
+            ['param[7]', '1111'],
+            ['param[8]', '1111'],
+            ['param[9]', '1111'],
+        ];
+
+        $this->assertSame($expectedPairs, $this->decodeQueryPairs($canonicalQuery));
+
+        $expectedCanonical = "GET\n/service\n" . $canonicalQuery . "\nhost:example.com\n\nhost\n" . $payload;
+        $this->assertSame($expectedCanonical, $context['creq']);
+
+        $signed = $signature->signRequest($request, $credentials);
+        $this->assertSame($expectedPairs, $this->decodeQueryPairs($signed->getUri()->getQuery()));
+
+        $expectedSigned = "GET /service?param%5B0%5D=1111&param%5B1%5D=1111&param%5B10%5D=1111&param%5B2%5D=1111&param%5B3%5D=1111&param%5B4%5D=1111&param%5B5%5D=1111&param%5B6%5D=1111&param%5B7%5D=1111&param%5B8%5D=1111&param%5B9%5D=1111 HTTP/1.1\r\n"
+            . "Host: example.com\r\n"
+            . "X-Amz-Date: 20110909T233600Z\r\n"
+            . "Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/region/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=db59e82a5b69e8d4a0fb1a6ceff6a0ff7beca86ac5531b8c69fa93ea0028634b\r\n\r\n";
+        $this->assertSame($expectedSigned, Psr7\Message::toString($signed));
     }
 
     public function testEnsuresContentSha256CanBeCalculated()


### PR DESCRIPTION
🐛 Bug: Incorrect Query Parameter Sorting Causes Signature Mismatch

Description
When using AWS SDK, requests fail with a signature mismatch if one of the query parameters is an array with 10 or more elements.

Error message:

The request signature we calculated does not match the signature you provided.

⚙️ Root Cause

The issue occurs due to incorrect sorting of query parameters when generating the canonical query string for signing.
Currently, parameters are being sorted before URL encoding, but according to AWS documentation, they must be sorted after encoding.

“You must also sort the parameters in the canonical query string alphabetically by key name. The sorting occurs after encoding.”

This incorrect order in ksort causes an invalid canonical string and therefore an invalid signature.

🧩 Example

Request URL:

https://example.com/service?param[0]=1111&param[1]=1111&param[10]=1111&param[2]=1111&param[3]=1111&param[4]=1111&param[5]=1111&param[6]=1111&param[7]=1111&param[8]=1111&param[9]=1111


Current (incorrect) sorting result:

array(11) {
  ["param[0]"]  => "1111"
  ["param[10]"] => "1111"
  ["param[1]"]  => "1111"
  ["param[2]"]  => "1111"
  ["param[3]"]  => "1111"
  ["param[4]"]  => "1111"
  ["param[5]"]  => "1111"
  ["param[6]"]  => "1111"
  ["param[7]"]  => "1111"
  ["param[8]"]  => "1111"
  ["param[9]"]  => "1111"
}


Expected (correct) sorting result:

array(11) {
  ["param[0]"]  => "1111"
  ["param[1]"]  => "1111"
  ["param[10]"] => "1111"
  ["param[2]"]  => "1111"
  ["param[3]"]  => "1111"
  ["param[4]"]  => "1111"
  ["param[5]"]  => "1111"
  ["param[6]"]  => "1111"
  ["param[7]"]  => "1111"
  ["param[8]"]  => "1111"
  ["param[9]"]  => "1111"
}

✅ Proposed Fix

Sort query parameters after URL encoding instead of before, following the official AWS signing specification.

📚 References

[AWS Signature Version 4 – Creating a Canonical Request](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html)

Our fix in async aws library:
https://github.com/async-aws/aws/pull/1938

Probably fix the issue: https://github.com/aws/aws-sdk-php/issues/3132