### PR TITLE
feat: login credential provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.362.0 - 2025-11-19
+
+* `Aws\Credentials` - Adds `LoginCredentialProvider`, which supports AWS Console sign-in credentials through the `aws login` CLI workflow.
+
 ## 3.361.0 - 2025-11-19
 
 * `Aws\Route53` - Add dual-stack endpoint support for Route53

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -61,6 +61,8 @@ class ClientResolver
         __CLASS__,
         '_resolve_from_env_ini'
     ];
+    private const ANONYMOUS_SIGNATURE = 'anonymous';
+    private const DPOP_SIGNATURE = 'dpop';
 
     /** @var array Map of types to a corresponding function */
     private static $typeMap = [
@@ -668,7 +670,10 @@ class ClientResolver
             $args['credentials'] = CredentialProvider::fromCredentials(
                 new Credentials('', '')
             );
-            $args['config']['signature_version'] = 'anonymous';
+            if ($args['config']['signature_version'] !== self::DPOP_SIGNATURE) {
+                $args['config']['signature_version'] = self::ANONYMOUS_SIGNATURE;
+            }
+
             $args['config']['configured_signature_version'] = true;
         } elseif ($value instanceof CacheInterface) {
             $args['credentials'] = CredentialProvider::defaultProvider($args);

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -43,15 +43,16 @@ use GuzzleHttp\Promise;
  */
 class CredentialProvider
 {
-    const ENV_ARN = 'AWS_ROLE_ARN';
-    const ENV_KEY = 'AWS_ACCESS_KEY_ID';
-    const ENV_PROFILE = 'AWS_PROFILE';
-    const ENV_ROLE_SESSION_NAME = 'AWS_ROLE_SESSION_NAME';
-    const ENV_SECRET = 'AWS_SECRET_ACCESS_KEY';
-    const ENV_ACCOUNT_ID = 'AWS_ACCOUNT_ID';
-    const ENV_SESSION = 'AWS_SESSION_TOKEN';
-    const ENV_TOKEN_FILE = 'AWS_WEB_IDENTITY_TOKEN_FILE';
-    const ENV_SHARED_CREDENTIALS_FILE = 'AWS_SHARED_CREDENTIALS_FILE';
+    public const ENV_ARN = 'AWS_ROLE_ARN';
+    public const ENV_KEY = 'AWS_ACCESS_KEY_ID';
+    public const ENV_PROFILE = 'AWS_PROFILE';
+    public const ENV_ROLE_SESSION_NAME = 'AWS_ROLE_SESSION_NAME';
+    public const ENV_SECRET = 'AWS_SECRET_ACCESS_KEY';
+    public const ENV_ACCOUNT_ID = 'AWS_ACCOUNT_ID';
+    public const ENV_SESSION = 'AWS_SESSION_TOKEN';
+    public const ENV_TOKEN_FILE = 'AWS_WEB_IDENTITY_TOKEN_FILE';
+    public const ENV_SHARED_CREDENTIALS_FILE = 'AWS_SHARED_CREDENTIALS_FILE';
+    public const ENV_CONFIG_FILE = 'AWS_CONFIG_FILE';
     public const ENV_REGION = 'AWS_REGION';
     public const FALLBACK_REGION = 'us-east-1';
     public const REFRESH_WINDOW = 60;
@@ -82,6 +83,7 @@ class CredentialProvider
         $cacheable = [
             'web_identity',
             'sso',
+            'login',
             'process_credentials',
             'process_config',
             'ecs',
@@ -94,24 +96,24 @@ class CredentialProvider
             'env' => self::env(),
             'web_identity' => self::assumeRoleWithWebIdentityCredentialProvider($config),
         ];
-        if (
-            !isset($config['use_aws_shared_config_files'])
+        if (!isset($config['use_aws_shared_config_files'])
             || $config['use_aws_shared_config_files'] !== false
         ) {
             $defaultChain['sso'] = self::sso(
                 $profileName,
-                self::getHomeDir() . '/.aws/config',
+                self::getConfigFileName(),
                 $config
             );
+            $defaultChain['login'] = self::login($profileName, $config);
             $defaultChain['process_credentials'] = self::process();
             $defaultChain['ini'] = self::ini(null, null, $config);
             $defaultChain['process_config'] = self::process(
                 'profile ' . $profileName,
-                self::getHomeDir() . '/.aws/config'
+                self::getConfigFileName()
             );
             $defaultChain['ini_config'] = self::ini(
                 'profile '. $profileName,
-                self::getHomeDir() . '/.aws/config'
+                self::getConfigFileName()
             );
         }
 
@@ -339,11 +341,12 @@ class CredentialProvider
      *
      * @return callable
      */
-    public static function sso($ssoProfileName = 'default',
-                               $filename = null,
-                               $config = []
+    public static function sso(
+        $ssoProfileName = 'default',
+        $filename = null,
+        $config = []
     ) {
-        $filename = $filename ?: (self::getHomeDir() . '/.aws/config');
+        $filename = $filename ?? self::getConfigFileName();
 
         return function () use ($ssoProfileName, $filename, $config) {
             if (!@is_readable($filename)) {
@@ -489,17 +492,13 @@ class CredentialProvider
      */
     public static function ini($profile = null, $filename = null, array $config = [])
     {
-        $filename = self::getFileName($filename);
+        $filename = self::getCredentialsFileName($filename);
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
         return function () use ($profile, $filename, $config) {
-            $preferStaticCredentials = isset($config['preferStaticCredentials'])
-                ? $config['preferStaticCredentials']
-                : false;
-            $disableAssumeRole = isset($config['disableAssumeRole'])
-                ? $config['disableAssumeRole']
-                : false;
-            $stsClient = isset($config['stsClient']) ? $config['stsClient'] : null;
+            $preferStaticCredentials = $config['preferStaticCredentials'] ?? false;
+            $disableAssumeRole = $config['disableAssumeRole'] ?? false;
+            $stsClient = $config['stsClient'] ?? null;
 
             if (!@is_readable($filename)) {
                 return self::reject("Cannot read credentials from $filename");
@@ -583,7 +582,7 @@ class CredentialProvider
      */
     public static function process($profile = null, $filename = null)
     {
-        $filename = self::getFileName($filename);
+        $filename = self::getCredentialsFileName($filename);
         $profile = $profile ?: (getenv(self::ENV_PROFILE) ?: 'default');
 
         return function () use ($profile, $filename) {
@@ -660,6 +659,41 @@ class CredentialProvider
     }
 
     /**
+     * Login credential provider for AWS local development using console credentials
+     *
+     * @param string|null $profileName profile containing your console login session information
+     * @param array $config region used for refresh requests.
+     *                      pass `'region' => <your_region>` to configure a region,
+     *                      otherwise, provider construction falls back to AWS_REGION,
+     *                      then the profile specified for `login`
+     *
+     * @return callable
+     */
+    public static function login(
+        ?string $profileName = null,
+        array $config = [],
+    ): callable
+    {
+        $resolvedProfile = $profileName ?? getenv(self::ENV_PROFILE) ?: 'default';
+
+        return static function () use ($resolvedProfile, $config) {
+            try {
+                $provider = new LoginCredentialProvider(
+                    $resolvedProfile,
+                    $config['region'] ?? null
+                );
+            } catch (\Exception $e) {
+                return self::reject(
+                    "Failed to initialize login credential provider for profile '{$resolvedProfile}': " 
+                    . $e->getMessage()
+                );
+            }
+
+            return $provider();
+        };
+    }
+
+    /**
      * Assumes role for profile that includes role_arn
      *
      * @return callable
@@ -672,13 +706,11 @@ class CredentialProvider
         $config = []
     ) {
         $roleProfile = $profiles[$profileName];
-        $roleArn = isset($roleProfile['role_arn']) ? $roleProfile['role_arn'] : '';
-        $roleSessionName = isset($roleProfile['role_session_name'])
-            ? $roleProfile['role_session_name']
-            : 'aws-sdk-php-' . round(microtime(true) * 1000);
+        $roleArn = $roleProfile['role_arn'] ?? '';
+        $roleSessionName = $roleProfile['role_session_name']
+            ?? 'aws-sdk-php-' . round(microtime(true) * 1000);
 
-        if (
-            empty($roleProfile['source_profile'])
+        if (empty($roleProfile['source_profile'])
             == empty($roleProfile['credential_source'])
         ) {
             return self::reject("Either source_profile or credential_source must be set " .
@@ -748,7 +780,7 @@ class CredentialProvider
      *
      * @return null|string
      */
-    private static function getHomeDir()
+    public static function getHomeDir()
     {
         // On Linux/Unix-like systems, use the HOME environment variable
         if ($homeDir = getenv('HOME')) {
@@ -765,7 +797,7 @@ class CredentialProvider
     /**
      * Gets profiles from specified $filename, or default ini files.
      */
-    private static function loadProfiles($filename)
+    public static function loadProfiles($filename)
     {
         $profileData = \Aws\parse_ini_file($filename, true, INI_SCANNER_RAW);
 
@@ -773,7 +805,7 @@ class CredentialProvider
         if ($filename === self::getHomeDir() . '/.aws/credentials'
             && getenv('AWS_SDK_LOAD_NONDEFAULT_CONFIG')
         ) {
-            $configFilename = self::getHomeDir() . '/.aws/config';
+            $configFilename = self::getConfigFileName();
             $configProfileData = \Aws\parse_ini_file($configFilename, true, INI_SCANNER_RAW);
             foreach ($configProfileData as $name => $profile) {
                 // standardize config profile names
@@ -790,7 +822,8 @@ class CredentialProvider
     /**
      * Gets profiles from ~/.aws/credentials and ~/.aws/config ini files
      */
-    private static function loadDefaultProfiles() {
+    private static function loadDefaultProfiles()
+    {
         $profiles = [];
         $credFile = self::getHomeDir() . '/.aws/credentials';
         $configFile = self::getHomeDir() . '/.aws/config';
@@ -861,15 +894,32 @@ class CredentialProvider
     }
 
     /**
+     * Locates shared configuration file by first checking for AWS_CONFIG,
+     * then falling back to the default location.  Returns the path of the
+     * resolved configuration file.
+     *
+     * @return string
+     */
+    public static function getConfigFileName(): string
+    {
+        return getenv(self::ENV_CONFIG_FILE) ?: self::getHomeDir() . '/.aws/config';
+    }
+
+    /**
+     *  Locates credentials file by first checking for AWS_SHARED_CREDENTIALS_FILE,
+     *  then falling back to the default location.  Returns the path of the
+     *  resolved credentials file.
+     *
      * @param $filename
      * @return string
      */
-    private static function getFileName($filename)
+    public static function getCredentialsFileName($filename): string
     {
         if (!isset($filename)) {
             $filename = getenv(self::ENV_SHARED_CREDENTIALS_FILE) ?:
                 (self::getHomeDir() . '/.aws/credentials');
         }
+
         return $filename;
     }
 

--- a/src/Credentials/CredentialSources.php
+++ b/src/Credentials/CredentialSources.php
@@ -19,4 +19,5 @@ final class CredentialSources
     const PROFILE_SSO = 'profile_sso';
     const PROFILE_SSO_LEGACY = 'profile_sso_legacy';
     const PROFILE_PROCESS = 'profile_process';
+    const PROFILE_LOGIN = 'profile_login';
 }

--- a/src/Credentials/LoginCredentialProvider.php
+++ b/src/Credentials/LoginCredentialProvider.php
@@ -1,0 +1,527 @@
+<?php
+namespace Aws\Credentials;
+
+use Aws\Configuration\ConfigurationResolver;
+use Aws\Exception\CredentialsException;
+use Aws\Signin\SigninClient;
+use Aws\Signin\Exception\SigninException;
+use GuzzleHttp\Promise;
+
+/**
+ * Credential provider for login using console credentials
+ */
+final class LoginCredentialProvider
+{
+    private const EXT_OPENSSL = 'openssl';
+    private const DEFAULT_REFRESH_THRESHOLD = 180; // 3 minutes
+    private const ENV_CACHE_DIRECTORY = 'AWS_LOGIN_CACHE_DIRECTORY';
+    private const DEFAULT_CACHE_DIRECTORY = '/.aws/login/cache';
+    private const REAUTHENTICATE_MSG = ' Please reauthenticate using `aws login`.';
+    private const PROFILE_DEFAULT = 'default';
+    private const PROFILE_SECONDARY = 'profile ';
+    private const GRANT_TYPE = 'refresh_token';
+    private const REQUEST_KEY_GRANT_TYPE = 'grantType';
+    private const REQUEST_KEY_CLIENT_ID = 'clientId';
+    private const REQUEST_KEY_REFRESH_TOKEN = 'refreshToken';
+    private const REQUEST_KEY_TOKEN_INPUT = 'tokenInput';
+    private const RESULT_TOKEN_OUTPUT = 'tokenOutput';
+    private const RESULT_EXPIRES_IN = 'expiresIn';
+    private const CLIENT_SIGNATURE_DPOP = 'dpop';
+    private const KEY_CLIENT_SIGNATURE_VERSION = 'signature_version';
+    private const KEY_CLIENT_REGION = 'region';
+    private const KEY_CLIENT_CREDENTIALS = 'credentials';
+    private const KEY_PROFILE_LOGIN_SESSION = 'login_session';
+    private const KEY_ACCESS_TOKEN = 'accessToken';
+    private const KEY_DPOP_KEY = 'dpopKey';
+    private const KEY_ACCESS_KEY_ID = 'accessKeyId';
+    private const KEY_SECRET_ACCESS_KEY = 'secretAccessKey';
+    private const KEY_SESSION_TOKEN = 'sessionToken';
+    private const KEY_ACCOUNT_ID = 'accountId';
+    private const KEY_EXPIRES_AT = 'expiresAt';
+    private const REQUIRED_CACHE_KEYS = [
+        self::KEY_ACCESS_TOKEN,
+        self::REQUEST_KEY_CLIENT_ID,
+        self::REQUEST_KEY_REFRESH_TOKEN,
+        self::KEY_DPOP_KEY
+    ];
+    private const REQUIRED_ACCESS_TOKEN_KEYS = [
+        self::KEY_ACCESS_KEY_ID,
+        self::KEY_SECRET_ACCESS_KEY,
+        self::KEY_SESSION_TOKEN,
+        self::KEY_ACCOUNT_ID,
+        self::KEY_EXPIRES_AT
+    ];
+
+    /** @var string The profile name used for login session configuration */
+    private string $profileName;
+    
+    /** @var SigninClient The Signin service client used for token refresh operations */
+    private SigninClient $client;
+    
+    /** @var string The file path to the cached token location */
+    private string $tokenLocation;
+    
+    /** @var array|null The cached token data including access token, refresh token, and DPoP key */
+    private ?array $token = null;
+
+    /**
+     * @param string $profileName Profile containing your console login session information
+     * @param string|null $region Region used for refresh requests. If not provided,
+     *                            attempts will be made to resolve a region using
+     *                            `AWS_REGION`, then the profile specified for `login`.
+     */
+    public function __construct(
+        string $profileName,
+        ?string $region = null
+    ) {
+        if (!extension_loaded(self::EXT_OPENSSL)) {
+            throw new \RuntimeException(
+                'The `openssl` extension is required to use Login credentials. '
+                . 'Please install or enable the `openssl` extension.'
+            );
+        }
+
+        $this->profileName = $profileName;
+        $this->client = $this->createSigninClient($profileName, $region);
+        $this->tokenLocation = $this->resolveTokenLocation($profileName);
+    }
+
+    /**
+     * Returns a promise that resolves to AWS credentials
+     * 
+     * This method loads the cached token, refreshes it if necessary,
+     * and returns AWS credentials sourced from the access token.
+     *
+     * @return Promise\PromiseInterface A promise that resolves to a Credentials object
+     * @throws CredentialsException If re-authentication is required or credentials cannot be loaded
+     * @throws SigninException If the token refresh fails with a SigninException
+     */
+    public function __invoke(): Promise\PromiseInterface
+    {
+        return Promise\Coroutine::of(function () {
+            $this->token ??= $this->loadToken();
+            $credentials = $this->token[self::KEY_ACCESS_TOKEN];
+            
+            if ($this->shouldRefresh($credentials)) {
+                try {
+                    $credentials = yield from $this->refresh($credentials);
+                } catch (CredentialsException $e) {
+                    // For specific re-authentication errors, re-throw
+                    throw $e;
+                } catch (SigninException $e) {
+                    // For SigninException not handled by refresh(), re-throw
+                    throw new CredentialsException(
+                        'Unable to refresh login credentials: ' . $e->getAwsErrorMessage(),
+                        $e->getCode(),
+                        $e
+                    );
+                } catch (\Exception $e) {
+                    // For other refresh failures, log and continue with existing token
+                    trigger_error(
+                        'Continuing with existing token after refresh failure: ' . $e->getMessage(),
+                        E_USER_NOTICE
+                    );
+                }
+            }
+
+            yield $credentials;
+        });
+    }
+
+    /**
+     * Refreshes the access token using the refresh token and returns new credentials,
+     * or, if refreshed from another source, returns the externally refreshed credentials.
+     *
+     * @param Credentials $currentCredentials The current credentials to refresh
+     *
+     * @return \Generator Generator that yields and returns refreshed credentials
+     * @throws CredentialsException If re-authentication is required due to expired or changed credentials
+     * @throws SigninException If the token refresh fails with a SigninException
+     * @throws \Exception For unexpected errors during refresh
+     */
+    private function refresh(Credentials $currentCredentials): \Generator
+    {
+        // Check for external refresh
+        if ($refreshedToken = $this->getExternalRefresh($currentCredentials)) {
+            $this->token = $refreshedToken;
+            
+            return $refreshedToken[self::KEY_ACCESS_TOKEN];
+        }
+
+        try {
+            $refreshed = (yield $this->client->createOAuth2TokenAsync([
+                self::REQUEST_KEY_TOKEN_INPUT => [
+                    self::REQUEST_KEY_CLIENT_ID => $this->token[self::REQUEST_KEY_CLIENT_ID],
+                    self::REQUEST_KEY_GRANT_TYPE => self::GRANT_TYPE,
+                    self::REQUEST_KEY_REFRESH_TOKEN => $this->token[self::REQUEST_KEY_REFRESH_TOKEN]
+                ],
+                self::KEY_DPOP_KEY => $this->token[self::KEY_DPOP_KEY]
+            ]))->get(self::RESULT_TOKEN_OUTPUT);
+
+            $newCredentials = self::createCredentials(
+                $refreshed[self::KEY_ACCESS_TOKEN],
+                time() + $refreshed[self::RESULT_EXPIRES_IN],
+                $currentCredentials->getAccountId()
+            );
+
+            $this->token[self::KEY_ACCESS_TOKEN] = $newCredentials;
+            $this->token[self::REQUEST_KEY_REFRESH_TOKEN] = $refreshed[self::REQUEST_KEY_REFRESH_TOKEN];
+        } catch (\Exception $e) {
+            throw $this->handleRefreshException($e);
+        }
+
+        try {
+            $this->writeToCache();
+        } catch (\JsonException|\RuntimeException $e) {
+            trigger_error(
+                'Failed to update credential cache during refresh: ' . $e->getMessage()
+                . '. Using refreshed credentials in memory.',
+                E_USER_NOTICE
+            );
+        }
+        
+        return $newCredentials;
+    }
+
+    /**
+     * Gets externally refreshed token if token has been refreshed from another source.
+     * If the new token does not need refreshing, returns it.
+     * 
+     * @param Credentials $currentCredentials Current credentials to compare against
+     * @return array|null Returns the updated token array if externally refreshed, null otherwise
+     */
+    private function getExternalRefresh(Credentials $currentCredentials): ?array
+    {
+        try {
+            $latestToken = $this->loadToken();
+            $latestCredentials = $latestToken[self::KEY_ACCESS_TOKEN];
+            
+            // Refresh token must be different
+            if ($latestToken[self::REQUEST_KEY_REFRESH_TOKEN]
+                === $this->token[self::REQUEST_KEY_REFRESH_TOKEN]
+            ) {
+                return null;
+            }
+            
+            // Expiration must be newer
+            if ($latestCredentials->getExpiration()
+                <= $currentCredentials->getExpiration()
+            ) {
+                return null;
+            }
+            
+            // New token should not need refresh itself
+            if ($this->shouldRefresh($latestCredentials)) {
+                return null;
+            }
+
+            return $latestToken;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Writes the updated access token and refresh token to the cache file
+     *
+     * @throws \JsonException|\RuntimeException
+     */
+    private function writeToCache(): void
+    {
+        $credentials = $this->token[self::KEY_ACCESS_TOKEN];
+        $updates = [
+            self::KEY_ACCESS_TOKEN => [
+                self::KEY_ACCESS_KEY_ID => $credentials->getAccessKeyId(),
+                self::KEY_SECRET_ACCESS_KEY => $credentials->getSecretKey(),
+                self::KEY_SESSION_TOKEN => $credentials->getSecurityToken(),
+                self::KEY_ACCOUNT_ID => $credentials->getAccountId(),
+                self::KEY_EXPIRES_AT => gmdate('Y-m-d\TH:i:s\Z', $credentials->getExpiration())
+            ],
+            self::REQUEST_KEY_REFRESH_TOKEN => $this->token[self::REQUEST_KEY_REFRESH_TOKEN]
+        ];
+        
+        $existing = json_decode(
+            file_get_contents($this->tokenLocation), true, 512, JSON_THROW_ON_ERROR
+        );
+        $merged = array_merge($existing, $updates);
+
+        $result = file_put_contents(
+            $this->tokenLocation,
+            json_encode($merged, JSON_THROW_ON_ERROR),
+            LOCK_EX
+        );
+
+        if (!$result) {
+            throw new \RuntimeException('Failed to write cache file');
+        }
+    }
+
+    /**
+     * Loads and validates the token from the cache file
+     *
+     * @return array The loaded token data with Credentials object, DPoP key, and other fields
+     * @throws CredentialsException If the cache file is invalid, missing required keys,
+     *                              or DPoP key cannot be loaded
+     */
+    private function loadToken(): array
+    {
+        try {
+            $cached = json_decode(
+                file_get_contents($this->tokenLocation),
+                true, 512, JSON_THROW_ON_ERROR
+            );
+        } catch (\JsonException $e) {
+            throw new CredentialsException(
+                'Invalid JSON in cache file: ' . $e->getMessage(),
+                0,
+                $e
+            );
+        }
+
+        if (self::hasAllRequiredKeys($cached, self::REQUIRED_CACHE_KEYS)
+            && self::hasAllRequiredKeys(
+                $cached[self::KEY_ACCESS_TOKEN] ?? [],
+                self::REQUIRED_ACCESS_TOKEN_KEYS
+            )
+        ) {
+            // Convert expiresAt to Unix timestamp
+            $expiresAt = strtotime($cached[self::KEY_ACCESS_TOKEN][self::KEY_EXPIRES_AT]);
+            if ($expiresAt === false) {
+                throw new CredentialsException(
+                    'Invalid expiration date format in cached token `'
+                    . self::KEY_EXPIRES_AT . '` field.' . self::REAUTHENTICATE_MSG
+                );
+            }
+
+            $cached[self::KEY_ACCESS_TOKEN] = self::createCredentials(
+                $cached[self::KEY_ACCESS_TOKEN],
+                $expiresAt,
+                $cached[self::KEY_ACCESS_TOKEN][self::KEY_ACCOUNT_ID]
+            );
+            
+            // Load DPoP key
+            $cached[self::KEY_DPOP_KEY] = openssl_pkey_get_private($cached[self::KEY_DPOP_KEY]);
+            if ($cached[self::KEY_DPOP_KEY] === false) {
+                $error = openssl_error_string();
+                throw new CredentialsException(
+                    'Failed to load DPoP private key from cached token for profile '
+                    . "{$this->profileName}: " . ($error ? ": {$error}" : '.')
+                    . self::REAUTHENTICATE_MSG
+                );
+            }
+
+            return $cached;
+        }
+
+        throw new CredentialsException(
+            'Missing required keys in cached token for profile '
+            . $this->profileName . '.' . self::REAUTHENTICATE_MSG
+        );
+    }
+
+    /**
+     * @param Credentials $credentials The credentials to check for expiration
+     *
+     * @return bool True if the token expires within the refresh threshold
+     */
+    private function shouldRefresh(Credentials $credentials): bool
+    {
+        return ($credentials->getExpiration() - time()) <= self::DEFAULT_REFRESH_THRESHOLD;
+    }
+
+    /**
+     * Handles exceptions thrown during token refresh
+     *
+     * @param \Exception $e The exception thrown during refresh
+     * 
+     * @return \Exception The exception to be thrown (either transformed or original)
+     */
+    private function handleRefreshException(\Exception $e): \Exception
+    {
+        if ($e instanceof SigninException) {
+            trigger_error(
+                'Failed to refresh login credentials: ' . $e->getAwsErrorMessage(),
+                E_USER_NOTICE
+            );
+            
+            if ($e->getAwsErrorCode() === 'AccessDeniedException') {
+                $error = strtolower($e->get('error'));
+                switch ($error) {
+                    case 'token_expired':
+                        return new CredentialsException(
+                            'Your session has expired.' . self::REAUTHENTICATE_MSG,
+                            0,
+                            $e
+                        );
+                    case 'user_credentials_changed':
+                        return new CredentialsException(
+                            'Unable to refresh credentials because of a change in your password. '
+                            . 'Please reauthenticate with your new password.',
+                            0,
+                            $e
+                        );
+                    case 'insufficient_permissions':
+                        return new CredentialsException(
+                            'Unable to refresh credentials due to insufficient permissions. '
+                            . 'You may be missing permission for the `CreateOAuth2Token` action.',
+                            0,
+                            $e
+                        );
+                }
+            }
+            
+            return $e;
+        }
+        
+        // For all other exceptions
+        trigger_error(
+            'Unexpected error refreshing login credentials: ' . $e->getMessage(),
+            E_USER_NOTICE
+        );
+        
+        return $e;
+    }
+
+    /**
+     * Resolves the cache file location for the given profile
+     *
+     * @param string $profileName The profile name to resolve the token location for
+     *
+     * @return string The full path to the cache file
+     * @throws CredentialsException If the profile doesn't exist, lacks login_session,
+     *                              or cache file is not readable
+     */
+    private function resolveTokenLocation(string $profileName): string
+    {
+        $configFile = CredentialProvider::getConfigFileName();
+        if (!is_readable($configFile)) {
+            throw new CredentialsException(
+                'Unable to load configuration file at ' . $configFile
+                . '. Please ensure the file exists at the specified location.'
+            );
+        }
+
+        // Ensure profile and session are set
+        $profiles = CredentialProvider::loadProfiles($configFile);
+        if ($profileName === self::PROFILE_DEFAULT) {
+            $profileData = $profiles[self::PROFILE_DEFAULT] ?? null;
+        } elseif (str_starts_with($profileName, self::PROFILE_SECONDARY)) {
+            $profileData = $profiles[$profileName] ?? null;
+        } else {
+            // Try without prefix first, then with prefix
+            $profileData = $profiles[$profileName] 
+                        ?? $profiles[self::PROFILE_SECONDARY . $profileName]
+                        ?? null;
+        }
+        
+        if (!$profileData) {
+            throw new CredentialsException(
+                "Profile '{$profileName}' does not exist. "
+                . "Please ensure the specified profile is set at {$configFile}."
+            );
+        }
+        
+        if (empty($session = $profileData[self::KEY_PROFILE_LOGIN_SESSION] ?? null)) {
+            throw new CredentialsException(
+                "Profile '{$profileName}' did not contain a "
+                . self::KEY_PROFILE_LOGIN_SESSION . " value. "
+                . 're-authentication using `aws login` may be needed.'
+            );
+        }
+
+        // Resolve location and ensure it exists
+        $cacheDirectory = getenv(self::ENV_CACHE_DIRECTORY)
+            ?: CredentialProvider::getHomeDir() . self::DEFAULT_CACHE_DIRECTORY;
+        $cacheFile = $cacheDirectory . DIRECTORY_SEPARATOR . hash('sha256', trim($session)) . '.json';
+        if (!@is_readable($cacheFile)) {
+            throw new CredentialsException(
+                "Failed to load cached credentials for profile "
+                . "'{$profileName}'." . self::REAUTHENTICATE_MSG
+            );
+        }
+
+        return $cacheFile;
+    }
+
+    /**
+     * Creates a SigninClient configured for DPoP authentication
+     *
+     * @param string $profile
+     * @param string|null $region The AWS region for the Signin service
+     *
+     * @return SigninClient A configured SigninClient instance with DPoP signature version
+     */
+    private function createSigninClient(string $profile, ?string $region): SigninClient
+    {
+        $resolvedRegion = $region
+            ?? ConfigurationResolver::env(self::KEY_CLIENT_REGION)
+            ?? ConfigurationResolver::ini(self::KEY_CLIENT_REGION, 'string', $profile)
+            ?? ConfigurationResolver::ini(
+                self::KEY_CLIENT_REGION,
+                'string',
+                self::PROFILE_SECONDARY . $profile
+            );
+
+        if (empty($resolvedRegion)) {
+            throw new CredentialsException(
+                'Unable to determine region for the Sign-In service client '
+                . ' used for refreshing Login credentials. You can provide a region in-code '
+                . 'when constructing the provider, by setting the AWS_REGION environment variable'
+                . ', or by setting a `region` in your specified profile.'
+            );
+        }
+
+        return new SigninClient([
+            self::KEY_CLIENT_REGION => $resolvedRegion,
+            self::KEY_CLIENT_SIGNATURE_VERSION => self::CLIENT_SIGNATURE_DPOP,
+            self::KEY_CLIENT_CREDENTIALS => false
+        ]);
+    }
+
+    /**
+     * Creates a Credentials object from token data
+     *
+     * @param array $tokenData The token data containing access key, secret, and session token
+     * @param int $expiration Unix timestamp for credential expiration
+     * @param string $accountId The AWS account ID
+     *
+     * @return Credentials The created Credentials object
+     */
+    private static function createCredentials(
+        array $tokenData,
+        int $expiration,
+        string $accountId
+    ): Credentials
+    {
+        return new Credentials(
+            $tokenData[self::KEY_ACCESS_KEY_ID],
+            $tokenData[self::KEY_SECRET_ACCESS_KEY],
+            $tokenData[self::KEY_SESSION_TOKEN],
+            $expiration,
+            $accountId,
+            CredentialSources::PROFILE_LOGIN
+        );
+    }
+
+    /**
+     * Checks if all required keys are present and non-empty in the data array
+     *
+     * @param array $data The data array to check
+     * @param array $requiredKeys The list of keys that must be present and non-empty
+     *
+     * @return bool True if all required keys are present and non-empty, false otherwise
+     */
+    private static function hasAllRequiredKeys(
+        array $data,
+        array $requiredKeys
+    ): bool
+    {
+        foreach ($requiredKeys as $key) {
+            if (empty($data[$key])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/MetricsBuilder.php
+++ b/src/MetricsBuilder.php
@@ -53,6 +53,7 @@ final class MetricsBuilder
     const CREDENTIALS_PROFILE_PROCESS = "v";
     const CREDENTIALS_PROFILE_SSO = "r";
     const CREDENTIALS_PROFILE_SSO_LEGACY = "t";
+    const CREDENTIALS_PROFILE_LOGIN = "AC";
 
     /** @var int */
     private static $MAX_METRICS_SIZE = 1024; // 1KB or 1024 B
@@ -249,6 +250,8 @@ final class MetricsBuilder
                 self::CREDENTIALS_PROFILE_SSO,
             CredentialSources::PROFILE_SSO_LEGACY =>
                 self::CREDENTIALS_PROFILE_SSO_LEGACY,
+            CredentialSources::PROFILE_LOGIN =>
+                self::CREDENTIALS_PROFILE_LOGIN
         ];
         if (isset($credentialsMetricMapping[$source])) {
             $this->append($credentialsMetricMapping[$source]);

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -6,6 +6,7 @@ use Aws\Api\Validator;
 use Aws\Credentials\CredentialsInterface;
 use Aws\EndpointV2\EndpointProviderV2;
 use Aws\Exception\AwsException;
+use Aws\Signature\DpopSignature;
 use Aws\Signature\S3ExpressSignature;
 use Aws\Token\TokenAuthorization;
 use Aws\Token\TokenInterface;
@@ -154,44 +155,41 @@ final class Middleware
                 RequestInterface $request
             ) use ($handler, $signatureFunction, $credProvider, $tokenProvider, $config) {
                 $signer = $signatureFunction($command);
+
+                // Token authorization path
                 if ($signer instanceof TokenAuthorization) {
-                    return $tokenProvider()->then(
-                        function (TokenInterface $token)
-                        use ($handler, $command, $signer, $request) {
-                            $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
-                                'token',
-                                $token
-                            );
-
-                            return $handler(
-                                $command,
-                                $signer->authorizeRequest($request, $token)
-                            );
-                        }
-                    );
+                    return $tokenProvider()->then(function (TokenInterface $token) use ($handler, $command, $signer, $request) {
+                        $command->getMetricsBuilder()->identifyMetricByValueAndAppend('token', $token);
+                        return $handler($command, $signer->authorizeRequest($request, $token));
+                    });
                 }
 
-                if ($signer instanceof S3ExpressSignature) {
-                    $credentialPromise = $config['s3_express_identity_provider']($command);
-                } else {
-                    $credentialPromise = $credProvider();
-                }
-
-                return $credentialPromise->then(
-                    function (CredentialsInterface $creds)
-                    use ($handler, $command, $signer, $request) {
-                        // Capture credentials metric
-                        $command->getMetricsBuilder()->identifyMetricByValueAndAppend(
-                            'credentials',
-                            $creds
-                        );
-
-                        return $handler(
-                            $command,
-                            $signer->signRequest($request, $creds)
+                // DPoP path
+                if ($signer instanceof DpopSignature) {
+                    if (empty($key = $command['dpopKey'])
+                        || !($key instanceof \OpenSSLAsymmetricKey)
+                    ) {
+                        throw new \RuntimeException(
+                            'A valid DPoP key must be present for DPoP signatures'
                         );
                     }
-                );
+
+                    return $handler($command, $signer->signRequest($request, $key));
+                }
+
+                // Credential signing path
+                $credentialPromise = ($signer instanceof S3ExpressSignature)
+                    ? $config['s3_express_identity_provider']($command)
+                    : $credProvider();
+
+                return $credentialPromise->then(function (CredentialsInterface $creds) use ($handler,
+                    $command,
+                    $signer,
+                    $request
+                ) {
+                    $command->getMetricsBuilder()->identifyMetricByValueAndAppend('credentials', $creds);
+                    return $handler($command, $signer->signRequest($request, $creds));
+                });
             };
         };
     }

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -825,7 +825,7 @@ namespace Aws;
  */
 class Sdk
 {
-    const VERSION = '3.361.0';
+    const VERSION = '3.362.0';
 
     /** @var array Arguments for creating clients */
     private $args;

--- a/src/Signature/DpopSignature.php
+++ b/src/Signature/DpopSignature.php
@@ -1,0 +1,246 @@
+<?php
+namespace Aws\Signature;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use Random\RandomException;
+
+final class DpopSignature
+{
+    public const ALLOW_LISTED_SERVICES = ['signin' => true];
+    private const EXT_OPENSSL = 'openssl';
+    private const CURVE_NAME = 'prime256v1';
+    private const HEADER_DPOP = 'DPop';
+    private const HEADER_TYP = 'dpop+jwt';
+    private const HEADER_ALG = 'ES256';
+    private const HEADER_JWK_KTY = 'EC';
+    private const HEADER_JWK_CRV = 'P-256';
+    private const PAYLOAD_HTM = 'POST';
+    private const JWK_SCHEMA = [
+        'kty' => self::HEADER_JWK_KTY,
+        'crv' => self::HEADER_JWK_CRV,
+    ];
+    private const HEADER_SCHEMA = [
+        'typ' => self::HEADER_TYP,
+        'alg' => self::HEADER_ALG,
+        'jwk' => self::JWK_SCHEMA
+    ];
+    private const PAYLOAD_SCHEMA = [
+        'htm' => self::PAYLOAD_HTM,
+    ];
+
+    /**
+     * Creates a new DpopSignature instance for the specified service
+     *
+     * @param string $serviceName The name of the AWS service (must be in the allow list)
+     *
+     * @throws \RuntimeException If the OpenSSL extension is not loaded
+     * @throws \InvalidArgumentException If the service is not in the allow list
+     */
+    public function __construct(string $serviceName)
+    {
+        if (!extension_loaded(self::EXT_OPENSSL)) {
+            throw new \RuntimeException(
+                'the `openssl` extension is required to generate DPop signatures. '
+                . 'Please install or enable the `openssl` extension.'
+            );
+        }
+
+        if (!isset(self::ALLOW_LISTED_SERVICES[$serviceName])) {
+            throw new \InvalidArgumentException(
+                "The '{$serviceName}' service does not support DPop signatures. "
+                . 'Please configure a signature version this service supports.'
+            );
+        }
+    }
+
+    /**
+     * Signs an HTTP request with a DPoP header
+     *
+     * @param RequestInterface $request The HTTP request to sign
+     * @param \OpenSSLAsymmetricKey $key The private key for signing
+     *
+     * @return RequestInterface The request with the DPoP header added
+     * @throws \RuntimeException|\Exception If signature generation fails
+     */
+    public function signRequest(
+        RequestInterface $request,
+        \OpenSSLAsymmetricKey $key,
+    ) {
+        $dpopHeaderValue = $this->generateDpopProof($key, $request->getUri());
+
+        return $request->withHeader(self::HEADER_DPOP, $dpopHeaderValue);
+    }
+
+    /**
+     * Generates the DPoP JWT header value for the request
+     *
+     * @param \OpenSSLAsymmetricKey $key The private key for signing
+     * @param UriInterface $uri The URI of the request
+     *
+     * @return string The complete DPoP JWT token
+     * @throws \RuntimeException|\Exception If signature generation fails
+     */
+    private function generateDpopProof(
+        \OpenSSLAsymmetricKey $key,
+        UriInterface $uri
+    ): string
+    {
+        $keyDetails = openssl_pkey_get_details($key);
+        if (($keyDetails['ec']['curve_name'] ?? '') !== self::CURVE_NAME) {
+            throw new \InvalidArgumentException(
+                'DPoP signature keys must use P-256 curve. '
+                . 'Please check your configuration and try again.'
+            );
+        }
+
+        ['x' => $x, 'y' => $y] = $keyDetails['ec'];
+        $header = $this->buildDpopHeader($x, $y);
+        $payload = $this->buildDpopPayload((string) $uri);
+
+        $message = $this->base64url_encode(json_encode($header))
+            . '.' . $this->base64url_encode(json_encode($payload));
+        $signature = '';
+        if (!openssl_sign($message, $signature, $key, OPENSSL_ALGO_SHA256)) {
+            $error = openssl_error_string();
+
+            throw new \RuntimeException(
+                'Failed to generate signature.' . ($error ? ": $error" : '.')
+            );
+        }
+
+        $signature = $this->derToRaw($signature);
+
+        return $message . '.' . $this->base64url_encode($signature);
+    }
+
+    /**
+     * Builds the DPoP JWT header with the public key coordinates
+     *
+     * @param string $x The x-coordinate of the EC public key
+     * @param string $y The y-coordinate of the EC public key
+     *
+     * @return array The complete DPoP header with JWK
+     */
+    private function buildDpopHeader(string $x, string $y): array
+    {
+        return array_merge_recursive(self::HEADER_SCHEMA, [
+            'jwk' => [
+                'x' => $this->base64url_encode($x),
+                'y' => $this->base64url_encode($y)
+            ]
+        ]);
+    }
+
+    /**
+     * Builds the DPoP JWT payload with request-specific claims
+     *
+     * @param string $uri The target URI for the HTTP request
+     *
+     * @return array The complete DPoP payload with jti, htm, htu, and iat claims
+     * @throws RandomException
+     */
+    private function buildDpopPayload(string $uri): array
+    {
+        return array_merge(self::PAYLOAD_SCHEMA, [
+            'jti' => $this->uuidv4(),
+            'htu' => $uri,
+            'iat' => time()
+        ]);
+    }
+
+    /**
+     * Generates a version 4 UUID
+     *
+     * @return string A UUID v4 string
+     * @throws RandomException
+     */
+    private function uuidv4(): string
+    {
+        $data = random_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+
+    /**
+     * Encodes data to Base64URL format (RFC 4648)
+     *
+     * @param string $data The data to encode
+     *
+     * @return string Base64URL encoded string (no padding, URL-safe characters)
+     */
+    private function base64url_encode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * Convert DER-encoded ECDSA signature to raw R||S format (64 bytes for ES256)
+     *
+     * @param string $derSignature DER-encoded signature from openssl_sign
+     *
+     * @return string Raw signature (64 bytes: 32 bytes R + 32 bytes S)
+     * @throws \Exception If the DER signature is invalid
+     */
+    private function derToRaw(string $derSignature): string
+    {
+        $hex = bin2hex($derSignature);
+        $pos = 0;
+        
+        // Parse SEQUENCE tag (0x30)
+        if (substr($hex, $pos, 2) !== '30') {
+            throw new \Exception('Invalid DER signature format: missing SEQUENCE tag');
+        }
+        $pos += 2;
+        
+        // Parse SEQUENCE length
+        $seqLen = hexdec(substr($hex, $pos, 2));
+        $pos += 2;
+        
+        // Parse first INTEGER tag (0x02) for R
+        if (substr($hex, $pos, 2) !== '02') {
+            throw new \Exception('Invalid DER signature format: missing R INTEGER tag');
+        }
+        $pos += 2;
+        
+        // Parse R length
+        $rLen = hexdec(substr($hex, $pos, 2));
+        $pos += 2;
+        
+        // Extract R value
+        $r = substr($hex, $pos, $rLen * 2);
+        if (strlen($r) !== $rLen * 2) {
+            throw new \Exception('Invalid DER signature: R length mismatch');
+        }
+        $pos += $rLen * 2;
+        
+        // Parse second INTEGER tag (0x02) for S  
+        if (substr($hex, $pos, 2) !== '02') {
+            throw new \Exception('Invalid DER signature format: missing S INTEGER tag');
+        }
+        $pos += 2;
+        
+        // Parse S length
+        $sLen = hexdec(substr($hex, $pos, 2));
+        $pos += 2;
+        
+        // Extract S value
+        $s = substr($hex, $pos, $sLen * 2);
+        if (strlen($s) !== $sLen * 2) {
+            throw new \Exception('Invalid DER signature: S length mismatch');
+        }
+        
+        // Remove leading zeros (if any) and pad to 32 bytes
+        $r = str_pad(ltrim($r, '0'), 64, '0', STR_PAD_LEFT);
+        $s = str_pad(ltrim($s, '0'), 64, '0', STR_PAD_LEFT);
+        
+        // Ensure exactly 32 bytes each
+        if (strlen($r) !== 64 || strlen($s) !== 64) {
+            throw new \Exception('Invalid signature component length');
+        }
+        
+        return hex2bin($r . $s);
+    }
+}

--- a/src/Signature/SignatureProvider.php
+++ b/src/Signature/SignatureProvider.php
@@ -65,6 +65,7 @@ class SignatureProvider
         $result = $provider($version, $service, $region);
         if ($result instanceof SignatureInterface
             || $result instanceof BearerTokenAuthorization
+            || $result instanceof DpopSignature
         ) {
             return $result;
         }
@@ -139,6 +140,8 @@ class SignatureProvider
                     return new BearerTokenAuthorization();
                 case 'anonymous':
                     return new AnonymousSignature();
+                case 'dpop':
+                    return new DpopSignature($service);
                 default:
                     return null;
             }

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -382,6 +382,22 @@ class ClientResolverTest extends TestCase
         $this->assertSame('anonymous', $conf['config']['signature_version']);
     }
 
+    public function testCanCreateNullCredentialsWithDpop()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $conf = $r->resolve([
+            'service' => 'sqs',
+            'region' => 'x',
+            'credentials' => false,
+            'signature_version' => 'dpop'
+        ], new HandlerList());
+        $creds = call_user_func($conf['credentials'])->wait();
+        $this->assertInstanceOf(Credentials::class, $creds);
+        // `'credentials' => false` results in a signature_version overwrite
+        // to 'anonymous' for any other value
+        $this->assertSame('dpop', $conf['config']['signature_version']);
+    }
+
     public function testCanCreateCredentialsFromProvider()
     {
         $c = new Credentials('foo', 'bar');

--- a/tests/Credentials/LoginCredentialProviderTest.php
+++ b/tests/Credentials/LoginCredentialProviderTest.php
@@ -1,0 +1,1722 @@
+<?php
+namespace Aws\Test\Credentials;
+
+use Aws\CommandInterface;
+use Aws\Credentials\LoginCredentialProvider;
+use Aws\Credentials\CredentialSources;
+use Aws\Exception\AwsException;
+use Aws\Exception\CredentialsException;
+use Aws\Result;
+use Aws\Signin\SigninClient;
+use Aws\Signin\Exception\SigninException;
+use Aws\Test\UsesServiceTrait;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * @covers Aws\Credentials\LoginCredentialProvider
+ */
+class LoginCredentialProviderTest extends TestCase
+{
+    use UsesServiceTrait;
+
+    /** @var array<string, string|false> */
+    private array $originalEnv = [];
+
+    /** @var list<string> */
+    private array $tempDirs = [];
+
+    /**
+     * Environment variables to track
+     */
+    private const ENV_VARS_TO_TRACK = [
+        'HOME',
+        'HOMEDRIVE',
+        'HOMEPATH',
+        'AWS_PROFILE',
+        'AWS_REGION',
+        'AWS_DEFAULT_REGION',
+        'AWS_LOGIN_CACHE_DIRECTORY',
+        'AWS_CONFIG_FILE',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Snapshot all tracked env vars
+        foreach (self::ENV_VARS_TO_TRACK as $var) {
+            $this->originalEnv[$var] = getenv($var);
+        }
+
+        // Clear AWS-specific env vars
+        putenv('AWS_PROFILE=');
+        putenv('AWS_REGION=');
+        putenv('AWS_DEFAULT_REGION=');
+        putenv('AWS_LOGIN_CACHE_DIRECTORY=');
+        putenv('AWS_CONFIG_FILE=');
+        unset($_SERVER['AWS_PROFILE'],
+            $_SERVER['AWS_REGION'],
+            $_SERVER['AWS_DEFAULT_REGION'],
+            $_SERVER['AWS_LOGIN_CACHE_DIRECTORY'],
+            $_SERVER['AWS_CONFIG_FILE']
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore all tracked env vars to their original values
+        foreach ($this->originalEnv as $key => $value) {
+            if ($value !== false) {
+                putenv("$key=$value");
+                $_SERVER[$key] = $value;
+            } else {
+                putenv("$key=");
+                if (isset($_SERVER[$key])) {
+                    unset($_SERVER[$key]);
+                }
+            }
+        }
+        $this->originalEnv = [];
+
+        // Clean any temp dirs created during tests
+        foreach ($this->tempDirs as $dir) {
+            if (is_dir($dir)) {
+                $this->recursiveDelete($dir);
+            }
+        }
+        $this->tempDirs = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * Create an isolated temp HOME with a `.aws` dir.
+     * Sets HOME to the temp base dir and returns the `.aws` path.
+     */
+    private function createAwsHome(): string
+    {
+        $base = sys_get_temp_dir() . '/aws_test_' . uniqid('', true);
+        $awsDir = $base . '/.aws';
+        mkdir($awsDir, 0777, true);
+        $this->tempDirs[] = $base;
+        putenv('HOME=' . $base);
+        $_SERVER['HOME'] = $base;
+        return $awsDir;
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(
+                $dir,
+            \RecursiveDirectoryIterator::SKIP_DOTS
+            ),
+        \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $file) {
+            $path = $file->getPathname();
+            if ($file->isDir()) {
+                @rmdir($path);
+            } else {
+                @unlink($path);
+            }
+        }
+        @rmdir($dir);
+    }
+
+    private function createValidTokenCache(
+        string $awsDir,
+        string $loginSession,
+        array $overrides = []
+    ): string
+    {
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() + 3600);
+        $tokenData = array_merge([
+            'accessToken' => [
+                'accessKeyId' => 'testKey',
+                'secretAccessKey' => 'testSecret',
+                'sessionToken' => 'testToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ],
+            'tokenType' => 'aws_sigv4',
+            'refreshToken' => 'testRefresh',
+            'idToken' => 'testId',
+            'clientId' => 'arn:aws:signin:::devtools/same-device',
+            'dpopKey' => "-----BEGIN EC PRIVATE KEY-----\n" .
+"MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+"AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+"rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+"-----END EC PRIVATE KEY-----"
+        ], $overrides);
+        
+        file_put_contents($tokenFile, json_encode($tokenData));
+        return $tokenFile;
+    }
+
+    private function createConfigFile(
+        string $awsDir,
+        string $profileName,
+        string $loginSession
+    ): string
+    {
+        $configFile = $awsDir . '/config';
+        $prefix = $profileName === 'default' ? '' : 'profile ';
+        $config = <<<EOT
+[{$prefix}{$profileName}]
+login_session = {$loginSession}
+region = us-east-1
+EOT;
+        file_put_contents($configFile, $config);
+        return $configFile;
+    }
+
+    public function testConstructorFailsWithMissingConfigFile(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('Unable to load configuration file');
+        
+        $awsDir = $this->createAwsHome();
+        // Don't create config file
+
+        new LoginCredentialProvider('default', 'us-west-2');
+    }
+
+    public function testConstructorFailsWithMissingProfile(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage("Profile 'nonexistent' does not exist");
+        
+        $awsDir = $this->createAwsHome();
+        $this->createConfigFile(
+            $awsDir,
+            'default',
+            'arn:aws:iam::123456789012:user/TestUser'
+        );
+
+        new LoginCredentialProvider('nonexistent', 'us-west-2');
+    }
+
+    public function testConstructorFailsWithMissingLoginSession(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('did not contain a login_session value');
+        
+        $awsDir = $this->createAwsHome();
+        $configFile = $awsDir . '/config';
+        $config = <<<EOT
+[default]
+region = us-east-1
+EOT;
+        file_put_contents($configFile, $config);
+
+        new LoginCredentialProvider('default');
+    }
+
+    public function testConstructorFailsWithMissingCacheFile(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('Failed to load cached credentials');
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        // Don't create cache file
+
+        new LoginCredentialProvider('default', 'us-west-2');
+    }
+
+    public function testConstructorHandlesProfilePrefix(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('Failed to load cached credentials');
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'myprofile', $loginSession);
+
+        new LoginCredentialProvider('myprofile', 'us-west-2');
+    }
+
+    public function testUsesCustomCacheDirectory(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('Failed to load cached credentials');
+        
+        $awsDir = $this->createAwsHome();
+        $customCacheDir = sys_get_temp_dir() . '/custom_cache_' . uniqid('', true);
+        $this->tempDirs[] = $customCacheDir;
+        
+        putenv('AWS_LOGIN_CACHE_DIRECTORY=' . $customCacheDir);
+        
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+
+        new LoginCredentialProvider('default', 'us-west-2');
+    }
+
+    public function testLoadCredentialsFromValidCache(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        $this->createValidTokenCache($awsDir, $loginSession);
+
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        
+        $credentials = $provider()->wait();
+        
+        $this->assertEquals(CredentialSources::PROFILE_LOGIN, $credentials->getSource());
+        $this->assertEquals('testKey', $credentials->getAccessKeyId());
+        $this->assertEquals('testSecret', $credentials->getSecretKey());
+        $this->assertEquals('testToken', $credentials->getSecurityToken());
+        $this->assertEquals('123456789012', $credentials->getAccountId());
+    }
+
+    public function testLoadTokenFailsWithInvalidJson(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('Invalid JSON in cache file');
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        file_put_contents($tokenFile, 'invalid json {');
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $provider()->wait();
+    }
+
+    /**
+     * @dataProvider missingCacheKeysProvider
+     */
+    public function testLoadTokenFailsWithMissingOrEmptyCacheKeys(
+        array $tokenData,
+        string $expectedMessage
+    ): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage($expectedMessage);
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        file_put_contents($tokenFile, json_encode($tokenData));
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $provider()->wait();
+    }
+    
+    public function missingCacheKeysProvider(): array
+    {
+        $validDpopKey = "-----BEGIN EC PRIVATE KEY-----\n" .
+            "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+            "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+            "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+            "-----END EC PRIVATE KEY-----";
+            
+        return [
+            'missing refreshToken' => [
+                [
+                    'accessToken' => [
+                        'accessKeyId' => 'testKey',
+                        'secretAccessKey' => 'testSecret',
+                        'sessionToken' => 'testToken',
+                        'accountId' => '123456789012',
+                        'expiresAt' => '2500-01-01T00:00:00Z'
+                    ],
+                    'tokenType' => 'aws_sigv4',
+                    // Missing refreshToken
+                    'idToken' => 'testId',
+                    'clientId' => 'arn:aws:signin:::devtools/same-device',
+                    'dpopKey' => $validDpopKey
+                ],
+                'Missing required keys in cached token'
+            ],
+            'missing secretAccessKey in accessToken' => [
+                [
+                    'accessToken' => [
+                        'accessKeyId' => 'testKey',
+                        // Missing secretAccessKey
+                        'sessionToken' => 'testToken',
+                        'accountId' => '123456789012',
+                        'expiresAt' => '2500-01-01T00:00:00Z'
+                    ],
+                    'tokenType' => 'aws_sigv4',
+                    'refreshToken' => 'testRefresh',
+                    'idToken' => 'testId',
+                    'clientId' => 'arn:aws:signin:::devtools/same-device',
+                    'dpopKey' => $validDpopKey
+                ],
+                'Missing required keys in cached token'
+            ],
+            'empty accessToken array' => [
+                [
+                    'accessToken' => [],
+                    'tokenType' => 'aws_sigv4',
+                    'refreshToken' => 'testRefresh',
+                    'idToken' => 'testId',
+                    'clientId' => 'arn:aws:signin:::devtools/same-device',
+                    'dpopKey' => $validDpopKey
+                ],
+                'Missing required keys in cached token'
+            ],
+            'empty string sessionToken' => [
+                [
+                    'accessToken' => [
+                        'accessKeyId' => 'testKey',
+                        'secretAccessKey' => 'testSecret',
+                        'sessionToken' => '', // Empty string session token
+                        'accountId' => '123456789012',
+                        'expiresAt' => '2500-01-01T00:00:00Z'
+                    ],
+                    'tokenType' => 'aws_sigv4',
+                    'refreshToken' => 'testRefresh',
+                    'idToken' => 'testId',
+                    'clientId' => 'arn:aws:signin:::devtools/same-device',
+                    'dpopKey' => $validDpopKey
+                ],
+                'Missing required keys in cached token'
+            ],
+            'missing dpopKey' => [
+                [
+                    'accessToken' => [
+                        'accessKeyId' => 'testKey',
+                        'secretAccessKey' => 'testSecret',
+                        'sessionToken' => 'testToken',
+                        'accountId' => '123456789012',
+                        'expiresAt' => '2500-01-01T00:00:00Z'
+                    ],
+                    'tokenType' => 'aws_sigv4',
+                    'refreshToken' => 'testRefresh',
+                    'idToken' => 'testId',
+                    'clientId' => 'arn:aws:signin:::devtools/same-device',
+                    // Missing dpopKey
+                ],
+                'Missing required keys in cached token'
+            ],
+            'missing clientId' => [
+                [
+                    'accessToken' => [
+                        'accessKeyId' => 'testKey',
+                        'secretAccessKey' => 'testSecret',
+                        'sessionToken' => 'testToken',
+                        'accountId' => '123456789012',
+                        'expiresAt' => '2500-01-01T00:00:00Z'
+                    ],
+                    'tokenType' => 'aws_sigv4',
+                    'refreshToken' => 'testRefresh',
+                    'idToken' => 'testId',
+                    // Missing clientId
+                    'dpopKey' => $validDpopKey
+                ],
+                'Missing required keys in cached token'
+            ]
+        ];
+    }
+
+    public function testLoadTokenFailsWithInvalidDpopKey(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('Failed to load DPoP private key');
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'testKey',
+                    'secretAccessKey' => 'testSecret',
+                    'sessionToken' => 'testToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => '2500-01-01T00:00:00Z'
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => 'invalid key data'
+            ],
+            JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $provider()->wait();
+    }
+
+
+    public function testShouldRefreshReturnsTrueForExpiringCredentials(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        // Create credentials expiring in 2 minutes (within 3 minute threshold)
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() + 120);
+        $this->createValidTokenCache($awsDir, $loginSession, [
+            'accessToken' => [
+                'accessKeyId' => 'testKey',
+                'secretAccessKey' => 'testSecret',
+                'sessionToken' => 'testToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ]
+        ]);
+        
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+
+        $refreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'newRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'refreshedKey',
+                    'secretAccessKey' => 'refreshedSecret',
+                    'sessionToken' => 'refreshedToken',
+                ],
+                'expiresIn' => 3600
+            ]
+        ]);
+        
+        $this->addMockResults($mockClient, [$refreshResult]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        $credentials = $provider()->wait();
+        
+        // Should have refreshed
+        $this->assertEquals('refreshedKey', $credentials->getAccessKeyId());
+    }
+
+    public function testShouldRefreshReturnsFalseForFreshCredentials(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        // Create credentials expiring in 10 minutes (outside 3 minute threshold)
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() + 600);
+        $this->createValidTokenCache($awsDir, $loginSession, [
+            'accessToken' => [
+                'accessKeyId' => 'testKey',
+                'secretAccessKey' => 'testSecret',
+                'sessionToken' => 'testToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ]
+        ]);
+        
+        $mockClient = $this->createMock(SigninClient::class);
+        // Should not call refresh
+        $mockClient->expects($this->never())->method('__call');
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        $credentials = $provider()->wait();
+        
+        // Should use existing credentials
+        $this->assertEquals('testKey', $credentials->getAccessKeyId());
+    }
+
+    public function testRefreshUpdatesCredentialsCorrectly(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create expired credentials
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'expiredKey',
+                    'secretAccessKey' => 'expiredSecret',
+                    'sessionToken' => 'expiredToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => $expiration
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => "-----BEGIN PRIVATE KEY-----\n" .
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUCM6wO00sOZ3xv1I\n" .
+    "HUZQk6Owz3nW+TPqxFHKzsli6VOhRANCAASB46Rm/KSro0ieDm88ztr43WflZZN5\n" .
+    "ttLT1iSB4ORVJ7mRJ0MVrk7phe/nK6oLp925JsYfzdJyGqYJEGmD+TwC\n" .
+    "-----END PRIVATE KEY-----"
+            ],
+            JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $refreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'newRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'refreshedKey',
+                    'secretAccessKey' => 'refreshedSecret',
+                    'sessionToken' => 'refreshedToken',
+                ],
+                'expiresIn' => 3600
+            ]
+        ]);
+        
+        $this->addMockResults($mockClient, [$refreshResult]);
+        
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        $credentials = $provider()->wait();
+        
+        $this->assertEquals('refreshedKey', $credentials->getAccessKeyId());
+        $this->assertEquals('refreshedSecret', $credentials->getSecretKey());
+        $this->assertEquals('refreshedToken', $credentials->getSecurityToken());
+    }
+
+    public function testContinuesWithExistingTokenAfterRefreshFailure(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        // Create credentials expiring in 5 minutes (within refresh window)
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() + 300);
+        $this->createValidTokenCache($awsDir, $loginSession, [
+            'accessToken' => [
+                'accessKeyId' => 'existingKey',
+                'secretAccessKey' => 'existingSecret',
+                'sessionToken' => 'existingToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ]
+        ]);
+        
+        // Use test client with mock handler that returns a network error
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        // Add a generic network error to the mock handler
+        $mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+        $exception = new AwsException(
+            'Network error',
+            $mockCommand,
+            [
+                'code' => 'Network error',
+            ]
+        );
+        $this->addMockResults($mockClient, [$exception]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        $credentials = @$provider()->wait();
+        
+        // Should use existing credentials despite refresh failure
+        $this->assertEquals('existingKey', $credentials->getAccessKeyId());
+        $this->assertEquals('existingSecret', $credentials->getSecretKey());
+        $this->assertEquals('existingToken', $credentials->getSecurityToken());
+    }
+
+    public function testRefreshThrowsOnTokenExpiredError(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage(
+            'Your session has expired. Please reauthenticate using `aws login`'
+        );
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        // Create expired credentials to force refresh
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $this->createValidTokenCache($awsDir, $loginSession, [
+            'accessToken' => [
+                'accessKeyId' => 'expiredKey',
+                'secretAccessKey' => 'expiredSecret',
+                'sessionToken' => 'expiredToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ]
+        ]);
+
+        $mockClient = $this->getTestClient(
+            'Signin', 
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+        $exception = new SigninException(
+            'Token expired',
+            $mockCommand,
+            [
+                'code' => 'AccessDeniedException',
+                'body' => ['error' => 'token_expired']
+            ]
+        );
+        
+        $this->addMockResults($mockClient, [$exception]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        @$provider()->wait();
+    }
+
+    public function testRefreshThrowsOnUserCredentialsChangedError(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage('Unable to refresh credentials because of a change in your password');
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        // Create expired credentials to force refresh
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $this->createValidTokenCache($awsDir, $loginSession, [
+            'accessToken' => [
+                'accessKeyId' => 'expiredKey',
+                'secretAccessKey' => 'expiredSecret',
+                'sessionToken' => 'expiredToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ]
+        ]);
+
+        $mockClient = $this->getTestClient(
+            'Signin', 
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+        $exception = new SigninException(
+            'User credentials changed',
+            $mockCommand,
+            [
+                'code' => 'AccessDeniedException',
+                'body' => ['error' => 'user_credentials_changed']
+            ]
+        );
+        
+        $this->addMockResults($mockClient, [$exception]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        @$provider()->wait();
+    }
+
+    public function testRefreshThrowsOnInsufficientPermissionsError(): void
+    {
+        $this->expectException(CredentialsException::class);
+        $this->expectExceptionMessage(
+            'Unable to refresh credentials due to insufficient permissions'
+        );
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        // Create expired credentials to force refresh
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $this->createValidTokenCache($awsDir, $loginSession, [
+            'accessToken' => [
+                'accessKeyId' => 'expiredKey',
+                'secretAccessKey' => 'expiredSecret',
+                'sessionToken' => 'expiredToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ]
+        ]);
+
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+
+        $mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+        $exception = new SigninException(
+            'Insufficient permissions',
+            $mockCommand,
+            [
+                'code' => 'AccessDeniedException',
+                'body' => ['error' => 'insufficient_permissions']
+            ]
+        );
+        
+        $this->addMockResults($mockClient, [$exception]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        @$provider()->wait();
+    }
+
+    public function testRefreshRethrowsOtherRefreshExceptions(): void
+    {
+        $this->expectException(CredentialsException::class);
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        // Create expired credentials to force refresh
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $this->createValidTokenCache($awsDir, $loginSession, [
+            'accessToken' => [
+                'accessKeyId' => 'expiredKey',
+                'secretAccessKey' => 'expiredSecret',
+                'sessionToken' => 'expiredToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ]
+        ]);
+
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+        $exception = new SigninException(
+            'Some other error',
+            $mockCommand,
+            [
+                'code' => 'SomeOtherError',
+                'body' => []
+            ]
+        );
+        
+        $this->addMockResults($mockClient, [$exception]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        @$provider()->wait();
+    }
+
+    public function testRefreshUpdatesInMemoryAndFileCache(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create expired credentials
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'expiredKey',
+                    'secretAccessKey' => 'expiredSecret',
+                    'sessionToken' => 'expiredToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => $expiration
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => "-----BEGIN PRIVATE KEY-----\n" .
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUCM6wO00sOZ3xv1I\n" .
+    "HUZQk6Owz3nW+TPqxFHKzsli6VOhRANCAASB46Rm/KSro0ieDm88ztr43WflZZN5\n" .
+    "ttLT1iSB4ORVJ7mRJ0MVrk7phe/nK6oLp925JsYfzdJyGqYJEGmD+TwC\n" .
+    "-----END PRIVATE KEY-----"
+            ],
+            JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+        
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $refreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'newRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'refreshedKey',
+                    'secretAccessKey' => 'refreshedSecret',
+                    'sessionToken' => 'refreshedToken',
+                    'accountId' => '123456789012'
+                ],
+                'expiresIn' => 3600
+            ]
+        ]);
+        
+        $this->addMockResults($mockClient, [$refreshResult]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        $credentials = $provider()->wait();
+        
+        // Should have refreshed
+        $this->assertEquals('refreshedKey', $credentials->getAccessKeyId());
+        $this->assertEquals('refreshedSecret', $credentials->getSecretKey());
+        $this->assertEquals('refreshedToken', $credentials->getSecurityToken());
+        
+        // Verify cache file was updated
+        $updatedCache = json_decode(file_get_contents($tokenFile), true);
+        $this->assertEquals('newRefresh', $updatedCache['refreshToken']);
+        $this->assertEquals('refreshedKey', $updatedCache['accessToken']['accessKeyId']);
+    }
+
+    public function testProviderCachesCredentialsInMemory(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create expired credentials
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'expiredKey',
+                    'secretAccessKey' => 'expiredSecret',
+                    'sessionToken' => 'expiredToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => $expiration
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => "-----BEGIN EC PRIVATE KEY-----\n" .
+    "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+    "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+    "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+    "-----END EC PRIVATE KEY-----"
+            ],
+            JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $refreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'newRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'refreshedKey',
+                    'secretAccessKey' => 'refreshedSecret',
+                    'sessionToken' => 'refreshedToken',
+                    'accountId' => '123456789012'
+                ],
+                'expiresIn' => 3600
+            ]
+        ]);
+        
+        $this->addMockResults($mockClient, [$refreshResult]);
+        
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        // First call should trigger refresh
+        $credentials1 = $provider()->wait();
+        $this->assertEquals('refreshedKey', $credentials1->getAccessKeyId());
+        
+        // Second call should use in-memory cache, not call refresh again
+        $credentials2 = $provider()->wait();
+        $this->assertEquals('refreshedKey', $credentials2->getAccessKeyId());
+        $this->assertSame($credentials1, $credentials2); // Should be the same object
+    }
+
+
+    public function testLoadsCredentialsWithValidCacheAndAccountId(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Test various date formats
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() + 7200);
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'testKey',
+                    'secretAccessKey' => 'testSecret',
+                    'sessionToken' => 'testToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => $expiration
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => "-----BEGIN EC PRIVATE KEY-----\n" .
+    "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+    "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+    "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+    "-----END EC PRIVATE KEY-----"
+            ],
+            JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        
+        $credentials = $provider()->wait();
+        
+        // Verify expiration is parsed correctly
+        $this->assertGreaterThan(time(), $credentials->getExpiration());
+        $this->assertLessThan(time() + 10000, $credentials->getExpiration());
+    }
+
+    public function testInvalidExpirationFormatThrowsException(): void
+    {
+        $this->expectException(CredentialsException::class);
+        
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create credentials with invalid expiration format
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'testKey',
+                    'secretAccessKey' => 'testSecret',
+                    'sessionToken' => 'testToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => 'invalid-date-format' // This will cause strtotime to fail
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => "-----BEGIN EC PRIVATE KEY-----\n" .
+    "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+    "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+    "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+    "-----END EC PRIVATE KEY-----"
+            ],
+            JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+        
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        
+        // This should throw due to invalid date format when loading the token
+        $provider()->wait();
+    }
+
+    public function testWriteToCacheMergesWithExistingCache(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create expired credentials with extra fields
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'expiredKey',
+                    'secretAccessKey' => 'expiredSecret',
+                    'sessionToken' => 'expiredToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => $expiration
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => "-----BEGIN PRIVATE KEY-----\n" .
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUCM6wO00sOZ3xv1I\n" .
+    "HUZQk6Owz3nW+TPqxFHKzsli6VOhRANCAASB46Rm/KSro0ieDm88ztr43WflZZN5\n" .
+    "ttLT1iSB4ORVJ7mRJ0MVrk7phe/nK6oLp925JsYfzdJyGqYJEGmD+TwC\n" .
+    "-----END PRIVATE KEY-----",
+                'extraField' => 'shouldBePreserved'
+            ],
+        JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $refreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'newRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'refreshedKey',
+                    'secretAccessKey' => 'refreshedSecret',
+                    'sessionToken' => 'refreshedToken',
+                ],
+                'expiresIn' => 3600
+            ]
+        ]);
+        
+        $this->addMockResults($mockClient, [$refreshResult]);
+        
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        $credentials = $provider()->wait();
+        
+        // Check that file was updated and extra fields preserved
+        $updatedData = json_decode(
+            file_get_contents($tokenFile),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertEquals('newRefresh', $updatedData['refreshToken']);
+        $this->assertEquals('refreshedKey', $updatedData['accessToken']['accessKeyId']);
+        $this->assertEquals('refreshedSecret', $updatedData['accessToken']['secretAccessKey']);
+        $this->assertEquals('refreshedToken', $updatedData['accessToken']['sessionToken']);
+        $this->assertEquals('shouldBePreserved', $updatedData['extraField']); // Extra fields should be preserved
+    }
+
+    /**
+     * Test that a key with specifiedCurve parameters works correctly
+     */
+    public function testLoadCredentialsWithSpecifiedCurveKey(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() + 3600);
+        
+        // Key with specifiedCurve parameters
+        $specifiedCurveKey = "-----BEGIN EC PRIVATE KEY-----\n" .
+            "MIIBUQIBAQQgW2JEXxOdj8dFip0hyS6SHr9dHciiZQyoTZoe6sox1KGggeMwgeAC\n" .
+            "AQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAAAAAAAAAAAAAA////////////////\n" .
+            "MEQEIP////8AAAABAAAAAAAAAAAAAAAA///////////////8BCBaxjXYqjqT57Pr\n" .
+            "vVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwRBBGsX0fLhLEJH+Lzm5WOkQPJ3A32BLesz\n" .
+            "oPShOUXYmMKWT+NC4v4af5uO5+tKfA+eFivOM1drMV7Oy7ZAaDe/UfUCIQD/////\n" .
+            "AAAAAP//////////vOb6racXnoTzucrC/GMlUQIBAaFEA0IABFqlTnAPfLQfFrmn\n" .
+            "uJFbpcMA89r5uhBzUe+KvRCCPpscjMats1NUCB64qslJ3QYEGuAx2BP2gOeQBUbl\n" .
+            "rSdm4F4=\n" .
+            "-----END EC PRIVATE KEY-----";
+        
+        $tokenData = json_encode(
+            [
+                'accessToken' => [
+                    'accessKeyId' => 'testKey',
+                    'secretAccessKey' => 'testSecret',
+                    'sessionToken' => 'testToken',
+                    'accountId' => '123456789012',
+                    'expiresAt' => $expiration
+                ],
+                'tokenType' => 'aws_sigv4',
+                'refreshToken' => 'testRefresh',
+                'idToken' => 'testId',
+                'clientId' => 'arn:aws:signin:::devtools/same-device',
+                'dpopKey' => $specifiedCurveKey
+            ],
+            JSON_THROW_ON_ERROR
+        );
+        
+        file_put_contents($tokenFile, $tokenData);
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        
+        $credentials = $provider()->wait();
+        
+        $this->assertEquals(CredentialSources::PROFILE_LOGIN, $credentials->getSource());
+        $this->assertEquals('testKey', $credentials->getAccessKeyId());
+        $this->assertEquals('testSecret', $credentials->getSecretKey());
+        $this->assertEquals('testToken', $credentials->getSecurityToken());
+        $this->assertEquals('123456789012', $credentials->getAccountId());
+    }
+
+    /**
+     * @dataProvider loginTestCasesProvider
+     */
+    public function testLoginCredentialProviderFromTestCases(
+        string $documentation,
+        string $configContents,
+        array $cacheContents,
+        array $mockApiCalls,
+        array $outcomes
+    ): void
+    {
+        $awsDir = $this->createAwsHome();
+
+        // Write the config file
+        file_put_contents($awsDir . '/config', $configContents);
+
+        // Set up cache files
+        if (!empty($cacheContents)) {
+            $cacheDir = $awsDir . '/login/cache';
+            mkdir($cacheDir, 0777, true);
+
+            foreach ($cacheContents as $filename => $content) {
+                file_put_contents($cacheDir . '/' . $filename, json_encode($content));
+            }
+        } else {
+            $this->expectException(CredentialsException::class);
+            $this->expectExceptionMessage(
+                "Failed to load cached credentials for profile 'signin'. "
+                . "Please reauthenticate using `aws login`."
+            );
+        }
+
+        $provider = new LoginCredentialProvider('signin', 'us-west-2');
+        if (!empty($mockApiCalls)) {
+            $mockClient = $this->getTestClient(
+                'Signin',
+                ['credentials' => false, 'signature_version' => 'dpop']
+            );
+
+            $mockResults = [];
+            foreach ($mockApiCalls as $call) {
+                if (isset($call['responseCode']) && $call['responseCode'] >= 400) {
+                    // Create an error response
+                    $mockCommand = $this->getMockBuilder(CommandInterface::class)->getMock();
+                    $exception = new SigninException(
+                        'API Error',
+                        $mockCommand,
+                        ['code' => 'Error', 'statusCode' => $call['responseCode']]
+                    );
+                    $mockResults[] = $exception;
+                } elseif (isset($call['response'])) {
+                    $mockResults[] = new Result($call['response']);
+                }
+            }
+
+            if (!empty($mockResults)) {
+                $this->addMockResults($mockClient, $mockResults);
+
+                $reflection = new \ReflectionClass($provider);
+                $clientProperty = $reflection->getProperty('client');
+                $clientProperty->setValue($provider, $mockClient);
+            }
+        }
+
+        foreach ($outcomes as $outcome) {
+            switch ($outcome['result']) {
+                case 'error':
+                    $this->expectException(CredentialsException::class);
+                    @$provider()->wait();
+
+                    break;
+
+                case 'credentials':
+                    $credentials = $provider()->wait();
+
+                    $this->assertEquals($outcome['accessKeyId'], $credentials->getAccessKeyId());
+                    $this->assertEquals($outcome['secretAccessKey'], $credentials->getSecretKey());
+                    $this->assertEquals($outcome['sessionToken'], $credentials->getSecurityToken());
+                    $this->assertEquals($outcome['accountId'], $credentials->getAccountId());
+                    $this->assertEquals(CredentialSources::PROFILE_LOGIN, $credentials->getSource());
+
+                    break;
+
+                case 'cacheContents':
+                    foreach ($outcome as $filename => $expectedContent) {
+                        if ($filename === 'result') {
+                            continue;
+                        }
+
+                        $actualPath = $awsDir . '/login/cache/' . $filename;
+                        if (file_exists($actualPath)) {
+                            $actualContent = json_decode(file_get_contents($actualPath), true);
+                            if (isset($expectedContent['accessToken'])) {
+                                $this->assertArrayHasKey('accessToken', $actualContent);
+
+                                $expectedToken = $expectedContent['accessToken'];
+                                $actualToken = $actualContent['accessToken'];
+
+                                $this->assertEquals(
+                                    $expectedToken['accessKeyId'],
+                                    $actualToken['accessKeyId']
+                                );
+                                $this->assertEquals(
+                                    $expectedToken['secretAccessKey'],
+                                    $actualToken['secretAccessKey']
+                                );
+                                $this->assertEquals(
+                                    $expectedToken['sessionToken'],
+                                    $actualToken['sessionToken']
+                                );
+                            }
+
+                            if (isset($expectedContent['refreshToken'])) {
+                                $this->assertEquals(
+                                    $expectedContent['refreshToken'],
+                                    $actualContent['refreshToken']
+                                );
+                            }
+                        }
+                    }
+
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Provider for test cases from JSON file
+     *
+     * @return \Generator
+     * @throws \JsonException
+     */
+    public function loginTestCasesProvider(): \Generator
+    {
+        $testCasesFile = __DIR__ . '/fixtures/login/test-cases.json';
+
+        if (!file_exists($testCasesFile)) {
+            throw new \RuntimeException("Test cases file not found: {$testCasesFile}");
+        }
+
+        $testCases = json_decode(
+            file_get_contents($testCasesFile),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        foreach ($testCases as $index => $testCase) {
+            yield $testCase['documentation'] => [
+                $testCase['documentation'],
+                $testCase['configContents'],
+                $testCase['cacheContents'] ?? [],
+                $testCase['mockApiCalls'] ?? [],
+                $testCase['outcomes']
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider externalRefreshProvider
+     */
+    public function testExternalRefreshBehavior(
+        string $scenario,
+        int $currentExpiryMinutes,
+        int $diskExpiryMinutes,
+        bool $sameRefreshToken,
+        bool $shouldUseExternal
+    ): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create initial token that will expire and trigger refresh
+        $currentExpiration = gmdate('Y-m-d\TH:i:s\Z', time() + ($currentExpiryMinutes * 60));
+        $initialTokenData = [
+            'accessToken' => [
+                'accessKeyId' => 'currentKey',
+                'secretAccessKey' => 'currentSecret',
+                'sessionToken' => 'currentToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $currentExpiration
+            ],
+            'tokenType' => 'aws_sigv4',
+            'refreshToken' => 'currentRefresh',
+            'idToken' => 'testId',
+            'clientId' => 'arn:aws:signin:::devtools/same-device',
+            'dpopKey' => "-----BEGIN EC PRIVATE KEY-----\n" .
+                "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+                "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+                "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+                "-----END EC PRIVATE KEY-----"
+        ];
+        
+        file_put_contents($tokenFile, json_encode($initialTokenData));
+        
+        // Create provider and let it load the initial token
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $reflection = new \ReflectionClass($provider);
+        
+        // Set up mock client
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        // First call will trigger refresh due to 2-minute expiry
+        // Return credentials that also expire soon so second call triggers refresh
+        $firstRefreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'firstRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'firstKey',
+                    'secretAccessKey' => 'firstSecret',
+                    'sessionToken' => 'firstToken',
+                ],
+                'expiresIn' => 120  // 2 minutes - will trigger refresh on second call
+            ]
+        ]);
+        
+        if (!$shouldUseExternal) {
+            // Second call should also use API for refresh
+            $secondRefreshResult = new Result([
+                'tokenOutput' => [
+                    'refreshToken' => 'apiRefresh',
+                    'accessToken' => [
+                        'accessKeyId' => 'apiKey',
+                        'secretAccessKey' => 'apiSecret',
+                        'sessionToken' => 'apiToken',
+                    ],
+                    'expiresIn' => 3600
+                ]
+            ]);
+            
+            $this->addMockResults($mockClient, [$firstRefreshResult, $secondRefreshResult]);
+        } else {
+            // Only the first call needs a mock result
+            $this->addMockResults($mockClient, [$firstRefreshResult]);
+        }
+        
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        // Force load the initial token
+        $provider()->wait();
+        
+        // Now modify the cache file to simulate external refresh
+        $diskExpiration = gmdate('Y-m-d\TH:i:s\Z', time() + ($diskExpiryMinutes * 60));
+        $externalTokenData = array_merge($initialTokenData, [
+            'accessToken' => [
+                'accessKeyId' => 'externalKey',
+                'secretAccessKey' => 'externalSecret',
+                'sessionToken' => 'externalToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $diskExpiration
+            ],
+            'refreshToken' => $sameRefreshToken ? 'firstRefresh' : 'externalRefresh'
+        ]);
+        
+        file_put_contents($tokenFile, json_encode($externalTokenData));
+        
+        // Now invoke again - this should trigger refresh logic
+        $credentials = $provider()->wait();
+        
+        if ($shouldUseExternal) {
+            // Should have used the external token
+            $this->assertEquals('externalKey', $credentials->getAccessKeyId());
+            $this->assertEquals('externalSecret', $credentials->getSecretKey());
+            $this->assertEquals('externalToken', $credentials->getSecurityToken());
+        } else {
+            // Should have used API refresh
+            $this->assertEquals('apiKey', $credentials->getAccessKeyId());
+            $this->assertEquals('apiSecret', $credentials->getSecretKey());
+            $this->assertEquals('apiToken', $credentials->getSecurityToken());
+        }
+    }
+
+    public function externalRefreshProvider(): array
+    {
+        return [
+            'external refresh detected - all conditions met' => [
+                'scenario' => 'valid external refresh',
+                'currentExpiryMinutes' => 2,  // Triggers refresh
+                'diskExpiryMinutes' => 10,     // Fresh token
+                'sameRefreshToken' => false,
+                'shouldUseExternal' => true
+            ],
+            'same refresh token - no external refresh' => [
+                'scenario' => 'same refresh token',
+                'currentExpiryMinutes' => 2,
+                'diskExpiryMinutes' => 10,
+                'sameRefreshToken' => true,
+                'shouldUseExternal' => false
+            ],
+            'older expiration - no external refresh' => [
+                'scenario' => 'older expiration',
+                'currentExpiryMinutes' => 2,
+                'diskExpiryMinutes' => 1,      // Older than current
+                'sameRefreshToken' => false,
+                'shouldUseExternal' => false
+            ],
+            'external token needs refresh - no external refresh' => [
+                'scenario' => 'external token needs refresh',
+                'currentExpiryMinutes' => 2,
+                'diskExpiryMinutes' => 2,      // Also within 3-minute threshold
+                'sameRefreshToken' => false,
+                'shouldUseExternal' => false
+            ]
+        ];
+    }
+
+    public function testRefreshContinuesWhenDiskReadFails(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create expiring token
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() + 120); // 2 minutes
+        $tokenData = [
+            'accessToken' => [
+                'accessKeyId' => 'expiredKey',
+                'secretAccessKey' => 'expiredSecret',
+                'sessionToken' => 'expiredToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ],
+            'tokenType' => 'aws_sigv4',
+            'refreshToken' => 'testRefresh',
+            'idToken' => 'testId',
+            'clientId' => 'arn:aws:signin:::devtools/same-device',
+            'dpopKey' => "-----BEGIN EC PRIVATE KEY-----\n" .
+                "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+                "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+                "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+                "-----END EC PRIVATE KEY-----"
+        ];
+        
+        file_put_contents($tokenFile, json_encode($tokenData));
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        $refreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'newRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'refreshedKey',
+                    'secretAccessKey' => 'refreshedSecret',
+                    'sessionToken' => 'refreshedToken',
+                ],
+                'expiresIn' => 3600
+            ]
+        ]);
+        
+        $this->addMockResults($mockClient, [$refreshResult]);
+        
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        // Load token first (will trigger refresh due to 2-minute expiry)
+        $provider()->wait();
+        
+        // Make file unreadable for the second refresh attempt
+        chmod($tokenFile, 0000);
+        
+        // Now call again - should use API refresh since disk read fails
+        $credentials = @$provider()->wait();
+        
+        // Restore permissions before assertions
+        chmod($tokenFile, 0644);
+        
+        // Verify API was called (not external token)
+        $this->assertEquals('refreshedKey', $credentials->getAccessKeyId());
+        $this->assertEquals('refreshedSecret', $credentials->getSecretKey());
+        $this->assertEquals('refreshedToken', $credentials->getSecurityToken());
+    }
+
+    public function testRefreshSucceedsWhenCacheWriteFails(): void
+    {
+        $awsDir = $this->createAwsHome();
+        $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
+        $this->createConfigFile($awsDir, 'default', $loginSession);
+        
+        $cacheDir = $awsDir . '/login/cache';
+        mkdir($cacheDir, 0777, true);
+        
+        $sessionHash = hash('sha256', trim($loginSession));
+        $tokenFile = $cacheDir . '/' . $sessionHash . '.json';
+        
+        // Create expired credentials to force refresh
+        $expiration = gmdate('Y-m-d\TH:i:s\Z', time() - 3600);
+        $tokenData = [
+            'accessToken' => [
+                'accessKeyId' => 'expiredKey',
+                'secretAccessKey' => 'expiredSecret',
+                'sessionToken' => 'expiredToken',
+                'accountId' => '123456789012',
+                'expiresAt' => $expiration
+            ],
+            'tokenType' => 'aws_sigv4',
+            'refreshToken' => 'testRefresh',
+            'idToken' => 'testId',
+            'clientId' => 'arn:aws:signin:::devtools/same-device',
+            'dpopKey' => "-----BEGIN EC PRIVATE KEY-----\n" .
+                "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+                "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+                "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+                "-----END EC PRIVATE KEY-----"
+        ];
+        
+        file_put_contents($tokenFile, json_encode($tokenData));
+        
+        // Set up mock client with successful refresh
+        $mockClient = $this->getTestClient(
+            'Signin',
+            ['credentials' => false, 'signature_version' => 'dpop']
+        );
+        
+        $refreshResult = new Result([
+            'tokenOutput' => [
+                'refreshToken' => 'newRefresh',
+                'accessToken' => [
+                    'accessKeyId' => 'refreshedKey',
+                    'secretAccessKey' => 'refreshedSecret',
+                    'sessionToken' => 'refreshedToken',
+                ],
+                'expiresIn' => 3600
+            ]
+        ]);
+        
+        $this->addMockResults($mockClient, [$refreshResult]);
+        
+        $provider = new LoginCredentialProvider('default', 'us-west-2');
+        
+        $reflection = new \ReflectionClass($provider);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setValue($provider, $mockClient);
+        
+        // Make cache file read-only to prevent writes
+        chmod($tokenFile, 0444);
+
+        // This should succeed despite write failure
+        $credentials = @$provider()->wait();
+        
+        // refreshed credentials
+        $this->assertEquals('refreshedKey', $credentials->getAccessKeyId());
+        $this->assertEquals('refreshedSecret', $credentials->getSecretKey());
+        $this->assertEquals('refreshedToken', $credentials->getSecurityToken());
+        $this->assertEquals('123456789012', $credentials->getAccountId());
+        
+        // cache file was not updated
+        $cacheContent = json_decode(file_get_contents($tokenFile), true);
+        $this->assertEquals('expiredKey', $cacheContent['accessToken']['accessKeyId']);
+        $this->assertEquals('testRefresh', $cacheContent['refreshToken']); // Old refresh token
+    }
+}

--- a/tests/Credentials/fixtures/login/test-cases.json
+++ b/tests/Credentials/fixtures/login/test-cases.json
@@ -1,0 +1,231 @@
+[
+  {
+    "documentation": "Success - Valid credentials are returned immediately",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+      "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+        "accessToken": {
+          "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+          "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+          "sessionToken": "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE",
+          "accountId": "012345678901",
+          "expiresAt": "3025-09-14T04:05:45Z"
+        },
+        "clientId": "arn:aws:signin:::devtools/same-device",
+        "refreshToken": "refresh_token",
+        "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ",
+        "dpopKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPt/u8InPLpQeQLJTvVX+sNDzni8vMDMt3Liu+nMBigfoAoGCCqGSM49\nAwEHoUQDQgAEILkGG7rNOnxiIJlMgimY1UPP8eDMFP0DAY6WGjngP4bvTAiUCQ/I\nffut2379uP+OBCm2ovGpBOJRgrl1RspUOQ==\n-----END EC PRIVATE KEY-----\n"
+      }
+    },
+    "outcomes": [
+      {
+        "result": "credentials",
+        "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+        "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "sessionToken": "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE",
+        "accountId": "012345678901",
+        "expiresAt": "3025-09-14T04:05:45Z"
+      }
+    ]
+  },
+  {
+    "documentation": "Failure - No cache file",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+    },
+    "outcomes": [
+      {
+        "result": "error"
+      }
+    ]
+  },
+  {
+    "documentation": "Failure - Missing accessToken",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+      "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+        "clientId": "arn:aws:signin:::devtools/same-device",
+        "refreshToken": "valid_refresh_token_456",
+        "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ",
+        "dpopKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPt/u8InPLpQeQLJTvVX+sNDzni8vMDMt3Liu+nMBigfoAoGCCqGSM49\nAwEHoUQDQgAEILkGG7rNOnxiIJlMgimY1UPP8eDMFP0DAY6WGjngP4bvTAiUCQ/I\nffut2379uP+OBCm2ovGpBOJRgrl1RspUOQ==\n-----END EC PRIVATE KEY-----\n"
+      }
+    },
+    "outcomes": [
+      {
+        "result": "error"
+      }
+    ]
+  },
+  {
+    "documentation": "Failure - Missing refreshToken",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+      "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+        "accessToken": {
+          "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+          "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+          "sessionToken": "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE",
+          "accountId": "012345678901",
+          "expiresAt": "2020-01-01T00:00:00Z"
+        },
+        "clientId": "arn:aws:signin:::devtools/same-device",
+        "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ",
+        "dpopKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPt/u8InPLpQeQLJTvVX+sNDzni8vMDMt3Liu+nMBigfoAoGCCqGSM49\nAwEHoUQDQgAEILkGG7rNOnxiIJlMgimY1UPP8eDMFP0DAY6WGjngP4bvTAiUCQ/I\nffut2379uP+OBCm2ovGpBOJRgrl1RspUOQ==\n-----END EC PRIVATE KEY-----\n"
+      }
+    },
+    "outcomes": [
+      {
+        "result": "error"
+      }
+    ]
+  },
+  {
+    "documentation": "Failure - Missing clientId in cache",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+      "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+        "accessToken": {
+          "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+          "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+          "sessionToken": "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE",
+          "accountId": "012345678901",
+          "expiresAt": "2020-01-01T00:00:00Z"
+        },
+        "refreshToken": "valid_refresh_token_789",
+        "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ",
+        "dpopKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPt/u8InPLpQeQLJTvVX+sNDzni8vMDMt3Liu+nMBigfoAoGCCqGSM49\nAwEHoUQDQgAEILkGG7rNOnxiIJlMgimY1UPP8eDMFP0DAY6WGjngP4bvTAiUCQ/I\nffut2379uP+OBCm2ovGpBOJRgrl1RspUOQ==\n-----END EC PRIVATE KEY-----\n"
+      }
+    },
+    "outcomes": [
+      {
+        "result": "error"
+      }
+    ]
+  },
+  {
+    "documentation": "Failure - Missing dpopKey",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+      "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+        "accessToken": {
+          "accessKeyId": "AKIAIOSFODNN7EXAMPLE",
+          "secretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+          "sessionToken": "AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE",
+          "accountId": "012345678901",
+          "expiresAt": "2020-01-01T00:00:00Z"
+        },
+        "clientId": "arn:aws:signin:::devtools/same-device",
+        "refreshToken": "valid_refresh_token_101112",
+        "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ"
+      }
+    },
+    "outcomes": [
+      {
+        "result": "error"
+      }
+    ]
+  },
+  {
+    "documentation": "Success - Expired token triggers successful refresh",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+      "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+        "accessToken": {
+          "accessKeyId": "OLDEXPIREDKEY",
+          "secretAccessKey": "oldExpiredSecretKey",
+          "sessionToken": "oldExpiredSessionToken",
+          "accountId": "012345678901",
+          "expiresAt": "2020-01-01T00:00:00Z"
+        },
+        "clientId": "arn:aws:signin:::devtools/same-device",
+        "refreshToken": "valid_refresh_token",
+        "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ",
+        "dpopKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPt/u8InPLpQeQLJTvVX+sNDzni8vMDMt3Liu+nMBigfoAoGCCqGSM49\nAwEHoUQDQgAEILkGG7rNOnxiIJlMgimY1UPP8eDMFP0DAY6WGjngP4bvTAiUCQ/I\nffut2379uP+OBCm2ovGpBOJRgrl1RspUOQ==\n-----END EC PRIVATE KEY-----\n"
+      }
+    },
+    "mockApiCalls": [
+      {
+        "request": {
+          "tokenInput": {
+            "clientId": "arn:aws:signin:::devtools/same-device",
+            "refreshToken": "valid_refresh_token",
+            "grantType": "refresh_token"
+          }
+        },
+        "response": {
+          "tokenOutput": {
+            "accessToken": {
+              "accessKeyId": "NEWREFRESHEDKEY",
+              "secretAccessKey": "newRefreshedSecretKey",
+              "sessionToken": "newRefreshedSessionToken"
+            },
+            "refreshToken": "new_refresh_token",
+            "expiresIn": 900
+          }
+        }
+      }
+    ],
+    "outcomes": [
+      {
+        "result": "credentials",
+        "accessKeyId": "NEWREFRESHEDKEY",
+        "secretAccessKey": "newRefreshedSecretKey",
+        "sessionToken": "newRefreshedSessionToken",
+        "accountId": "012345678901",
+        "expiresAt": "2025-11-19T00:15:00Z"
+      },
+      {
+        "result": "cacheContents",
+        "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+          "accessToken": {
+            "accessKeyId": "NEWREFRESHEDKEY",
+            "secretAccessKey": "newRefreshedSecretKey",
+            "sessionToken": "newRefreshedSessionToken",
+            "accountId": "012345678901",
+            "expiresAt": "2025-11-19T00:15:00Z"
+          },
+          "clientId": "arn:aws:signin:::devtools/same-device",
+          "refreshToken": "new_refresh_token",
+          "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ",
+          "dpopKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPt/u8InPLpQeQLJTvVX+sNDzni8vMDMt3Liu+nMBigfoAoGCCqGSM49\nAwEHoUQDQgAEILkGG7rNOnxiIJlMgimY1UPP8eDMFP0DAY6WGjngP4bvTAiUCQ/I\nffut2379uP+OBCm2ovGpBOJRgrl1RspUOQ==\n-----END EC PRIVATE KEY-----\n"
+        }
+      }
+    ]
+  },
+  {
+    "documentation": "Failure - Expired token triggers failed refresh",
+    "configContents": "[profile signin]\nlogin_session = arn:aws:sts::012345678910:assumed-role/Admin/admin\n",
+    "cacheContents": {
+      "4b0ba8f99f075c0633e122fd73346ce203a3faf18ea0310eb2d29df1bab2e255.json": {
+        "accessToken": {
+          "accessKeyId": "OLDEXPIREDKEY",
+          "secretAccessKey": "oldExpiredSecretKey",
+          "sessionToken": "oldExpiredSessionToken",
+          "accountId": "012345678901",
+          "expiresAt": "2020-01-01T00:00:00Z"
+        },
+        "clientId": "arn:aws:signin:::devtools/same-device",
+        "refreshToken": "expired_refresh_token",
+        "idToken": "eyJraWQiOiI1MzYxMjY2ZS1mNjI5LTQ0ZGQtOTA1My1jYzJkNTM1OTJiOTIiLCJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJzdWIiOiJhcm46YXdzOnN0czo6NzIxNzgxNjAzNzU1OmFzc3VtZWQtcm9sZVwvQWRtaW5cL3Nob3ZsaWEtSXNlbmdhcmQiLCJhdWQiOiJhcm46YXdzOnNpZ25pbjo6OmNsaVwvc2FtZS1kZXZpY2UiLCJpc3MiOiJodHRwczpcL1wvc2lnbmluLmF3cy5hbWF6b24uY29tXC9zaWduaW4iLCJzZXNzaW9uX2FybiI6ImFybjphd3M6c3RzOjo3MjE3ODE2MDM3NTU6YXNzdW1lZC1yb2xlXC9BZG1pblwvc2hvdmxpYS1Jc2VuZ2FyZCIsImV4cCI6MTc2MTE2Nzk0NiwiaWF0IjoxNzYxMTY3MDQ2fQ.EzySTg0K11hwQtIYtcBcnNMmX33F6XrVqXsk8WyTWjYcMQxaMnqXebLwBQBCRZha05hZiIZ5xPVCBIt7hZGyymurSfOL72cz69xHUH6u7rwu8vn10UKLHfyKLneKBlmJ",
+        "dpopKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPt/u8InPLpQeQLJTvVX+sNDzni8vMDMt3Liu+nMBigfoAoGCCqGSM49\nAwEHoUQDQgAEILkGG7rNOnxiIJlMgimY1UPP8eDMFP0DAY6WGjngP4bvTAiUCQ/I\nffut2379uP+OBCm2ovGpBOJRgrl1RspUOQ==\n-----END EC PRIVATE KEY-----\n"
+      }
+    },
+    "mockApiCalls": [
+      {
+        "request": {
+          "tokenInput": {
+            "clientId": "arn:aws:signin:::devtools/same-device",
+            "refreshToken": "expired_refresh_token",
+            "grantType": "refresh_token"
+          }
+        },
+        "responseCode": 400
+      }
+    ],
+    "outcomes": [
+      {
+        "result": "error"
+      }
+    ]
+  }
+]

--- a/tests/Script/ComposerTest.php
+++ b/tests/Script/ComposerTest.php
@@ -82,7 +82,7 @@ class ComposerTest extends TestCase
         }
         $filesystem->mkdir( $clientPath . 'Api');
 
-        $unsafeForDeletion = ['Kms', 'S3', 'SSO', 'SSOOIDC', 'Sts'];
+        $unsafeForDeletion = ['Kms', 'S3', 'SSO', 'SSOOIDC', 'Sts', 'Signin'];
         if (in_array('DynamoDbStreams', $servicesToKeep)) {
             $unsafeForDeletion[] = 'DynamoDb';
         }

--- a/tests/Signature/DpopSignatureTest.php
+++ b/tests/Signature/DpopSignatureTest.php
@@ -1,0 +1,390 @@
+<?php
+namespace Aws\Test\Signature;
+
+use Aws\Signature\DpopSignature;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Request;
+
+/**
+ * @covers Aws\Signature\DpopSignature
+ */
+class DpopSignatureTest extends TestCase
+{
+    private function getValidEcKey(): \OpenSSLAsymmetricKey
+    {
+        $pem = "-----BEGIN EC PRIVATE KEY-----\n" .
+            "MHcCAQEEID9l+ckeHBxlF47cg0h5qJnAErPvCm1brUY8i7b6qSJToAoGCCqGSM49\n" .
+            "AwEHoUQDQgAETcWLAT2yUAT3s0ePMBGu+gcmdDvepL86SZDBSmtFCuDxRpXxt5C4\n" .
+            "rGaUy8ujiVIkEvm6a1x/U1As+fGq4eqtVw==\n" .
+            "-----END EC PRIVATE KEY-----";
+        
+        $key = openssl_pkey_get_private($pem);
+        if (!$key) {
+            throw new \RuntimeException('Failed to load EC key');
+        }
+        return $key;
+    }
+
+    public function testConstructorThrowsForInvalidService(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "The 'invalidservice' service does not support DPop signatures"
+        );
+        
+        new DpopSignature('invalidservice');
+    }
+
+    public function testConstructorSucceedsForSigninService(): void
+    {
+        $dpop = new DpopSignature('signin');
+        $this->assertInstanceOf(DpopSignature::class, $dpop);
+    }
+
+    public function testSignRequestAddsDpopHeader(): void
+    {
+        $dpop = new DpopSignature('signin');
+        $key = $this->getValidEcKey();
+        
+        $request = new Request('POST', 'https://example.com/api');
+        $signedRequest = $dpop->signRequest($request, $key);
+        
+        $this->assertTrue($signedRequest->hasHeader('DPop'));
+        $dpopHeader = $signedRequest->getHeader('DPop')[0];
+        $this->assertNotEmpty($dpopHeader);
+        
+        // Verify JWT structure (3 parts separated by dots)
+        $parts = explode('.', $dpopHeader);
+        $this->assertCount(3, $parts);
+    }
+
+    public function testDpopJwtHeaderStructure(): void
+    {
+        $dpop = new DpopSignature('signin');
+        $key = $this->getValidEcKey();
+        
+        $request = new Request('POST', 'https://example.com/api');
+        $signedRequest = $dpop->signRequest($request, $key);
+        
+        $dpopHeader = $signedRequest->getHeader('DPop')[0];
+        $parts = explode('.', $dpopHeader);
+        
+        // Decode header
+        $header = json_decode(
+            base64_decode(strtr($parts[0], '-_', '+/')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        
+        $this->assertEquals('dpop+jwt', $header['typ']);
+        $this->assertEquals('ES256', $header['alg']);
+        $this->assertArrayHasKey('jwk', $header);
+        $this->assertEquals('EC', $header['jwk']['kty']);
+        $this->assertEquals('P-256', $header['jwk']['crv']);
+        $this->assertArrayHasKey('x', $header['jwk']);
+        $this->assertArrayHasKey('y', $header['jwk']);
+    }
+
+    public function testDpopJwtPayloadStructure(): void
+    {
+        $dpop = new DpopSignature('signin');
+        $key = $this->getValidEcKey();
+        
+        $uri = 'https://example.com/api/endpoint';
+        $request = new Request('POST', $uri);
+        $signedRequest = $dpop->signRequest($request, $key);
+        
+        $dpopHeader = $signedRequest->getHeader('DPop')[0];
+        $parts = explode('.', $dpopHeader);
+        
+        // Decode payload
+        $payload = json_decode(
+            base64_decode(strtr($parts[1], '-_', '+/')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        
+        $this->assertArrayHasKey('jti', $payload);
+        $this->assertEquals('POST', $payload['htm']);
+        $this->assertEquals($uri, $payload['htu']);
+        $this->assertArrayHasKey('iat', $payload);
+        
+        // Verify jti is a valid UUID v4
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+            $payload['jti']
+        );
+        
+        // Verify iat is recent (within last minute)
+        $this->assertGreaterThan(time() - 60, $payload['iat']);
+        $this->assertLessThanOrEqual(time(), $payload['iat']);
+    }
+
+    public function testDerToRawConvertsValidSignature(): void
+    {
+        $dpop = new DpopSignature('signin');
+        $key = $this->getValidEcKey();
+        
+        // Generate a real signature to test derToRaw
+        $message = 'test message';
+        $signature = '';
+        openssl_sign($message, $signature, $key, OPENSSL_ALGO_SHA256);
+        
+        // Use reflection to access private method
+        $reflection = new \ReflectionClass($dpop);
+        $method = $reflection->getMethod('derToRaw');
+        
+        $raw = $method->invoke($dpop, $signature);
+        
+        // Raw signature for ES256 should be exactly 64 bytes
+        $this->assertEquals(64, strlen($raw));
+    }
+
+    /**
+     * Test that derToRaw properly handles DER signatures with various R and S lengths
+     */
+    public function testDerToRawHandlesVariableLengthComponents(): void
+    {
+        $dpop = new DpopSignature('signin');
+        
+        // Use reflection to access private method
+        $reflection = new \ReflectionClass($dpop);
+        $method = $reflection->getMethod('derToRaw');
+        
+        // Test case 1: R and S both 32 bytes (no leading zeros)
+        $der1 = hex2bin(
+            '3044' . '0220'
+            . str_repeat('ab', 32) . '0220'
+            . str_repeat('cd', 32)
+        );
+        $raw1 = $method->invoke($dpop, $der1);
+        $this->assertEquals(64, strlen($raw1));
+        
+        // Test case 2: R with leading zero (33 bytes in DER)
+        $der2 = hex2bin(
+            '3045' . '0221' . '00'
+            . str_repeat('ff', 32) . '0220'
+            . str_repeat('aa', 32)
+        );
+        $raw2 = $method->invoke($dpop, $der2);
+        $this->assertEquals(64, strlen($raw2));
+        
+        // Test case 3: S with leading zero (33 bytes in DER)
+        $der3 = hex2bin(
+            '3045' . '0220' . str_repeat('bb', 32)
+            . '0221' . '00'
+            . str_repeat('ee', 32)
+        );
+        $raw3 = $method->invoke($dpop, $der3);
+        $this->assertEquals(64, strlen($raw3));
+        
+        // Test case 4: Both with leading zeros (33 bytes each in DER)
+        $der4 = hex2bin(
+            '3046' . '0221' . '00'
+            . str_repeat('dd', 32) . '0221'
+            . '00' . str_repeat('cc', 32)
+        );
+        $raw4 = $method->invoke($dpop, $der4);
+        $this->assertEquals(64, strlen($raw4));
+    }
+
+    /**
+     * Test that derToRaw throws for invalid DER signatures
+     */
+    public function testDerToRawThrowsForInvalidSignatures(): void
+    {
+        $dpop = new DpopSignature('signin');
+        
+        // Use reflection to access private method
+        $reflection = new \ReflectionClass($dpop);
+        $method = $reflection->getMethod('derToRaw');
+        
+        // Test case 1: Missing SEQUENCE tag
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid DER signature format: missing SEQUENCE tag');
+        $method->invoke(
+            $dpop,
+            hex2bin('31440220' . str_repeat('ab', 32) . '0220' . str_repeat('cd', 32))
+        );
+    }
+
+    public function testDerToRawThrowsForMissingRIntegerTag(): void
+    {
+        $dpop = new DpopSignature('signin');
+        
+        // Use reflection to access private method
+        $reflection = new \ReflectionClass($dpop);
+        $method = $reflection->getMethod('derToRaw');
+        
+        // Missing R INTEGER tag
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid DER signature format: missing R INTEGER tag');
+        $method->invoke(
+            $dpop,
+            hex2bin('30440320' . str_repeat('ab', 32) . '0220' . str_repeat('cd', 32))
+        );
+    }
+
+    public function testDerToRawThrowsForMissingSIntegerTag(): void
+    {
+        $dpop = new DpopSignature('signin');
+        
+        // Use reflection to access private method
+        $reflection = new \ReflectionClass($dpop);
+        $method = $reflection->getMethod('derToRaw');
+        
+        // Missing S INTEGER tag
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid DER signature format: missing S INTEGER tag');
+        $method->invoke(
+            $dpop,
+            hex2bin('30440220' . str_repeat('ab', 32) . '0320' . str_repeat('cd', 32))
+        );
+    }
+
+    public function testDerToRawThrowsForLengthMismatch(): void
+    {
+        $dpop = new DpopSignature('signin');
+        
+        // Use reflection to access private method
+        $reflection = new \ReflectionClass($dpop);
+        $method = $reflection->getMethod('derToRaw');
+        
+        // R length says 32 bytes but only provide 31 (the rest is cut off so no S INTEGER tag found)
+        $this->expectException(\Exception::class);
+        // The parser will find the mismatch when it tries to extract R value
+        $this->expectExceptionMessage('Invalid DER signature');
+        $method->invoke(
+            $dpop,
+            hex2bin('30430220' . str_repeat('ab', 31) . '0220' . str_repeat('cd', 32))
+        );
+    }
+
+    /**
+     * Test that the signature can be verified with openssl
+     */
+    public function testSignatureCanBeVerified(): void
+    {
+        $dpop = new DpopSignature('signin');
+        $key = $this->getValidEcKey();
+        
+        $request = new Request('POST', 'https://example.com/api');
+        $signedRequest = $dpop->signRequest($request, $key);
+        
+        $dpopHeader = $signedRequest->getHeader('DPop')[0];
+        $parts = explode('.', $dpopHeader);
+        
+        // Recreate the message
+        $message = $parts[0] . '.' . $parts[1];
+        
+        // Decode the signature
+        $signature = base64_decode(strtr($parts[2], '-_', '+/'));
+        
+        // Convert raw signature back to DER for verification
+        $r = substr($signature, 0, 32);
+        $s = substr($signature, 32, 32);
+        
+        // Remove leading zeros from r and s for DER
+        $r = ltrim($r, "\x00");
+        $s = ltrim($s, "\x00");
+        
+        // Add leading zero if high bit is set (for DER encoding)
+        if (ord($r[0]) & 0x80) {
+            $r = "\x00" . $r;
+        }
+        if (ord($s[0]) & 0x80) {
+            $s = "\x00" . $s;
+        }
+        
+        // Build DER
+        $rDer = "\x02" . chr(strlen($r)) . $r;
+        $sDer = "\x02" . chr(strlen($s)) . $s;
+        $der = "\x30" . chr(strlen($rDer . $sDer)) . $rDer . $sDer;
+        
+        // Get public key from private key
+        $keyDetails = openssl_pkey_get_details($key);
+        $publicKey = openssl_pkey_get_public($keyDetails['key']);
+        
+        // Verify signature
+        $verified = openssl_verify(
+            $message, $der, $publicKey, OPENSSL_ALGO_SHA256
+        );
+        $this->assertEquals(1, $verified);
+    }
+
+    /**
+     * Test that multiple signatures from the same key produce different JWTs (due to jti)
+     */
+    public function testMultipleSignaturesProduceDifferentJwts(): void
+    {
+        $dpop = new DpopSignature('signin');
+        $key = $this->getValidEcKey();
+        
+        $request = new Request('POST', 'https://example.com/api');
+        
+        $signedRequest1 = $dpop->signRequest($request, $key);
+        $signedRequest2 = $dpop->signRequest($request, $key);
+        
+        $dpopHeader1 = $signedRequest1->getHeader('DPop')[0];
+        $dpopHeader2 = $signedRequest2->getHeader('DPop')[0];
+        
+        // Headers should be different due to different jti values
+        $this->assertNotEquals($dpopHeader1, $dpopHeader2);
+        
+        // But header portions (containing JWK) should be the same
+        $parts1 = explode('.', $dpopHeader1);
+        $parts2 = explode('.', $dpopHeader2);
+        $this->assertEquals($parts1[0], $parts2[0]);
+    }
+
+    /**
+     * Test that a key with specifiedCurve parameters works correctly
+     */
+    public function testSignRequestWithSpecifiedCurveKey(): void
+    {
+        $dpop = new DpopSignature('signin');
+        
+        // Key with specifiedCurve parameters
+        $pem = "-----BEGIN EC PRIVATE KEY-----\n" .
+            "MIIBUQIBAQQgW2JEXxOdj8dFip0hyS6SHr9dHciiZQyoTZoe6sox1KGggeMwgeAC\n" .
+            "AQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAAAAAAAAAAAAAA////////////////\n" .
+            "MEQEIP////8AAAABAAAAAAAAAAAAAAAA///////////////8BCBaxjXYqjqT57Pr\n" .
+            "vVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwRBBGsX0fLhLEJH+Lzm5WOkQPJ3A32BLesz\n" .
+            "oPShOUXYmMKWT+NC4v4af5uO5+tKfA+eFivOM1drMV7Oy7ZAaDe/UfUCIQD/////\n" .
+            "AAAAAP//////////vOb6racXnoTzucrC/GMlUQIBAaFEA0IABFqlTnAPfLQfFrmn\n" .
+            "uJFbpcMA89r5uhBzUe+KvRCCPpscjMats1NUCB64qslJ3QYEGuAx2BP2gOeQBUbl\n" .
+            "rSdm4F4=\n" .
+            "-----END EC PRIVATE KEY-----";
+        
+        $key = openssl_pkey_get_private($pem);
+        $this->assertNotFalse($key, 'Failed to load EC key with specifiedCurve');
+        
+        $request = new Request('POST', 'https://example.com/api');
+        $signedRequest = $dpop->signRequest($request, $key);
+        
+        $this->assertTrue($signedRequest->hasHeader('DPop'));
+        $dpopHeader = $signedRequest->getHeader('DPop')[0];
+        $this->assertNotEmpty($dpopHeader);
+        
+        // Verify JWT structure (3 parts separated by dots)
+        $parts = explode('.', $dpopHeader);
+        $this->assertCount(3, $parts);
+        
+        // Verify the header contains the JWK
+        $header = json_decode(
+            base64_decode(strtr($parts[0], '-_', '+/')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+        $this->assertEquals('dpop+jwt', $header['typ']);
+        $this->assertEquals('ES256', $header['alg']);
+        $this->assertArrayHasKey('jwk', $header);
+        $this->assertEquals('EC', $header['jwk']['kty']);
+        $this->assertEquals('P-256', $header['jwk']['crv']);
+        $this->assertArrayHasKey('x', $header['jwk']);
+        $this->assertArrayHasKey('y', $header['jwk']);
+    }
+}

--- a/tests/Signature/SignatureProviderTest.php
+++ b/tests/Signature/SignatureProviderTest.php
@@ -2,6 +2,7 @@
 namespace Aws\Test\Signature;
 
 use Aws\Signature\AnonymousSignature;
+use Aws\Signature\DpopSignature;
 use Aws\Signature\S3ExpressSignature;
 use Aws\Signature\S3SignatureV4;
 use Aws\Signature\SignatureInterface;
@@ -30,7 +31,8 @@ class SignatureProviderTest extends TestCase
             ['v4-s3express', S3ExpressSignature::class, 's3express'],
             ['v4-unsigned-body', SignatureV4::class, 'foo'],
             ['anonymous', AnonymousSignature::class, 's3'],
-            ['s3v4', S3SignatureV4::class, 's3-outposts']
+            ['s3v4', S3SignatureV4::class, 's3-outposts'],
+            ['dpop', DpopSignature::class, 'signin'],
         ];
     }
 


### PR DESCRIPTION
*Description of changes:*
Adds `LoginCredentialProvider`, which supports AWS Console sign-in credentials through the `aws login` CLI workflow. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
