### PR TITLE
S3Client: fix 'recieved' -> 'received' typo in internal-error message

### DIFF
--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -1142,7 +1142,7 @@ class S3Client extends AwsClient implements S3ClientInterface
 
         // Add a note on the CopyObject docs
          $s3ExceptionRetryMessage = "<p>Additional info on response behavior: if there is"
-            . " an internal error in S3 after the request was successfully recieved,"
+            . " an internal error in S3 after the request was successfully received,"
             . " a 200 response will be returned with an <code>S3Exception</code> embedded"
             . " in it; this will still be caught and retried by"
             . " <code>RetryMiddleware.</code></p>";


### PR DESCRIPTION
### Description

The internal-error message in `src/S3/S3Client.php` at line 1145 contained a spelling error:

```
"... an internal error in S3 after the request was successfully recieved, ..."
```

Should be "received". This string is surfaced to users when the SDK translates a 200-response internal-error into an exception, so the typo is user-visible in logs and error output.

### Motivation and Context

Cosmetic user-visible string fix.

### Testing

String-literal-only change — no behavioral change, no tests affected.

### Screenshots (if appropriate)

N/A

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **README** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.