### PR TITLE
fix: location name on structure members

### DIFF
--- a/src/Api/Serializer/RestXmlSerializer.php
+++ b/src/Api/Serializer/RestXmlSerializer.php
@@ -41,7 +41,7 @@ class RestXmlSerializer extends RestSerializer
      */
     private function getXmlBody(StructureShape $member, array $value)
     {
-        $xmlBody = (string)$this->xmlBody->build($member, $value);
+        $xmlBody = $this->xmlBody->build($member, $value);
         $xmlBody = str_replace("'", "&apos;", $xmlBody);
         $xmlBody = str_replace('\r', "&#13;", $xmlBody);
         $xmlBody = str_replace('\n', "&#10;", $xmlBody);

--- a/src/Api/Serializer/XmlBody.php
+++ b/src/Api/Serializer/XmlBody.php
@@ -99,7 +99,8 @@ class XmlBody
             // Default to member name
             $elementName = $k;
 
-            if ($definition['member']['locationName']) {
+            if ($definition['member']['locationName']
+                && !isset($definition['member']['locationNameAtStructureLevel'])) {
                 $elementName = $definition['member']['locationName'];
             }
 

--- a/src/Api/ShapeMap.php
+++ b/src/Api/ShapeMap.php
@@ -51,7 +51,14 @@ class ShapeMap implements \ArrayAccess
             return $this->simple[$shape];
         }
 
-        $definition = $shapeRef + $this->definitions[$shape];
+        $shapeDefinition = $this->definitions[$shape];
+        $definition = $shapeRef + $shapeDefinition;
+        // Property to know whether the locationName was set at member level
+        // or the structure level.
+        if (isset($shapeDefinition['locationName'])) {
+            $definition['locationNameAtStructureLevel'] = true;
+        }
+
         $definition['name'] = $definition['shape'];
         if (isset($definition['shape'])) {
             unset($definition['shape']);

--- a/tests/Api/test_cases/protocols/input/rest-xml.json
+++ b/tests/Api/test_cases/protocols/input/rest-xml.json
@@ -542,6 +542,84 @@
         ]
     },
     {
+        "description": "Test cases for xmlName at member level operation",
+        "metadata": {
+            "apiVersion": "2019-12-16",
+            "auth": [
+                "aws.auth#sigv4"
+            ],
+            "endpointPrefix": "restxml",
+            "protocol": "rest-xml",
+            "protocols": [
+                "rest-xml"
+            ],
+            "serviceFullName": "RestXml",
+            "serviceId": "Rest Xml Protocol",
+            "signatureVersion": "v4",
+            "signingName": "RestXml",
+            "uid": "rest-xml-protocol-2019-12-16"
+        },
+        "shapes": {
+            "MyShapeInputAndOutput": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "Payload",
+                        "locationName": "CustomPayload"
+                    }
+                },
+                "locationName": "MyShape"
+            },
+            "Payload": {
+                "type": "structure",
+                "members": {
+                    "name": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "XMLNameAtMemberLevel",
+                "given": {
+                    "name": "XMLNameAtMemberLevel",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/XMLNameAtMemberLevel",
+                        "responseCode": 200
+                    },
+                    "input": {
+                        "shape": "MyShapeInputAndOutput",
+                        "locationName": "XMLNameAtMemberLevelRequest"
+                    },
+                    "documentation": "<p>The following example serializes a body that uses an XML name, changing the wrapper name.</p>",
+                    "idempotent": true
+                },
+                "description": "Serializes a payload using a wrapper name based on the xmlName",
+                "params": {
+                    "nested": {
+                        "name": "TestParameterValue"
+                    }
+                },
+                "serialized": {
+                    "method": "PUT",
+                    "uri": "/XMLNameAtMemberLevel",
+                    "body": "<MyShape><CustomPayload><name>TestParameterValue</name></CustomPayload></MyShape>",
+                    "headers": {
+                        "Content-Type": "application/xml"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    },
+    {
         "description": "Test cases for ConstantAndVariableQueryString operation",
         "metadata": {
             "apiVersion": "2019-12-16",


### PR DESCRIPTION
*Issue #3239*

*Description of changes:*

When a structure member has the locationName `xmlName trait` then we should use that name instead of the original name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
