### PR TITLE
Make EcsCredentialProvider retry behavior configurable

### DIFF
--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -3,6 +3,7 @@ namespace Aws\Credentials;
 
 use Aws\Arn\Arn;
 use Aws\Exception\CredentialsException;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
@@ -107,7 +108,11 @@ class EcsCredentialProvider
                     })->otherwise(function ($reason) {
                         $reason = is_array($reason) ? $reason['exception'] : $reason;
 
-                        $isRetryable = $reason instanceof ConnectException;
+                        $isRetryable = $reason instanceof ConnectException
+                            || (
+                                $reason instanceof BadResponseException
+                                && $reason->getResponse()->getStatusCode() === 429
+                            );
                         if ($isRetryable && ($this->attempts < $this->retries)) {
                             sleep((int)pow(1.2, $this->attempts));
                         } else {

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -42,11 +42,22 @@ class EcsCredentialProvider
     /** @var int */
     private $attempts;
 
+    /** @var string[] */
+    private $retryableExceptions;
+
+    /** @var int[] */
+    private $retryableErrorCodes;
+
     /**
      *  The constructor accepts following options:
      *  - timeout: (optional) Connection timeout, in seconds, default 1.0
      *  - retries: Optional number of retries to be attempted, default 3.
      *  - client: An EcsClient to make request from
+     *  - retryable_exceptions: Optional array of exception class names that
+     *    should be retried. Defaults to [ConnectException::class].
+     *  - retryable_error_codes: Optional array of HTTP status codes that
+     *    should be retried when returned in a BadResponseException. Defaults
+     *    to an empty array.
      *
      * @param array $config Configuration options
      */
@@ -60,6 +71,9 @@ class EcsCredentialProvider
             : ((int) getenv(self::ENV_RETRIES) ?: self::DEFAULT_ENV_RETRIES);
 
         $this->client = $config['client'] ?? \Aws\default_http_handler();
+        $this->retryableExceptions = $config['retryable_exceptions']
+            ?? [ConnectException::class];
+        $this->retryableErrorCodes = $config['retryable_error_codes'] ?? [];
     }
 
     /**
@@ -108,12 +122,7 @@ class EcsCredentialProvider
                     })->otherwise(function ($reason) {
                         $reason = is_array($reason) ? $reason['exception'] : $reason;
 
-                        $isRetryable = $reason instanceof ConnectException
-                            || (
-                                $reason instanceof BadResponseException
-                                && $reason->getResponse()->getStatusCode() === 429
-                            );
-                        if ($isRetryable && ($this->attempts < $this->retries)) {
+                        if ($this->isRetryable($reason) && ($this->attempts < $this->retries)) {
                             sleep((int)pow(1.2, $this->attempts));
                         } else {
                             $msg = $reason->getMessage();
@@ -224,6 +233,31 @@ class EcsCredentialProvider
         }
 
         return self::SERVER_URI . $credsUri;
+    }
+
+    /**
+     * Determines whether a failed request should be retried, based on the
+     * configured retryable_exceptions and retryable_error_codes.
+     */
+    private function isRetryable($reason): bool
+    {
+        foreach ($this->retryableExceptions as $exceptionClass) {
+            if ($reason instanceof $exceptionClass) {
+                return true;
+            }
+        }
+
+        if ($reason instanceof BadResponseException
+            && in_array(
+                $reason->getResponse()->getStatusCode(),
+                $this->retryableErrorCodes,
+                true
+            )
+        ) {
+            return true;
+        }
+
+        return false;
     }
 
     private function decodeResult($response)

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -41,11 +41,22 @@ class EcsCredentialProvider
     /** @var int */
     private $attempts;
 
+    /** @var string[] */
+    private $retryableExceptions;
+
+    /** @var int[] */
+    private $retryableErrorCodes;
+
     /**
      *  The constructor accepts following options:
      *  - timeout: (optional) Connection timeout, in seconds, default 1.0
      *  - retries: Optional number of retries to be attempted, default 3.
      *  - client: An EcsClient to make request from
+     *  - retryable_exceptions: Optional array of additional exception class
+     *    names that should be retried. Connection errors are always retried,
+     *    regardless of this option.
+     *  - retryable_error_codes: Optional array of HTTP status codes that
+     *    should be retried. Defaults to an empty array.
      *
      * @param array $config Configuration options
      */
@@ -58,6 +69,8 @@ class EcsCredentialProvider
             : ((int) getenv(self::ENV_RETRIES) ?: self::DEFAULT_ENV_RETRIES);
 
         $this->client = $config['client'] ?? \Aws\default_http_handler();
+        $this->retryableExceptions = $config['retryable_exceptions'] ?? [];
+        $this->retryableErrorCodes = $config['retryable_error_codes'] ?? [];
     }
 
     /**
@@ -106,7 +119,8 @@ class EcsCredentialProvider
                     })->otherwise(function ($reason) {
                         $connectionError = is_array($reason) && !empty($reason['connection_error']);
                         $exception = is_array($reason) ? ($reason['exception'] ?? null) : $reason;
-                        $isRetryable = $connectionError || ($exception instanceof \Throwable && HttpHandlerError::isConnectionError($exception));
+                        $isRetryable = $connectionError
+                            || ($exception instanceof \Throwable && $this->isRetryable($exception));
 
                         if ($isRetryable && ($this->attempts < $this->retries)) {
                             sleep((int)pow(1.2, $this->attempts));
@@ -219,6 +233,33 @@ class EcsCredentialProvider
         }
 
         return self::SERVER_URI . $credsUri;
+    }
+
+    /**
+     * Determines whether a failed request should be retried. Connection
+     * errors are always retried; the configured retryable_exceptions and
+     * retryable_error_codes are checked in addition to them.
+     */
+    private function isRetryable(\Throwable $exception): bool
+    {
+        if (HttpHandlerError::isConnectionError($exception)) {
+            return true;
+        }
+
+        foreach ($this->retryableExceptions as $exceptionClass) {
+            if ($exception instanceof $exceptionClass) {
+                return true;
+            }
+        }
+
+        $response = HttpHandlerError::getResponse($exception);
+
+        return $response !== null
+            && in_array(
+                $response->getStatusCode(),
+                $this->retryableErrorCodes,
+                true
+            );
     }
 
     private function decodeResult($response)

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -463,17 +463,135 @@ EOF;
                 ],
                 $credsObject
             ],
-            'With retries for HTTP 429 (Pod Identity Agent rate limit)' => [
-                [
-                    'responses' => [
-                        $rejectionTooManyRequests,
-                        $promiseCreds
-                    ],
-                    'credentials' => $creds
-                ],
-                $credsObject
-            ],
         ];
+    }
+
+    public function testRetriesOptedInErrorCode()
+    {
+        $expiry = time() + 1000;
+        $creds = ['foo_key', 'baz_secret', 'qux_token', "@{$expiry}"];
+
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => new BadResponseException(
+                '429 Too Many Requests',
+                new Psr7\Request('GET', '/latest'),
+                new Psr7\Response(429)
+            ),
+        ]);
+        $promiseCreds = Promise\Create::promiseFor(
+            new Response(200, [], Psr7\Utils::streamFor(
+                json_encode(call_user_func_array(
+                    [self::class, 'getCredentialArray'],
+                    $creds
+                )))
+            )
+        );
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionTooManyRequests,
+                $promiseCreds,
+            ], $creds),
+            'retries' => 2,
+            'retryable_error_codes' => [429],
+        ]);
+
+        $credentials = $provider()->wait();
+        $this->assertSame('foo_key', $credentials->getAccessKeyId());
+        $this->assertSame('baz_secret', $credentials->getSecretKey());
+    }
+
+    public function testDoesNotRetry429ByDefault()
+    {
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => new BadResponseException(
+                '429 Too Many Requests',
+                new Psr7\Request('GET', '/latest'),
+                new Psr7\Response(429)
+            ),
+        ]);
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionTooManyRequests,
+            ]),
+            'retries' => 3,
+        ]);
+
+        try {
+            $provider()->wait();
+            $this->fail('Provider should have thrown an exception.');
+        } catch (CredentialsException $e) {
+            $this->assertStringContainsString(
+                'attempt 0/3',
+                $e->getMessage()
+            );
+            $this->assertStringContainsString('429 Too Many Requests', $e->getMessage());
+        }
+
+        $this->assertSame(0, $provider->getAttempts());
+    }
+
+    public function testRetriesOptedInExceptionClass()
+    {
+        $expiry = time() + 1000;
+        $creds = ['foo_key', 'baz_secret', 'qux_token', "@{$expiry}"];
+
+        $rejectionRequest = Promise\Create::rejectionFor([
+            'exception' => new RequestException(
+                'Boom',
+                new Psr7\Request('GET', '/latest'),
+                new Psr7\Response(500)
+            ),
+        ]);
+        $promiseCreds = Promise\Create::promiseFor(
+            new Response(200, [], Psr7\Utils::streamFor(
+                json_encode(call_user_func_array(
+                    [self::class, 'getCredentialArray'],
+                    $creds
+                )))
+            )
+        );
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionRequest,
+                $promiseCreds,
+            ], $creds),
+            'retries' => 2,
+            'retryable_exceptions' => [
+                ConnectException::class,
+                RequestException::class,
+            ],
+        ]);
+
+        $credentials = $provider()->wait();
+        $this->assertSame('foo_key', $credentials->getAccessKeyId());
+    }
+
+    public function testCustomRetryableExceptionsReplaceDefaults()
+    {
+        $rejectionConnection = Promise\Create::rejectionFor([
+            'exception' => new ConnectException(
+                'cURL error 28: Connection timed out after 1000 milliseconds',
+                new Psr7\Request('GET', '/latest')
+            ),
+        ]);
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionConnection,
+            ]),
+            'retries' => 3,
+            'retryable_exceptions' => [],
+        ]);
+
+        try {
+            $provider()->wait();
+            $this->fail('Provider should have thrown an exception.');
+        } catch (CredentialsException $e) {
+            $this->assertSame(0, $provider->getAttempts());
+        }
     }
 
     /**
@@ -547,16 +665,45 @@ EOF;
                     'Error retrieving credentials from container metadata after attempt 1/1 (cURL error 28: Connection timed out after 1000 milliseconds)'
                 )
             ],
-            'Retryable HTTP 429 error exhausts retries' => [
+            'Non-retryable HTTP 429 by default' => [
                 [
-                    $rejectionTooManyRequests,
                     $rejectionTooManyRequests,
                 ],
                 new CredentialsException(
-                    'Error retrieving credentials from container metadata after attempt 1/1 (429 Too Many Requests)'
+                    'Error retrieving credentials from container metadata after attempt 0/1 (429 Too Many Requests)'
                 )
             ],
         ];
+    }
+
+    public function testOptedInHTTP429RetryExhaustsAttempts()
+    {
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => new BadResponseException(
+                '429 Too Many Requests',
+                new Psr7\Request('GET', '/latest'),
+                new Psr7\Response(429)
+            ),
+        ]);
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionTooManyRequests,
+                $rejectionTooManyRequests,
+            ]),
+            'retries' => 1,
+            'retryable_error_codes' => [429],
+        ]);
+
+        try {
+            $provider()->wait();
+            $this->fail('Provider should have thrown an exception.');
+        } catch (CredentialsException $e) {
+            $this->assertSame(
+                'Error retrieving credentials from container metadata after attempt 1/1 (429 Too Many Requests)',
+                $e->getMessage()
+            );
+        }
     }
 
     public function testReadsRetriesFromEnvironment()

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -7,6 +7,7 @@ use Aws\Credentials\EcsCredentialProvider;
 use Aws\Exception\CredentialsException;
 use Aws\Handler\Guzzle\GuzzleHandler;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
@@ -414,6 +415,15 @@ EOF;
             'exception' => $connectException,
         ]);
 
+        $tooManyRequestsException = new BadResponseException(
+            '429 Too Many Requests',
+            new Psr7\Request('GET', '/latest'),
+            new Psr7\Response(429)
+        );
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => $tooManyRequestsException,
+        ]);
+
         $promiseCreds = Promise\Create::promiseFor(
             new Response(200, [], Psr7\Utils::streamFor(
                 json_encode(call_user_func_array(
@@ -447,6 +457,16 @@ EOF;
                         $rejectionConnection,
                         $rejectionConnection,
                         $rejectionConnection,
+                        $promiseCreds
+                    ],
+                    'credentials' => $creds
+                ],
+                $credsObject
+            ],
+            'With retries for HTTP 429 (Pod Identity Agent rate limit)' => [
+                [
+                    'responses' => [
+                        $rejectionTooManyRequests,
                         $promiseCreds
                     ],
                     'credentials' => $creds
@@ -501,6 +521,13 @@ EOF;
         $rejectionConnection = Promise\Create::rejectionFor([
             'exception' => $connectException,
         ]);
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => new BadResponseException(
+                '429 Too Many Requests',
+                $getRequest,
+                new Psr7\Response(429)
+            )
+        ]);
 
         return [
             'Non-retryable error' => [
@@ -518,6 +545,15 @@ EOF;
                 ],
                 new CredentialsException(
                     'Error retrieving credentials from container metadata after attempt 1/1 (cURL error 28: Connection timed out after 1000 milliseconds)'
+                )
+            ],
+            'Retryable HTTP 429 error exhausts retries' => [
+                [
+                    $rejectionTooManyRequests,
+                    $rejectionTooManyRequests,
+                ],
+                new CredentialsException(
+                    'Error retrieving credentials from container metadata after attempt 1/1 (429 Too Many Requests)'
                 )
             ],
         ];

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -462,6 +462,15 @@ EOF;
         ]);
         $rejectionRawConnectException = Promise\Create::rejectionFor($connectException);
 
+        $tooManyRequestsException = self::createRequestException(
+            '429 Too Many Requests',
+            new Psr7\Request('GET', '/latest'),
+            new Psr7\Response(429)
+        );
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => $tooManyRequestsException,
+        ]);
+
         $promiseCreds = Promise\Create::promiseFor(
             new Response(200, [], Psr7\Utils::streamFor(
                 json_encode(call_user_func_array(
@@ -524,6 +533,135 @@ EOF;
         ];
     }
 
+    public function testRetriesOptedInErrorCode()
+    {
+        $expiry = time() + 1000;
+        $creds = ['foo_key', 'baz_secret', 'qux_token', "@{$expiry}"];
+
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => self::createRequestException(
+                '429 Too Many Requests',
+                new Psr7\Request('GET', '/latest'),
+                new Psr7\Response(429)
+            ),
+        ]);
+        $promiseCreds = Promise\Create::promiseFor(
+            new Response(200, [], Psr7\Utils::streamFor(
+                json_encode(call_user_func_array(
+                    [self::class, 'getCredentialArray'],
+                    $creds
+                )))
+            )
+        );
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionTooManyRequests,
+                $promiseCreds,
+            ], $creds),
+            'retries' => 2,
+            'retryable_error_codes' => [429],
+        ]);
+
+        $credentials = $provider()->wait();
+        $this->assertSame('foo_key', $credentials->getAccessKeyId());
+        $this->assertSame('baz_secret', $credentials->getSecretKey());
+    }
+
+    public function testDoesNotRetry429ByDefault()
+    {
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => self::createRequestException(
+                '429 Too Many Requests',
+                new Psr7\Request('GET', '/latest'),
+                new Psr7\Response(429)
+            ),
+        ]);
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionTooManyRequests,
+            ]),
+            'retries' => 3,
+        ]);
+
+        try {
+            $provider()->wait();
+            $this->fail('Provider should have thrown an exception.');
+        } catch (CredentialsException $e) {
+            $this->assertStringContainsString(
+                'attempt 0/3',
+                $e->getMessage()
+            );
+            $this->assertStringContainsString('429 Too Many Requests', $e->getMessage());
+        }
+
+        $this->assertSame(0, $provider->getAttempts());
+    }
+
+    public function testRetriesOptedInExceptionClass()
+    {
+        $expiry = time() + 1000;
+        $creds = ['foo_key', 'baz_secret', 'qux_token', "@{$expiry}"];
+
+        $rejectionRequest = Promise\Create::rejectionFor([
+            'exception' => new \DomainException('Boom'),
+        ]);
+        $promiseCreds = Promise\Create::promiseFor(
+            new Response(200, [], Psr7\Utils::streamFor(
+                json_encode(call_user_func_array(
+                    [self::class, 'getCredentialArray'],
+                    $creds
+                )))
+            )
+        );
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionRequest,
+                $promiseCreds,
+            ], $creds),
+            'retries' => 2,
+            'retryable_exceptions' => [\DomainException::class],
+        ]);
+
+        $credentials = $provider()->wait();
+        $this->assertSame('foo_key', $credentials->getAccessKeyId());
+    }
+
+    public function testCustomRetryableExceptionsAreAddedToDefaults()
+    {
+        $expiry = time() + 1000;
+        $creds = ['foo_key', 'baz_secret', 'qux_token', "@{$expiry}"];
+
+        $rejectionConnection = Promise\Create::rejectionFor([
+            'exception' => new ConnectException(
+                'cURL error 28: Connection timed out after 1000 milliseconds',
+                new Psr7\Request('GET', '/latest')
+            ),
+        ]);
+        $promiseCreds = Promise\Create::promiseFor(
+            new Response(200, [], Psr7\Utils::streamFor(
+                json_encode(call_user_func_array(
+                    [self::class, 'getCredentialArray'],
+                    $creds
+                )))
+            )
+        );
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionConnection,
+                $promiseCreds,
+            ], $creds),
+            'retries' => 2,
+            'retryable_exceptions' => [\DomainException::class],
+        ]);
+
+        $credentials = $provider()->wait();
+        $this->assertSame('foo_key', $credentials->getAccessKeyId());
+    }
+
     /**
      * @param $client
      * @param \Exception $expected
@@ -566,6 +704,13 @@ EOF;
             'connection_error' => true,
             'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
         ]);
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => self::createRequestException(
+                '429 Too Many Requests',
+                $getRequest,
+                new Psr7\Response(429)
+            )
+        ]);
 
         return [
             'Non-retryable error' => [
@@ -585,7 +730,45 @@ EOF;
                     'Error retrieving credentials from container metadata after attempt 1/1 (cURL error 28: Connection timed out after 1000 milliseconds)'
                 )
             ],
+            'Non-retryable HTTP 429 by default' => [
+                [
+                    $rejectionTooManyRequests,
+                ],
+                new CredentialsException(
+                    'Error retrieving credentials from container metadata after attempt 0/1 (429 Too Many Requests)'
+                )
+            ],
         ];
+    }
+
+    public function testOptedInHTTP429RetryExhaustsAttempts()
+    {
+        $rejectionTooManyRequests = Promise\Create::rejectionFor([
+            'exception' => self::createRequestException(
+                '429 Too Many Requests',
+                new Psr7\Request('GET', '/latest'),
+                new Psr7\Response(429)
+            ),
+        ]);
+
+        $provider = new EcsCredentialProvider([
+            'client' => $this->getTestClient([
+                $rejectionTooManyRequests,
+                $rejectionTooManyRequests,
+            ]),
+            'retries' => 1,
+            'retryable_error_codes' => [429],
+        ]);
+
+        try {
+            $provider()->wait();
+            $this->fail('Provider should have thrown an exception.');
+        } catch (CredentialsException $e) {
+            $this->assertSame(
+                'Error retrieving credentials from container metadata after attempt 1/1 (429 Too Many Requests)',
+                $e->getMessage()
+            );
+        }
     }
 
     public function testReadsRetriesFromEnvironment()


### PR DESCRIPTION
## Description of changes

Replaces the hardcoded retry condition in `EcsCredentialProvider` with two configurable allowlists, addressing review feedback that retry behavior for HTTP/container credential providers is largely undefined across AWS SDKs and shouldn't be expanded by default.

Two new constructor options:

- `retryable_exceptions` — array of exception class names. Defaults to `[ConnectException::class]`, preserving existing behavior.
- `retryable_error_codes` — array of HTTP status codes to retry when returned in a Guzzle `BadResponseException`. Defaults to `[]`.

The retry decision now lives in a private `isRetryable()` helper that consults both lists.

### Motivation

The EKS Pod Identity Agent's [rate limiter](https://github.com/aws/eks-pod-identity-agent/blob/main/internal/middleware/rate_limiter/rate_limiter.go) returns HTTP 429 when its token bucket is empty. Previously these surfaced immediately as `CredentialsException`. Callers in that environment can now opt in:

```php
new EcsCredentialProvider([
    'retryable_error_codes' => [429],
]);
```

This mirrors the explicit allowlist used by `aws-sdk-go-v2`'s [endpointcreds client](https://github.com/aws/aws-sdk-go-v2/blob/main/credentials/endpointcreds/internal/client/client.go), without changing default behavior for any existing caller.

### Tests

Added coverage for: opt-in 429 retry succeeds, opt-in 429 retry exhausts attempts, custom exception class added via config, custom config replacing defaults, 429 not retried by default. Existing `ConnectException` retry and 401 non-retryable cases unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

Generated by AI tools (Claude), and reviewed by Kieran Brown.