### PR TITLE
fix: describeDBInstances error code

### DIFF
--- a/features/smoke/rds.feature
+++ b/features/smoke/rds.feature
@@ -9,4 +9,4 @@ Feature: Amazon RDS
   Scenario: Handling errors
     When I attempt to call the "DescribeDBInstances" API with:
     | DBInstanceIdentifier | fake-id |
-    Then I expect the response error code to be "DBInstanceNotFoundFault"
+    Then I expect the response error code to be "DBInstanceNotFoundFault" or "DBInstancesNotFound"

--- a/tests/Integ/SmokeContext.php
+++ b/tests/Integ/SmokeContext.php
@@ -376,6 +376,22 @@ class SmokeContext extends Assert implements
     }
 
     /**
+     * @Then I expect the response error code to be :errorCode1 or :errorCode2
+     *
+     * @param $errorCode1
+     * @param $errorCode2
+     */
+    public function iExpectTheResponseErrorCodesToBe($errorCode1, $errorCode2)
+    {
+        $this->assertTrue(
+            in_array(
+                $this->error->getAwsErrorCode(),
+                [$errorCode1, $errorCode2]
+            )
+        );
+    }
+
+    /**
      * @Then I expect the marketplace commerce analytics response error code to be :errorCode
      *
      * @param string $errorCode


### PR DESCRIPTION
*Description of changes:*

Error code for DescribeDBInstances when not found is DBInstanceNotFoundFault

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
