### PR TITLE
chore: remove integ test that requires awscrt

### DIFF
--- a/features/s3Transfer/s3TransferManager.feature
+++ b/features/s3Transfer/s3TransferManager.feature
@@ -57,7 +57,6 @@ Feature: S3 Transfer Manager
     Examples:
       | filename                | content                            | checksum_algorithm |
       | myfile-test-5-1.txt     | This is a test file content #1     | crc32              |
-      | myfile-test-5-2.txt     | This is a test file content #2     | crc32c             |
       | myfile-test-5-3.txt     | This is a test file content #3     | sha256             |
       | myfile-test-5-4.txt     | This is a test file content #4     | sha1               |
 


### PR DESCRIPTION
- We need to find a way to skip integ tests based on certain conditions, in this case when awscrt is not enabled.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
