### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: aws-actions/closed-issue-message@v2
+      - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 # v2
         with:
           # These inputs are both required
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,16 +21,17 @@ jobs:
       AWS_SUPPRESS_PHP_DEPRECATION_WARNING: true
     steps:
       - name: Setup PHP with Xdebug
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: xdebug
           php-version: '8.3'
           ini-values: xdebug.overload_var_dump=0, memory_limit=4G, phar.readonly=false
 
       - name: Checkout codebase
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -42,7 +43,7 @@ jobs:
         run: vendor/bin/phpunit --testsuite=unit --coverage-clover=clover.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           file: ./clover.xml
           fail_ci_if_error: false

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,14 +15,16 @@ jobs:
     name: Build API documentation for PHP ${{ matrix.php-versions }}
     steps:
       - name: Setup PHP with JIT
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: none
           php-version: ${{ matrix.php-versions }}
           ini-values: memory_limit=4G, phar.readonly=false, opcache.enable=1, opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=128M
 
       - name: Checkout CodeBase
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/git-secrets-scan.yml
+++ b/.github/workflows/git-secrets-scan.yml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Git Secrets
         run: |
@@ -28,8 +30,8 @@ jobs:
 
       - name: Fetch previous commit
         run: |
-          git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-          export DIFF=$(git diff origin/${{ github.base_ref }} HEAD)
+          git fetch origin +refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}
+          export DIFF=$(git diff origin/${GITHUB_BASE_REF} HEAD)
           echo "${DIFF}" > diff.txt
 
       - name: Filter out skipped patterns

--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -14,6 +14,6 @@ jobs:
       discussions: write
     steps:
       - name: Stale discussions action
-        uses: aws-github-ops/handle-stale-discussions@v1
+        uses: aws-github-ops/handle-stale-discussions@c0beee451a5d33d9c8f048a6d4e7c856b5422544 # v1.6.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/issue-regression-labeler.yml
+++ b/.github/workflows/issue-regression-labeler.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Fetch template body
         id: check_regression
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEMPLATE_BODY: ${{ github.event.issue.body }}
@@ -25,8 +25,9 @@ jobs:
       - name: Manage regression label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION: ${{ steps.check_regression.outputs.is_regression }}
         run: |
-          if [ "${{ steps.check_regression.outputs.is_regression }}" == "true" ]; then
+          if [ "${STEPS_CHECK_REGRESSION_OUTPUTS_IS_REGRESSION}" == "true" ]; then
             gh issue edit ${{ github.event.issue.number }} --add-label "potential-regression" -R ${{ github.repository }}
           else
             gh issue edit ${{ github.event.issue.number }} --remove-label "potential-regression" -R ${{ github.repository }}

--- a/.github/workflows/model-changes.yml
+++ b/.github/workflows/model-changes.yml
@@ -13,11 +13,12 @@ jobs:
     name: Check for model changes
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - run: |
-          BASE_REPO="${{ github.event.pull_request.base.repo.clone_url }}"
+          BASE_REPO="${GITHUB_EVENT_PULL_REQUEST_BASE_REPO_CLONE_URL}"
           git fetch $BASE_REPO master:master -q
           CHANGED_FILES=$(git diff --name-only FETCH_HEAD...HEAD -- src/data/)
           if [ ! -z "$CHANGED_FILES" ]; then
@@ -25,3 +26,5 @@ jobs:
             echo "$CHANGED_FILES"
             exit 1
           fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_BASE_REPO_CLONE_URL: ${{ github.event.pull_request.base.repo.clone_url }}

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-      - uses: aws-actions/stale-issue-cleanup@v6
+      - uses: aws-actions/stale-issue-cleanup@7de35968489e4142233d2a6812519a82e68b5c38 # v6
         with:
           # Setting messages to an empty string will cause the automation to skip
           # that category

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SUPPRESS_PHP_DEPRECATION_WARNING: true
     steps:
       - name: Setup PHP with JIT
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: none
           php-version: ${{ matrix.php-versions }}
@@ -41,9 +41,10 @@ jobs:
           extensions: sockets
 
       - name: Checkout codebase
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # sets up the correct version of PHP with necessary config options
       - name: Setup PHP with JIT
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           coverage: none
           php-version: ${{ matrix.php-versions }}
@@ -54,9 +54,10 @@ jobs:
 
       # checkout the codebase from github
       - name: Checkout codebase
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # validate composer files
       - name: Validate composer.json and composer.lock


### PR DESCRIPTION
## Overview

This PR hardens several GitHub Actions workflows in `aws-sdk-php` to resolve [zizmor](https://docs.zizmor.sh/) findings around action pinning, credential persistence, and shell template expansion.

I highly recommend the team considers the following:
- Implement a mechanism to prevent regressions. This can be done through configuring zizmor as a pre-commit hook or integrating it into your CI. Note: The `aws` org has some limitations against third-party actions so avoid using [zizmor-action](https://github.com/zizmorcore/zizmor-action) for now.

## Summary

- Pins GitHub Actions `uses:` references to full commit SHAs while retaining version comments for readability.
- Sets `persist-credentials: false` on `actions/checkout` steps that do not need persisted Git credentials.
- Routes attacker-controlled or context-derived values through `env:` instead of inlining `${{ ... }}` inside `run:` blocks to avoid shell template expansion.
- Adds `cooldown.default-days: 7` to the existing `github-actions` Dependabot config.

These changes address the relevant zizmor audit guidance for [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses), [`excessive-permissions`](https://docs.zizmor.sh/audits/#excessive-permissions), and [`template-injection`](https://docs.zizmor.sh/audits/#template-injection).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
