### PR TITLE
bugfix: assume role with `credential_source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.359.0 - 2025-10-28
+
+* `Aws\Credentials` - Fixes issue caused by #3203 with role assumption when `credential_source` is specified.
+
 ## 3.358.1 - 2025-10-28
 
 * `Aws\TaxSettings` - Update endpoint ruleset parameters casing

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -1035,7 +1035,7 @@ class CredentialProvider
      * @return StsClient
      */
     private static function createDefaultStsClient(
-        CredentialsInterface $credentials,
+        CredentialsInterface|callable $credentials,
         ?string $region
     ): StsClient
     {

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -833,7 +833,7 @@ namespace Aws;
  */
 class Sdk
 {
-    const VERSION = '3.358.1';
+    const VERSION = '3.359.0';
 
     /** @var array Arguments for creating clients */
     private $args;


### PR DESCRIPTION
*Description of changes:*
Fixes issue with assuming roles specified in profiles caused by #3203.  `getCredentialsFromSource()` returns a callable and its result is passed to `createDefaultStsClient()` if no client is configured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
