### PR TITLE
feat: copy object metadata in multipartcopy

### DIFF
--- a/.changes/nextrelease/multipart-copy.json
+++ b/.changes/nextrelease/multipart-copy.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "S3",
+    "description": "Adds `metadata_directive` configuration option to `MultipartCopy`. When set to `'COPY'` (the new default), source object metadata (Metadata, CacheControl, ContentDisposition, ContentEncoding, ContentLanguage, ContentType, Expires) is automatically preserved on the destination object. Set to `'REPLACE'` to suppress automatic metadata copying and provide your own via the `params` option. User-provided values in `params` always take precedence over source metadata.\n"
+  }
+]

--- a/features/bootstrap/Aws/Test/Integ/MultipartContext.php
+++ b/features/bootstrap/Aws/Test/Integ/MultipartContext.php
@@ -163,7 +163,159 @@ class MultipartContext implements Context, SnippetAcceptingContext
                 'Bucket' => self::getResourceName(),
                 'Key' => $filename . '-copy',
             ])['Body']->getContents()
-        );    }
+        );
+    }
+
+    /**
+     * @Given I have an s3 client and an uploaded file named :filename with metadata
+     */
+    public function iHaveAnS3ClientAndAnUploadedFileNamedWithMetadata($filename)
+    {
+        $this->s3Client = self::getSdk()->createS3();
+        $this->filename = $filename;
+        $this->s3Client->putObject([
+            'Bucket' => self::getResourceName(),
+            'Key' => $filename,
+            'Body' => 'foo',
+            'Metadata' => [
+                'test-key' => 'test-value',
+                'another-key' => 'another-value',
+            ],
+            'CacheControl' => 'max-age=3600',
+            'ContentDisposition' => 'attachment; filename="test.txt"',
+        ]);
+    }
+
+    /**
+     * @When I call multipartCopy on :filename with metadata_directive :directive and custom metadata
+     */
+    public function iCallMultipartCopyWithDirectiveAndCustomMetadata($filename, $directive)
+    {
+        $bucketName = self::getResourceName();
+        $source = '/' . $bucketName . '/' . $filename;
+
+        $copier = new MultipartCopy(
+            $this->s3Client,
+            $source,
+            [
+                'bucket' => $bucketName,
+                'key' => $filename . '-copy',
+                'metadata_directive' => $directive,
+                'params' => [
+                    'Metadata' => ['custom-key' => 'custom-value'],
+                    'ContentType' => 'text/plain',
+                ],
+            ]
+        );
+
+        try {
+            $this->result = $copier->copy();
+        } catch (MultipartUploadException $e) {
+            $this->s3Client->abortMultipartUpload($e->getState()->getId());
+            Assert::fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @When I call multipartCopy on :filename with metadata_directive :directive and no metadata
+     */
+    public function iCallMultipartCopyWithDirectiveAndNoMetadata($filename, $directive)
+    {
+        $bucketName = self::getResourceName();
+        $source = '/' . $bucketName . '/' . $filename;
+
+        $copier = new MultipartCopy(
+            $this->s3Client,
+            $source,
+            [
+                'bucket' => $bucketName,
+                'key' => $filename . '-copy',
+                'metadata_directive' => $directive,
+            ]
+        );
+
+        try {
+            $this->result = $copier->copy();
+        } catch (MultipartUploadException $e) {
+            $this->s3Client->abortMultipartUpload($e->getState()->getId());
+            Assert::fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @Then the copied file :destKey should have the same metadata as :sourceKey
+     */
+    public function theCopiedFileShouldHaveTheSameMetadataAs($destKey, $sourceKey)
+    {
+        $bucketName = self::getResourceName();
+
+        $sourceHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $sourceKey,
+        ]);
+        $destHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $destKey,
+        ]);
+
+        Assert::assertEquals(
+            $sourceHead['Metadata'],
+            $destHead['Metadata'],
+            'User-defined metadata should be preserved'
+        );
+        Assert::assertEquals(
+            $sourceHead['CacheControl'],
+            $destHead['CacheControl'],
+            'CacheControl should be preserved'
+        );
+        Assert::assertEquals(
+            $sourceHead['ContentDisposition'],
+            $destHead['ContentDisposition'],
+            'ContentDisposition should be preserved'
+        );
+    }
+
+    /**
+     * @Then the copied file :destKey should have the custom metadata
+     */
+    public function theCopiedFileShouldHaveTheCustomMetadata($destKey)
+    {
+        $bucketName = self::getResourceName();
+
+        $destHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $destKey,
+        ]);
+
+        Assert::assertEquals(
+            ['custom-key' => 'custom-value'],
+            $destHead['Metadata'],
+            'Destination should have only the custom metadata'
+        );
+        Assert::assertEquals(
+            'text/plain',
+            $destHead['ContentType'],
+            'ContentType should be the user-provided value'
+        );
+    }
+
+    /**
+     * @Then the copied file :destKey should have no user-defined metadata
+     */
+    public function theCopiedFileShouldHaveNoUserDefinedMetadata($destKey)
+    {
+        $bucketName = self::getResourceName();
+
+        $destHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $destKey,
+        ]);
+
+        Assert::assertEmpty(
+            $destHead['Metadata'],
+            'Destination should have no user-defined metadata'
+        );
+    }
 
     /**
      * @Given I have a non-seekable read stream

--- a/features/multipart/s3.feature
+++ b/features/multipart/s3.feature
@@ -36,3 +36,18 @@ Feature: S3 Multipart Uploads
       | filename     |
       | the-file     |
       | the-?-file   |
+
+  Scenario: Copying a file preserves source metadata by default
+    Given I have an s3 client and an uploaded file named "meta-default" with metadata
+    When I call multipartCopy on "meta-default" to a new key in the same bucket
+    Then the copied file "meta-default-copy" should have the same metadata as "meta-default"
+
+  Scenario: Copying a file with REPLACE directive uses provided metadata
+    Given I have an s3 client and an uploaded file named "meta-replace" with metadata
+    When I call multipartCopy on "meta-replace" with metadata_directive "REPLACE" and custom metadata
+    Then the copied file "meta-replace-copy" should have the custom metadata
+
+  Scenario: Copying a file with REPLACE directive and no metadata strips metadata
+    Given I have an s3 client and an uploaded file named "meta-strip" with metadata
+    When I call multipartCopy on "meta-strip" with metadata_directive "REPLACE" and no metadata
+    Then the copied file "meta-strip-copy" should have no user-defined metadata

--- a/src/S3/MultipartCopy.php
+++ b/src/S3/MultipartCopy.php
@@ -9,7 +9,23 @@ use GuzzleHttp\Psr7;
 
 class MultipartCopy extends AbstractUploadManager
 {
-    use MultipartUploadingTrait;
+    use MultipartUploadingTrait {
+        getInitiateParams as private traitGetInitiateParams;
+    }
+
+    /**
+     * Metadata fields that can be copied from the source object
+     * to the destination during a multipart copy.
+     */
+    private static array $copyMetadataFields = [
+        'CacheControl',
+        'ContentDisposition',
+        'ContentEncoding',
+        'ContentLanguage',
+        'ContentType',
+        'Expires',
+        'Metadata',
+    ];
 
     /** @var string|array */
     private $source;
@@ -50,8 +66,18 @@ class MultipartCopy extends AbstractUploadManager
      *   of the multipart upload and that is used to resume a previous upload.
      *   When this option is provided, the `bucket`, `key`, and `part_size`
      *   options are ignored.
-     * - source_metadata: (Aws\ResultInterface) An object that represents the
-     *   result of executing a HeadObject command on the copy source.
+     * - metadata_directive: (string, default='COPY') Specifies whether to copy
+     *   source object metadata to the destination. Set to 'COPY' to
+     *   automatically forward metadata fields (Metadata, CacheControl,
+     *   ContentDisposition, ContentEncoding, ContentLanguage, ContentType,
+     *   Expires) from the source object. Set to 'REPLACE' to suppress automatic
+     *   metadata copying (you must then provide your own metadata via the
+     *   'params' option). User-provided values in 'params' always take
+     *   precedence over source metadata.
+     * - source_metadata: (Aws\ResultInterface) The result of a HeadObject call
+     *   on the copy source. If not provided, the SDK makes a HeadObject request
+     *   to obtain the source object's size and metadata. Providing this avoids
+     *   the extra request.
      * - display_progress: (boolean) Set true to track status in 1/8th increments
      *   for upload.
      *
@@ -177,6 +203,31 @@ class MultipartCopy extends AbstractUploadManager
     protected function extractETag(ResultInterface $result)
     {
         return $result->search('CopyPartResult.ETag');
+    }
+
+    protected function getInitiateParams()
+    {
+        $params = $this->traitGetInitiateParams();
+
+        $directive = strtoupper($this->config['metadata_directive'] ?? 'COPY');
+
+        if (!in_array($directive, ['COPY', 'REPLACE'], true)) {
+            throw new \InvalidArgumentException(
+                "Invalid metadata_directive value '$directive'."
+                . " Must be 'COPY' or 'REPLACE'."
+            );
+        }
+
+        if ($directive === 'COPY') {
+            $sourceMetadata = $this->getSourceMetadata();
+            foreach (self::$copyMetadataFields as $field) {
+                if (!isset($params[$field]) && !empty($sourceMetadata[$field])) {
+                    $params[$field] = $sourceMetadata[$field];
+                }
+            }
+        }
+
+        return $params;
     }
 
     protected function getSourceMimeType()

--- a/src/S3/ObjectCopier.php
+++ b/src/S3/ObjectCopier.php
@@ -14,6 +14,11 @@ use InvalidArgumentException;
 /**
  * Copies objects from one S3 location to another, utilizing a multipart copy
  * when appropriate.
+ *
+ * Makes a HeadObject call on the source to determine object size. Objects
+ * below the multipart threshold (default 5 GB) are copied with a single
+ * CopyObject call using MetadataDirective: COPY. Objects above the threshold
+ * use MultipartCopy, which also preserves source metadata by default.
  */
 class ObjectCopier implements PromisorInterface
 {

--- a/tests/Integ/MultipartContext.php
+++ b/tests/Integ/MultipartContext.php
@@ -207,7 +207,159 @@ class MultipartContext implements Context, SnippetAcceptingContext
                 'Bucket' => self::getResourceName(),
                 'Key' => $filename . '-copy',
             ])['Body']->getContents()
-        );    }
+        );
+    }
+
+    /**
+     * @Given I have an s3 client and an uploaded file named :filename with metadata
+     */
+    public function iHaveAnS3ClientAndAnUploadedFileNamedWithMetadata($filename)
+    {
+        $this->s3Client = self::getSdk()->createS3();
+        $this->filename = $filename;
+        $this->s3Client->putObject([
+            'Bucket' => self::getResourceName(),
+            'Key' => $filename,
+            'Body' => 'foo',
+            'Metadata' => [
+                'test-key' => 'test-value',
+                'another-key' => 'another-value',
+            ],
+            'CacheControl' => 'max-age=3600',
+            'ContentDisposition' => 'attachment; filename="test.txt"',
+        ]);
+    }
+
+    /**
+     * @When I call multipartCopy on :filename with metadata_directive :directive and custom metadata
+     */
+    public function iCallMultipartCopyWithDirectiveAndCustomMetadata($filename, $directive)
+    {
+        $bucketName = self::getResourceName();
+        $source = '/' . $bucketName . '/' . $filename;
+
+        $copier = new MultipartCopy(
+            $this->s3Client,
+            $source,
+            [
+                'bucket' => $bucketName,
+                'key' => $filename . '-copy',
+                'metadata_directive' => $directive,
+                'params' => [
+                    'Metadata' => ['custom-key' => 'custom-value'],
+                    'ContentType' => 'text/plain',
+                ],
+            ]
+        );
+
+        try {
+            $this->result = $copier->copy();
+        } catch (MultipartUploadException $e) {
+            $this->s3Client->abortMultipartUpload($e->getState()->getId());
+            Assert::fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @When I call multipartCopy on :filename with metadata_directive :directive and no metadata
+     */
+    public function iCallMultipartCopyWithDirectiveAndNoMetadata($filename, $directive)
+    {
+        $bucketName = self::getResourceName();
+        $source = '/' . $bucketName . '/' . $filename;
+
+        $copier = new MultipartCopy(
+            $this->s3Client,
+            $source,
+            [
+                'bucket' => $bucketName,
+                'key' => $filename . '-copy',
+                'metadata_directive' => $directive,
+            ]
+        );
+
+        try {
+            $this->result = $copier->copy();
+        } catch (MultipartUploadException $e) {
+            $this->s3Client->abortMultipartUpload($e->getState()->getId());
+            Assert::fail($e->getMessage());
+        }
+    }
+
+    /**
+     * @Then the copied file :destKey should have the same metadata as :sourceKey
+     */
+    public function theCopiedFileShouldHaveTheSameMetadataAs($destKey, $sourceKey)
+    {
+        $bucketName = self::getResourceName();
+
+        $sourceHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $sourceKey,
+        ]);
+        $destHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $destKey,
+        ]);
+
+        Assert::assertEquals(
+            $sourceHead['Metadata'],
+            $destHead['Metadata'],
+            'User-defined metadata should be preserved'
+        );
+        Assert::assertEquals(
+            $sourceHead['CacheControl'],
+            $destHead['CacheControl'],
+            'CacheControl should be preserved'
+        );
+        Assert::assertEquals(
+            $sourceHead['ContentDisposition'],
+            $destHead['ContentDisposition'],
+            'ContentDisposition should be preserved'
+        );
+    }
+
+    /**
+     * @Then the copied file :destKey should have the custom metadata
+     */
+    public function theCopiedFileShouldHaveTheCustomMetadata($destKey)
+    {
+        $bucketName = self::getResourceName();
+
+        $destHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $destKey,
+        ]);
+
+        Assert::assertEquals(
+            ['custom-key' => 'custom-value'],
+            $destHead['Metadata'],
+            'Destination should have only the custom metadata'
+        );
+        Assert::assertEquals(
+            'text/plain',
+            $destHead['ContentType'],
+            'ContentType should be the user-provided value'
+        );
+    }
+
+    /**
+     * @Then the copied file :destKey should have no user-defined metadata
+     */
+    public function theCopiedFileShouldHaveNoUserDefinedMetadata($destKey)
+    {
+        $bucketName = self::getResourceName();
+
+        $destHead = $this->s3Client->headObject([
+            'Bucket' => $bucketName,
+            'Key' => $destKey,
+        ]);
+
+        Assert::assertEmpty(
+            $destHead['Metadata'],
+            'Destination should have no user-defined metadata'
+        );
+    }
 
     /**
      * @Given I have a non-seekable read stream

--- a/tests/S3/MultipartCopyTest.php
+++ b/tests/S3/MultipartCopyTest.php
@@ -224,4 +224,304 @@ class MultipartCopyTest extends TestCase
         $uploader = new MultipartCopy($client, '/bucket/key', $copyOptions);
         $uploader->upload();
     }
+
+    public function testDefaultMetadataDirectiveCopiesSourceMetadata()
+    {
+        $client = $this->getTestClient('s3');
+        $url = 'http://foo.s3.amazonaws.com/bar';
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+            new Result(['ETag' => 'A']),
+            new Result(['ETag' => 'B']),
+            new Result(['ETag' => 'C']),
+            new Result(['Location' => $url])
+        ]);
+
+        $initiateParams = null;
+        $sourceMetadata = new Result([
+            'ContentLength' => 11 * self::MB,
+            'ContentType' => 'application/pdf',
+            'CacheControl' => 'max-age=3600',
+            'ContentDisposition' => 'attachment; filename="doc.pdf"',
+            'ContentEncoding' => 'gzip',
+            'ContentLanguage' => 'en-US',
+            'Expires' => 'Thu, 01 Dec 2025 16:00:00 GMT',
+            'Metadata' => ['custom-key' => 'custom-value', 'another' => 'meta'],
+            'WebsiteRedirectLocation' => '/redirect-target',
+        ]);
+
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => $sourceMetadata,
+            'before_initiate' => function ($command) use (&$initiateParams) {
+                $initiateParams = $command->toArray();
+            },
+        ]);
+        $uploader->upload();
+
+        $this->assertSame('application/pdf', $initiateParams['ContentType']);
+        $this->assertSame('max-age=3600', $initiateParams['CacheControl']);
+        $this->assertSame('attachment; filename="doc.pdf"', $initiateParams['ContentDisposition']);
+        $this->assertSame('gzip', $initiateParams['ContentEncoding']);
+        $this->assertSame('en-US', $initiateParams['ContentLanguage']);
+        $this->assertSame('Thu, 01 Dec 2025 16:00:00 GMT', $initiateParams['Expires']);
+        $this->assertSame(['custom-key' => 'custom-value', 'another' => 'meta'], $initiateParams['Metadata']);
+        // WebsiteRedirectLocation is NOT copied — matches CopyObject behavior
+        $this->assertArrayNotHasKey('WebsiteRedirectLocation', $initiateParams);
+    }
+
+    public function testMetadataDirectiveReplaceSuppressesSourceMetadata()
+    {
+        $client = $this->getTestClient('s3');
+        $url = 'http://foo.s3.amazonaws.com/bar';
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+            new Result(['ETag' => 'A']),
+            new Result(['ETag' => 'B']),
+            new Result(['ETag' => 'C']),
+            new Result(['Location' => $url])
+        ]);
+
+        $initiateParams = null;
+        $sourceMetadata = new Result([
+            'ContentLength' => 11 * self::MB,
+            'ContentType' => 'application/pdf',
+            'CacheControl' => 'max-age=3600',
+            'Metadata' => ['custom-key' => 'custom-value'],
+        ]);
+
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => $sourceMetadata,
+            'metadata_directive' => 'REPLACE',
+            'before_initiate' => function ($command) use (&$initiateParams) {
+                $initiateParams = $command->toArray();
+            },
+        ]);
+        $uploader->upload();
+
+        // ContentType is still set by the trait's getInitiateParams (from getSourceMimeType)
+        $this->assertSame('application/pdf', $initiateParams['ContentType']);
+        // But other metadata fields should NOT be forwarded
+        $this->assertArrayNotHasKey('CacheControl', $initiateParams);
+        $this->assertArrayNotHasKey('Metadata', $initiateParams);
+        $this->assertArrayNotHasKey('ContentDisposition', $initiateParams);
+    }
+
+    public function testUserParamsOverrideSourceMetadata()
+    {
+        $client = $this->getTestClient('s3');
+        $url = 'http://foo.s3.amazonaws.com/bar';
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+            new Result(['ETag' => 'A']),
+            new Result(['ETag' => 'B']),
+            new Result(['ETag' => 'C']),
+            new Result(['Location' => $url])
+        ]);
+
+        $initiateParams = null;
+        $sourceMetadata = new Result([
+            'ContentLength' => 11 * self::MB,
+            'ContentType' => 'application/pdf',
+            'CacheControl' => 'max-age=3600',
+            'Metadata' => ['source-key' => 'source-value'],
+        ]);
+
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => $sourceMetadata,
+            'params' => [
+                'ContentType' => 'text/plain',
+                'Metadata' => ['user-key' => 'user-value'],
+            ],
+            'before_initiate' => function ($command) use (&$initiateParams) {
+                $initiateParams = $command->toArray();
+            },
+        ]);
+        $uploader->upload();
+
+        // User-provided params should take precedence
+        $this->assertSame('text/plain', $initiateParams['ContentType']);
+        $this->assertSame(['user-key' => 'user-value'], $initiateParams['Metadata']);
+        // Source metadata that was NOT overridden should still be copied
+        $this->assertSame('max-age=3600', $initiateParams['CacheControl']);
+    }
+
+    public function testNonCopyableFieldsAreNotForwarded()
+    {
+        $client = $this->getTestClient('s3');
+        $url = 'http://foo.s3.amazonaws.com/bar';
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+            new Result(['ETag' => 'A']),
+            new Result(['ETag' => 'B']),
+            new Result(['ETag' => 'C']),
+            new Result(['Location' => $url])
+        ]);
+
+        $initiateParams = null;
+        $sourceMetadata = new Result([
+            'ContentLength' => 11 * self::MB,
+            'ContentType' => 'application/pdf',
+            'ETag' => '"abc123"',
+            'LastModified' => '2025-01-01T00:00:00Z',
+            'ServerSideEncryption' => 'aws:kms',
+            'SSEKMSKeyId' => 'arn:aws:kms:us-east-1:123456789:key/abcd',
+            'StorageClass' => 'STANDARD',
+            'VersionId' => 'v1',
+        ]);
+
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => $sourceMetadata,
+            'before_initiate' => function ($command) use (&$initiateParams) {
+                $initiateParams = $command->toArray();
+            },
+        ]);
+        $uploader->upload();
+
+        // These fields should NOT be forwarded to CreateMultipartUpload
+        $this->assertArrayNotHasKey('ETag', $initiateParams);
+        $this->assertArrayNotHasKey('LastModified', $initiateParams);
+        $this->assertArrayNotHasKey('ServerSideEncryption', $initiateParams);
+        $this->assertArrayNotHasKey('SSEKMSKeyId', $initiateParams);
+        $this->assertArrayNotHasKey('StorageClass', $initiateParams);
+        $this->assertArrayNotHasKey('VersionId', $initiateParams);
+        $this->assertArrayNotHasKey('ContentLength', $initiateParams);
+    }
+
+    public function testMetadataDirectiveCaseInsensitive()
+    {
+        $client = $this->getTestClient('s3');
+        $url = 'http://foo.s3.amazonaws.com/bar';
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+            new Result(['ETag' => 'A']),
+            new Result(['ETag' => 'B']),
+            new Result(['ETag' => 'C']),
+            new Result(['Location' => $url])
+        ]);
+
+        $initiateParams = null;
+        $sourceMetadata = new Result([
+            'ContentLength' => 11 * self::MB,
+            'ContentType' => 'text/html',
+            'CacheControl' => 'no-cache',
+        ]);
+
+        // Test lowercase 'copy'
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => $sourceMetadata,
+            'metadata_directive' => 'copy',
+            'before_initiate' => function ($command) use (&$initiateParams) {
+                $initiateParams = $command->toArray();
+            },
+        ]);
+        $uploader->upload();
+
+        $this->assertSame('no-cache', $initiateParams['CacheControl']);
+        $this->assertSame('text/html', $initiateParams['ContentType']);
+    }
+
+    public function testEmptyMetadataFieldsAreNotCopied()
+    {
+        $client = $this->getTestClient('s3');
+        $url = 'http://foo.s3.amazonaws.com/bar';
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+            new Result(['ETag' => 'A']),
+            new Result(['ETag' => 'B']),
+            new Result(['ETag' => 'C']),
+            new Result(['Location' => $url])
+        ]);
+
+        $initiateParams = null;
+        $sourceMetadata = new Result([
+            'ContentLength' => 11 * self::MB,
+            'ContentType' => 'text/plain',
+            'CacheControl' => '',
+            'ContentDisposition' => null,
+            'Metadata' => [],
+        ]);
+
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => $sourceMetadata,
+            'before_initiate' => function ($command) use (&$initiateParams) {
+                $initiateParams = $command->toArray();
+            },
+        ]);
+        $uploader->upload();
+
+        // Empty/null/falsy values should not be forwarded
+        $this->assertArrayNotHasKey('CacheControl', $initiateParams);
+        $this->assertArrayNotHasKey('ContentDisposition', $initiateParams);
+        $this->assertArrayNotHasKey('Metadata', $initiateParams);
+        // ContentType is set because it's non-empty
+        $this->assertSame('text/plain', $initiateParams['ContentType']);
+    }
+
+    public function testInvalidMetadataDirectiveThrowsException()
+    {
+        $client = $this->getTestClient('s3');
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid metadata_directive value 'INVALID'");
+
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => new Result(['ContentLength' => 11 * self::MB, 'ContentType' => 'text/plain']),
+            'metadata_directive' => 'INVALID',
+        ]);
+        $uploader->upload();
+    }
+
+    public function testMetadataDirectiveReplaceLowercaseWorks()
+    {
+        $client = $this->getTestClient('s3');
+        $url = 'http://foo.s3.amazonaws.com/bar';
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'baz']),
+            new Result(['ETag' => 'A']),
+            new Result(['ETag' => 'B']),
+            new Result(['ETag' => 'C']),
+            new Result(['Location' => $url])
+        ]);
+
+        $initiateParams = null;
+        $sourceMetadata = new Result([
+            'ContentLength' => 11 * self::MB,
+            'ContentType' => 'application/pdf',
+            'CacheControl' => 'max-age=3600',
+            'Metadata' => ['key' => 'value'],
+        ]);
+
+        $uploader = new MultipartCopy($client, '/bucket/key', [
+            'bucket' => 'foo',
+            'key' => 'bar',
+            'source_metadata' => $sourceMetadata,
+            'metadata_directive' => 'replace',
+            'before_initiate' => function ($command) use (&$initiateParams) {
+                $initiateParams = $command->toArray();
+            },
+        ]);
+        $uploader->upload();
+
+        // ContentType still set by trait (from getSourceMimeType), but others suppressed
+        $this->assertSame('application/pdf', $initiateParams['ContentType']);
+        $this->assertArrayNotHasKey('CacheControl', $initiateParams);
+        $this->assertArrayNotHasKey('Metadata', $initiateParams);
+    }
 }


### PR DESCRIPTION
*Description of changes:*

`MultipartCopy` previously forwarded only `ContentType` from the source object to `CreateMultipartUpload`. User-defined metadata, CacheControl, ContentDisposition, ContentEncoding, ContentLanguage, and Expires were not included in the initiation request.

Added a `metadata_directive` config option. Set to `'COPY'` (the new default), it reads these fields from the HeadObject result and passes them to `CreateMultipartUpload`. Set to `'REPLACE'`, it preserves the previous behavior. Values provided in `params` override source metadata regardless of directive.

The forwarded field set matches what `CopyObject` preserves under `MetadataDirective: COPY`. Encryption, storage class, object lock, website redirect location, and tags are excluded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
