### PR TITLE
chore: update login provider tests using `chmod()`

### DIFF
--- a/tests/Credentials/LoginCredentialProviderTest.php
+++ b/tests/Credentials/LoginCredentialProviderTest.php
@@ -1568,6 +1568,11 @@ EOT;
 
     public function testRefreshContinuesWhenDiskReadFails(): void
     {
+        // Skip test if running as root. chmod() will not work
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Test cannot run test as root user');
+        }
+
         $awsDir = $this->createAwsHome();
         $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
         $this->createConfigFile($awsDir, 'default', $loginSession);
@@ -1644,7 +1649,11 @@ EOT;
 
     public function testRefreshSucceedsWhenCacheWriteFails(): void
     {
-        $this->markTestSkipped();
+        // Skip test if running as root. chmod() will not work
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('Test cannot run test as root user');
+        }
+
         $awsDir = $this->createAwsHome();
         $loginSession = 'arn:aws:iam::123456789012:user/TestUser';
         $this->createConfigFile(


### PR DESCRIPTION
*Description of changes:*

One test that changed file permissions was failing in Docker/CodeBuild, and another was giving false coverage. In containerized environments, they run as root, and root can bypass `chmod()` restrictions (can write to read-only files, read no-permission files). Added root user detection to skip these tests when running as root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
