### PR TITLE
bugfix: sts-credential-providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.358.0 - 2025-10-27
+
+* `Aws\Credentials` - Updates STS providers to accept region passed from client, directly through in-code or profile configuration, or from `AWS_REGION`. Adds notice regarding fallback region.
+
 ## 3.357.3 - 2025-10-27
 
 * `Aws\ControlTower` - Update endpoint ruleset parameters casing

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -52,6 +52,8 @@ class CredentialProvider
     const ENV_SESSION = 'AWS_SESSION_TOKEN';
     const ENV_TOKEN_FILE = 'AWS_WEB_IDENTITY_TOKEN_FILE';
     const ENV_SHARED_CREDENTIALS_FILE = 'AWS_SHARED_CREDENTIALS_FILE';
+    public const ENV_REGION = 'AWS_REGION';
+    public const FALLBACK_REGION = 'us-east-1';
     public const REFRESH_WINDOW = 60;
 
     /**
@@ -102,7 +104,7 @@ class CredentialProvider
                 $config
             );
             $defaultChain['process_credentials'] = self::process();
-            $defaultChain['ini'] = self::ini();
+            $defaultChain['ini'] = self::ini(null, null, $config);
             $defaultChain['process_config'] = self::process(
                 'profile ' . $profileName,
                 self::getHomeDir() . '/.aws/config'
@@ -708,9 +710,6 @@ class CredentialProvider
         }
 
         if (empty($stsClient)) {
-            $sourceRegion = isset($profiles[$sourceProfileName]['region'])
-                ? $profiles[$sourceProfileName]['region']
-                : 'us-east-1';
             $config['preferStaticCredentials'] = true;
             $sourceCredentials = null;
             if (!empty($roleProfile['source_profile'])){
@@ -723,11 +722,13 @@ class CredentialProvider
                     $filename
                 );
             }
-            $stsClient = new StsClient([
-                'credentials' => $sourceCredentials,
-                'region' => $sourceRegion,
-                'version' => '2011-06-15',
-            ]);
+
+            $region = $profiles[$sourceProfileName]['region']
+                ?? $config['region']
+                ?? getEnv(self::ENV_REGION)
+                ?: null;
+
+            $stsClient = self::createDefaultStsClient($sourceCredentials, $region);
         }
 
         $result = $stsClient->assumeRole([
@@ -1025,6 +1026,38 @@ class CredentialProvider
 
         $ssoCredentials = $ssoResponse['roleCredentials'];
         return $ssoCredentials;
+    }
+
+    /**
+     * @param CredentialsInterface $credentials
+     * @param string|null $region
+     *
+     * @return StsClient
+     */
+    private static function createDefaultStsClient(
+        CredentialsInterface $credentials,
+        ?string $region
+    ): StsClient
+    {
+        if (empty($region)) {
+            $region = self::FALLBACK_REGION;
+            trigger_error(
+                'NOTICE: STS client created without explicit `region` configuration.' . PHP_EOL
+                . "Defaulting to `{$region}`. This fallback behavior may be removed." . PHP_EOL
+                . 'To avoid potential disruptions, configure a `region` using one of the following methods:' . PHP_EOL
+                . '(1) Add `region` to your source profile in ~/.aws/credentials,' . PHP_EOL
+                . '(2) Pass `region` in the `$config` array when calling the provider,' . PHP_EOL
+                . '(3) Set the `AWS_REGION` environment variable.' . PHP_EOL
+                . 'See: https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_assume_role.html#assume-role-with-profile'
+                . PHP_EOL,
+                E_USER_NOTICE
+            );
+        }
+
+        return new StsClient([
+            'credentials' => $credentials,
+            'region' => $region
+        ]);
     }
 }
 

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -833,7 +833,7 @@ namespace Aws;
  */
 class Sdk
 {
-    const VERSION = '3.357.3';
+    const VERSION = '3.358.0';
 
     /** @var array Arguments for creating clients */
     private $args;

--- a/tests/Integ/CredentialsContext.php
+++ b/tests/Integ/CredentialsContext.php
@@ -22,6 +22,7 @@ class CredentialsContext extends Assert implements
     private static $roleArn;
     private $credentials;
     private $client;
+    private $result;
 
     /**
      * @BeforeFeature @credentials
@@ -98,6 +99,7 @@ EOT;
 aws_access_key_id = $sourceKeyId
 aws_secret_access_key = $sourceAccessKey
 aws_session_token = $sourceToken
+region = us-west-2
 [assumeInteg]
 role_arn = $roleArn
 source_profile = default
@@ -123,7 +125,7 @@ EOT;
     public function iHaveAnStsClient()
     {
         $this->client = self::getSdk()->createSts([
-            'credentials' => $this->credentials
+            'credentials' => $this->credentials,
         ]);
     }
 


### PR DESCRIPTION
Issue #, if available:
Fixes https://github.com/aws/aws-sdk-php/issues/3197

Description of changes:
Adds support for resolving the region for STS clients created by assume role providers.  By default, the credentials chain will pass client configuration to expose the top-level client's region.  When providers are called outside the context of a client, they will accept `region` in-code configuration, `region` source profile configuration (for roles assumed via profiles), and will attempt to resolve `AWS_REGION` if any of the aforementioned options don't produce a region.

This also adds a notice that prompts to configure a region if a region cannot be found.  These providers will still fall back to `us-east-1`, but this is likely to change in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.