### PR TITLE
fix: use random_int instead of mt_rand for retry jitter

### DIFF
--- a/.changes/nextrelease/fix-backoff-delay.json
+++ b/.changes/nextrelease/fix-backoff-delay.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Enhance exponential delay calculation to reduce the possibilities of having 0 as the delay."
+    }
+]

--- a/src/RetryMiddlewareV2.php
+++ b/src/RetryMiddlewareV2.php
@@ -246,11 +246,12 @@ class RetryMiddlewareV2
      */
     public function exponentialDelayWithJitter($attempts)
     {
+        $max = mt_getrandmax();
         try {
-            $rand = random_int(0, mt_getrandmax()) / mt_getrandmax();
+            $rand = random_int(0, $max) / $max;
         } catch (Exception $_) {
             // fallback to prevent failing
-            $rand = mt_rand(0, mt_getrandmax()) / mt_getrandmax();
+            $rand = mt_rand(0, $max) / $max;
         }
 
         return min(1000 * $rand * pow(2, $attempts) , $this->maxBackoff);


### PR DESCRIPTION
*Issue #2991*

*Description of changes:*
Fixes biased distribution on 64-bit PHP builds that caused excessive zero delays.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
