### PR TITLE
chore: add deprecation notices to legacy s3 crypto clients

### DIFF
--- a/.changes/nextrelease/crypto-deprecations.json
+++ b/.changes/nextrelease/crypto-deprecations.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "S3",
+    "description": "Adds deprecation notices to `S3EncryptionClient` and `S3EncryptionClientV2`"
+  }
+]

--- a/src/S3/Crypto/S3EncryptionClient.php
+++ b/src/S3/Crypto/S3EncryptionClient.php
@@ -54,6 +54,14 @@ class S3EncryptionClient extends AbstractCryptoClient
         S3Client $client,
         $instructionFileSuffix = null
     ) {
+        trigger_error(
+            'S3EncryptionClient is deprecated and will be removed in a future ' .
+            'release due to security vulnerabilities. Please migrate to ' .
+            'S3EncryptionClientV3 as soon as possible.' . "\n" .
+            'See https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/' .
+            'security.html for upgrade guidance.',
+            E_USER_DEPRECATED
+        );
         $this->client = $client;
         $this->instructionFileSuffix = $instructionFileSuffix;
         MetricsBuilder::appendMetricsCaptureMiddleware(

--- a/src/S3/Crypto/S3EncryptionClientV2.php
+++ b/src/S3/Crypto/S3EncryptionClientV2.php
@@ -107,6 +107,14 @@ class S3EncryptionClientV2 extends AbstractCryptoClientV2
         S3Client $client,
         $instructionFileSuffix = null
     ) {
+        trigger_error(
+            'S3EncryptionClientV2 will be deprecated soon and will be removed in a future ' .
+            'release due to security vulnerabilities (CVE-2024-56473). Please ' .
+            'migrate to S3EncryptionClientV3 as soon as possible.' . "\n" .
+            'See https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/' .
+            'security.html for upgrade guidance.',
+            E_USER_DEPRECATED
+        );
         $this->client = $client;
         $this->instructionFileSuffix = $instructionFileSuffix;
         $this->legacyWarningCount = 0;

--- a/tests/Integ/S3EncryptionContext.php
+++ b/tests/Integ/S3EncryptionContext.php
@@ -130,7 +130,7 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
             'region' => $this->region,
             'version' => 'latest'
         ]);
-        $s3EncryptionClient = new S3EncryptionClient($s3Client);
+        $s3EncryptionClient = @new S3EncryptionClient($s3Client);
 
         foreach ($this->plaintexts as $fileKeyPart => $plaintext) {
             $params = $this->operationParams[$fileKeyPart];
@@ -160,7 +160,7 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
             'region' => $this->region,
             'version' => 'latest'
         ]);
-        $s3EncryptionClient = new S3EncryptionClient($s3Client);
+        $s3EncryptionClient = @new S3EncryptionClient($s3Client);
 
         $fileKeyParts = array_keys($this->plaintexts);
         foreach ($fileKeyParts as $fileKeyPart) {
@@ -227,4 +227,3 @@ class S3EncryptionContext implements Context, SnippetAcceptingContext
         return '';
     }
 }
-

--- a/tests/Integ/S3EncryptionContextV2.php
+++ b/tests/Integ/S3EncryptionContextV2.php
@@ -129,7 +129,7 @@ class S3EncryptionContextV2 implements Context, SnippetAcceptingContext
             'region' => $this->region,
             'version' => 'latest'
         ]);
-        $s3EncryptionClient = new S3EncryptionClientV2($s3Client);
+        $s3EncryptionClient = @new S3EncryptionClientV2($s3Client);
 
         foreach ($this->plaintexts as $fileKeyPart => $plaintext) {
             if (empty($this->operationParams[$fileKeyPart])) {
@@ -163,7 +163,7 @@ class S3EncryptionContextV2 implements Context, SnippetAcceptingContext
             'region' => $this->region,
             'version' => 'latest'
         ]);
-        $s3EncryptionClient = new S3EncryptionClientV2($s3Client);
+        $s3EncryptionClient = @new S3EncryptionClientV2($s3Client);
 
         $fileKeyParts = array_keys($this->plaintexts);
         foreach ($fileKeyParts as $fileKeyPart) {

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -82,7 +82,7 @@ class S3EncryptionClientTest extends TestCase
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -108,7 +108,7 @@ class S3EncryptionClientTest extends TestCase
 
         $s3 = $this->getS3Client();
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -147,7 +147,7 @@ class S3EncryptionClientTest extends TestCase
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -176,7 +176,7 @@ class S3EncryptionClientTest extends TestCase
         $keyId = '11111111-2222-3333-4444-555555555555';
         $provider = new KmsMaterialsProvider($kms, $keyId);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -204,7 +204,7 @@ class S3EncryptionClientTest extends TestCase
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient(
+        $client = @new S3EncryptionClient(
             $s3,
             InstructionFileMetadataStrategy::DEFAULT_FILE_SUFFIX
         );
@@ -235,7 +235,7 @@ class S3EncryptionClientTest extends TestCase
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -274,7 +274,7 @@ class S3EncryptionClientTest extends TestCase
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -318,7 +318,7 @@ class S3EncryptionClientTest extends TestCase
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -363,7 +363,7 @@ EOXML;
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -401,7 +401,7 @@ EOXML;
             new Result(['CiphertextBlob' => 'encrypted'])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -438,7 +438,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -494,7 +494,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -538,7 +538,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClient(
+        $client = @new S3EncryptionClient(
             $s3,
             InstructionFileMetadataStrategy::DEFAULT_FILE_SUFFIX
         );
@@ -585,7 +585,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -630,7 +630,7 @@ EOXML;
         ]);
 
         $provider = new KmsMaterialsProvider($kms);
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -661,7 +661,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -693,7 +693,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -734,7 +734,7 @@ EOXML;
             ])
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -777,7 +777,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClient($s3);
+        $client = @new S3EncryptionClient($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',

--- a/tests/S3/Crypto/S3EncryptionClientV2Test.php
+++ b/tests/S3/Crypto/S3EncryptionClientV2Test.php
@@ -84,7 +84,7 @@ class S3EncryptionClientV2Test extends TestCase
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -111,7 +111,7 @@ class S3EncryptionClientV2Test extends TestCase
 
         $s3 = $this->getS3Client();
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -154,7 +154,7 @@ class S3EncryptionClientV2Test extends TestCase
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -184,7 +184,7 @@ class S3EncryptionClientV2Test extends TestCase
         $keyId = '11111111-2222-3333-4444-555555555555';
         $provider = new KmsMaterialsProviderV2($kms, $keyId);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -216,7 +216,7 @@ class S3EncryptionClientV2Test extends TestCase
             ])
         ]);
 
-        $client = new S3EncryptionClientV2(
+        $client = @new S3EncryptionClientV2(
             $s3,
             InstructionFileMetadataStrategy::DEFAULT_FILE_SUFFIX
         );
@@ -251,7 +251,7 @@ class S3EncryptionClientV2Test extends TestCase
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -294,7 +294,7 @@ class S3EncryptionClientV2Test extends TestCase
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -348,7 +348,7 @@ class S3EncryptionClientV2Test extends TestCase
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -397,7 +397,7 @@ EOXML;
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -442,7 +442,7 @@ EOXML;
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -492,7 +492,7 @@ EOXML;
             ])
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->putObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -532,7 +532,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -567,7 +567,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -601,7 +601,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -635,7 +635,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -679,7 +679,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
 
         // Suppressing known warning for 'V2_AND_LEGACY' security profile warning
         // Necessary to test decrypting with legacy metadata
@@ -727,7 +727,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -772,7 +772,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -818,7 +818,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2(
+        $client = @new S3EncryptionClientV2(
             $s3,
             InstructionFileMetadataStrategy::DEFAULT_FILE_SUFFIX
         );
@@ -867,7 +867,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $result = $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -903,7 +903,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $result = @$client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -951,7 +951,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -997,7 +997,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -1017,7 +1017,7 @@ EOXML;
             'version' => 'latest',
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -1037,7 +1037,7 @@ EOXML;
             'version' => 'latest',
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',
@@ -1077,7 +1077,7 @@ EOXML;
             },
         ]);
 
-        $client = new S3EncryptionClientV2($s3);
+        $client = @new S3EncryptionClientV2($s3);
         $client->getObject([
             'Bucket' => 'foo',
             'Key' => 'bar',

--- a/tests/UserAgentMiddlewareTest.php
+++ b/tests/UserAgentMiddlewareTest.php
@@ -459,7 +459,7 @@ class UserAgentMiddlewareTest extends TestCase
                 ));
             },
         ]);
-        $encryptionClient = new S3EncryptionClient(
+        $encryptionClient = @new S3EncryptionClient(
             $s3Client,
             InstructionFileMetadataStrategy::DEFAULT_FILE_SUFFIX
         );
@@ -532,7 +532,7 @@ class UserAgentMiddlewareTest extends TestCase
                 ));
             },
         ]);
-        $encryptionClient = new S3EncryptionClientV2(
+        $encryptionClient = @new S3EncryptionClientV2(
             $s3Client,
             InstructionFileMetadataStrategy::DEFAULT_FILE_SUFFIX
         );


### PR DESCRIPTION
*Description of changes:*
Adds deprecation notices to `S3EncryptionClient` and `S3EncryptionClientV2` with links to upgrade guidance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
