### PR TITLE
chore: api docs updates

### DIFF
--- a/build/docs/config/dev-guide-service-examples.php
+++ b/build/docs/config/dev-guide-service-examples.php
@@ -130,5 +130,11 @@ return [
         'scenarios' => [
             'Send events to Amazon EventBridge global endpoints' => 'https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/eventbridge-examples.html'
         ]
+    ],
+    '_service_id_map' => [
+        'apigateway' => 'api-gateway',
+        'email' => 'ses',
+        'autoscaling' => 'auto-scaling',
+        'rds-data' => 'aurora',
     ]
 ];

--- a/build/remove-method-annotations.php
+++ b/build/remove-method-annotations.php
@@ -20,7 +20,7 @@ function removeMethodAnnotations($dir, $fileSuffix) {
 
             // Regular expression to match @method annotations
             // This pattern assumes @method annotations may span multiple lines and are within comment blocks
-            $pattern = '/\*\s+@method\s+[^\n]+\n/';
+            $pattern = '/^\s*\*\s+@method\s+[^\n]+\n/m';
 
             if (preg_match($pattern, $content)) {
                 // Remove @method annotations

--- a/src/AutoScaling/AutoScalingClient.php
+++ b/src/AutoScaling/AutoScalingClient.php
@@ -4,7 +4,7 @@ namespace Aws\AutoScaling;
 use Aws\AwsClient;
 
 /**
- * Auto Scaling client.
+ * This client is used to interact with the **AWS Auto Scaling** service.
  *
  * @method \Aws\Result attachInstances(array $args = [])
  * @method \GuzzleHttp\Promise\Promise attachInstancesAsync(array $args = [])


### PR DESCRIPTION
*Description of changes:*
Splits examples section into two subsections- latest from the [aws code library](https://docs.aws.amazon.com/code-library/latest/ug/php_3_code_examples.html), and legacy from the [dev guide](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/php_code_examples.html).  Fixes issue with method annotation removal (dangling docblock end) and fixes an issue with the Autoscaling client method annotation that caused a missed content update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
