### PR TITLE
fix: break circular reference cycles

### DIFF
--- a/.changes/nextrelease/fix-memory-leak.json
+++ b/.changes/nextrelease/fix-memory-leak.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "enhancement",
+        "category": "",
+        "description": "Use WeakReference in PresignUrlMiddleware and EndpointDiscoveryMiddleware to prevent circular reference memory leaks."
+    }
+]

--- a/src/EndpointDiscovery/EndpointDiscoveryMiddleware.php
+++ b/src/EndpointDiscovery/EndpointDiscoveryMiddleware.php
@@ -21,7 +21,7 @@ class EndpointDiscoveryMiddleware
     private static $discoveryCooldown = 60;
 
     private $args;
-    private $client;
+    private \WeakReference $client;
     private $config;
     private $discoveryTimes = [];
     private $nextHandler;
@@ -53,7 +53,7 @@ class EndpointDiscoveryMiddleware
         $config
     ) {
         $this->nextHandler = $handler;
-        $this->client = $client;
+        $this->client = \WeakReference::create($client);
         $this->args = $args;
         $this->service = $client->getApi();
         $this->config = $config;
@@ -91,7 +91,7 @@ class EndpointDiscoveryMiddleware
                 $identifiers = $this->getIdentifiers($op);
 
                 $cacheKey = $this->getCacheKey(
-                    $this->client->getCredentials()->wait(),
+                    $this->client->get()->getCredentials()->wait(),
                     $cmd,
                     $identifiers
                 );
@@ -178,7 +178,7 @@ class EndpointDiscoveryMiddleware
     ) {
         $discCmd = $this->getDiscoveryCommand($cmd, $identifiers);
         $this->discoveryTimes[$cacheKey] = time();
-        $result = $this->client->execute($discCmd);
+        $result = $this->client->get()->execute($discCmd);
 
         if (isset($result['Endpoints'])) {
             $endpointData = [];
@@ -237,7 +237,7 @@ class EndpointDiscoveryMiddleware
                 $params['Identifiers'][$identifier] = $cmd[$identifier];
             }
         }
-        $command = $this->client->getCommand($endpointOperation, $params);
+        $command = $this->client->get()->getCommand($endpointOperation, $params);
         $command->getHandlerList()->appendBuild(
             Middleware::mapRequest(function (RequestInterface $r) {
                 return $r->withHeader(

--- a/src/EndpointDiscovery/EndpointDiscoveryMiddleware.php
+++ b/src/EndpointDiscovery/EndpointDiscoveryMiddleware.php
@@ -32,14 +32,15 @@ class EndpointDiscoveryMiddleware
         $args,
         $config
     ) {
+        $clientRef = \WeakReference::create($client);
         return function (callable $handler) use (
-            $client,
+            $clientRef,
             $args,
             $config
         ) {
             return new static(
                 $handler,
-                $client,
+                $clientRef->get(),
                 $args,
                 $config
             );

--- a/src/PresignUrlMiddleware.php
+++ b/src/PresignUrlMiddleware.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\RequestInterface;
  */
 class PresignUrlMiddleware
 {
-    private $client;
+    private \WeakReference $client;
     private $endpointProvider;
     private $nextHandler;
     /** @var array names of operations that require presign url */
@@ -32,7 +32,7 @@ class PresignUrlMiddleware
         callable $nextHandler
     ) {
         $this->endpointProvider = $endpointProvider;
-        $this->client = $client;
+        $this->client = \WeakReference::create($client);
         $this->nextHandler = $nextHandler;
         $this->commandPool = $options['operations'];
         $this->serviceName = $options['service'];
@@ -61,7 +61,8 @@ class PresignUrlMiddleware
         if (in_array($cmd->getName(), $this->commandPool)
             && (!isset($cmd['__skip' . $cmd->getName()]))
         ) {
-            $cmd['DestinationRegion'] = $this->client->getRegion();
+            $client = $this->client->get();
+            $cmd['DestinationRegion'] = $client->getRegion();
             if (!empty($cmd['SourceRegion']) && !empty($cmd[$this->presignParam])) {
                 goto nexthandler;
             }
@@ -69,7 +70,7 @@ class PresignUrlMiddleware
                 || (!empty($cmd['SourceRegion'])
                     && $cmd['SourceRegion'] !== $cmd['DestinationRegion'])
             ) {
-                $cmd[$this->presignParam] = $this->createPresignedUrl($this->client, $cmd);
+                $cmd[$this->presignParam] = $this->createPresignedUrl($client, $cmd);
             }
         }
         nexthandler:
@@ -91,7 +92,7 @@ class PresignUrlMiddleware
         // Create the new endpoint for the target endpoint.
         if ($this->endpointProvider instanceof \Aws\EndpointV2\EndpointProviderV2) {
             $providerArgs = array_merge(
-                $this->client->getEndpointProviderArgs(),
+                $this->client->get()->getEndpointProviderArgs(),
                 ['Region' => $cmd['SourceRegion']]
             );
             $endpoint = $this->endpointProvider->resolveEndpoint($providerArgs)->getUrl();

--- a/src/PresignUrlMiddleware.php
+++ b/src/PresignUrlMiddleware.php
@@ -50,9 +50,9 @@ class PresignUrlMiddleware
         $endpointProvider,
         array $options = []
     ) {
-        return function (callable $handler) use ($endpointProvider, $client, $options) {
-            $f = new PresignUrlMiddleware($options, $endpointProvider, $client, $handler);
-            return $f;
+        $clientRef = \WeakReference::create($client);
+        return function (callable $handler) use ($endpointProvider, $clientRef, $options) {
+            return new PresignUrlMiddleware($options, $endpointProvider, $clientRef->get(), $handler);
         };
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-php/issues/1273

*Description of changes:*
`PresignUrlMiddleware` and `EndpointDiscoveryMiddleware` hold a direct $client reference back to the AwsClient through its HandlerList, creating a circular reference cycle that PHP's refcounting cannot collect. Replace $client with \WeakReference in both classes. The client outlives its own handler chain, so the weak reference resolves for the lifetime of the middleware.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
