### PR TITLE
TraceMiddleware crashes when http option is false

### DIFF
--- a/src/TraceMiddleware.php
+++ b/src/TraceMiddleware.php
@@ -286,7 +286,7 @@ class TraceMiddleware
 
     private function flushHttpDebug(CommandInterface $command)
     {
-        if ($res = $command['@http']['debug']) {
+        if ($res = ($command['@http']['debug'] ?? null)) {
             if (is_resource($res)) {
                 rewind($res);
                 $this->write(stream_get_contents($res));


### PR DESCRIPTION
```
Undefined array key "debug" at aws-sdk-php/src/TraceMiddleware.php:289
```

*Description of changes:*

When setting the debug.http option to false the above exception will be thrown because `$command['@http']['debug']` doesn't exist, adding a null check fixes the issue.

```
new S3Client([
    'debug' => [
        'logfn' => ...
        'http' => false,
    ],
]);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
