### PR TITLE
chore: allow filesystem 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-simplexml": "*",
         "aws/aws-crt-php": "^1.2.3",
         "psr/http-message": "^1.0 || ^2.0",
-        "symfony/filesystem": "^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+        "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
     },
     "require-dev": {
         "composer/composer" : "^2.7.8",


### PR DESCRIPTION
*Description of changes:*
Allows 5.4, which is in LTS until 2029

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
