### PR TITLE
fix: cast generated header values to strings

### DIFF
--- a/.changes/nextrelease/psr7-string-header-values.json
+++ b/.changes/nextrelease/psr7-string-header-values.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Api",
+        "description": "Cast generated HTTP header values to strings and validate invalid header values."
+    }
+]

--- a/src/Api/Serializer/AbstractRpcV2Serializer.php
+++ b/src/Api/Serializer/AbstractRpcV2Serializer.php
@@ -78,7 +78,7 @@ abstract class AbstractRpcV2Serializer
         // Content-Type must not be set
         if ($operation['input'] !== null) {
             $body = $this->serialize($operation->getInput(), $commandArgs);
-            $headers['Content-Length'] = strlen($body);
+            $headers['Content-Length'] = (string) strlen($body);
         } else {
             unset($headers['Content-Type']);
         }

--- a/src/Api/Serializer/JsonRpcSerializer.php
+++ b/src/Api/Serializer/JsonRpcSerializer.php
@@ -66,7 +66,7 @@ class JsonRpcSerializer
         $headers = [
                 'X-Amz-Target' => $this->api->getMetadata('targetPrefix') . '.' . $operationName,
                 'Content-Type' => $this->contentType,
-                'Content-Length' => strlen($body)
+                'Content-Length' => (string) strlen($body)
         ];
 
         if ($endpoint instanceof RulesetEndpoint) {

--- a/src/Api/Serializer/QuerySerializer.php
+++ b/src/Api/Serializer/QuerySerializer.php
@@ -61,7 +61,7 @@ class QuerySerializer
         }
         $body = http_build_query($body, '', '&', PHP_QUERY_RFC3986);
         $headers = [
-            'Content-Length' => strlen($body),
+            'Content-Length' => (string) strlen($body),
             'Content-Type'   => 'application/x-www-form-urlencoded'
         ];
         $requestUri = $operation['http']['requestUri'] ?? null;

--- a/src/Api/Serializer/RestJsonSerializer.php
+++ b/src/Api/Serializer/RestJsonSerializer.php
@@ -35,7 +35,7 @@ class RestJsonSerializer extends RestSerializer
     {
         $opts['headers']['Content-Type'] = $this->contentType;
         $body = $this->jsonFormatter->build($member, $value);
-        $opts['headers']['Content-Length'] = strlen($body);
+        $opts['headers']['Content-Length'] = (string) strlen($body);
         $opts['body'] = $body;
     }
 }

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -159,7 +159,7 @@ abstract class RestSerializer
 
             $body = $args[$name];
             if (!$m['streaming'] && is_string($body)) {
-                $opts['headers']['Content-Length'] = strlen($body);
+                $opts['headers']['Content-Length'] = (string) strlen($body);
             }
 
             // Streaming bodies or payloads that are strings are
@@ -173,20 +173,36 @@ abstract class RestSerializer
 
     private function applyHeader($name, Shape $member, $value, array &$opts)
     {
-        // Handle lists by recursively applying header logic to each element
+        if ($value === null) {
+            return;
+        }
+
+        // Handle lists by applying header logic to each element
         if ($member instanceof ListShape) {
+            if (!is_array($value)) {
+                throw new \InvalidArgumentException('Header values must be scalar or an array of scalars.');
+            }
+
             $listMember = $member->getMember();
             $headerValues = [];
 
             foreach ($value as $listValue) {
+                if ($listValue === null) {
+                    throw new \InvalidArgumentException('Header values must be scalar or an array of scalars.');
+                }
+
                 $tempOpts = ['headers' => []];
                 $this->applyHeader('temp', $listMember, $listValue, $tempOpts);
+                if (!array_key_exists('temp', $tempOpts['headers'])) {
+                    throw new \InvalidArgumentException('Header values must be scalar or an array of scalars.');
+                }
+
                 $convertedValue = $tempOpts['headers']['temp'];
                 $headerValues[] = $convertedValue;
             }
 
             $value = $headerValues;
-        } elseif (!is_null($value)) {
+        } else {
             switch ($member->getType()) {
                 case 'timestamp':
                     $timestampFormat = $member['timestampFormat'] ?? 'rfc822';
@@ -208,7 +224,7 @@ abstract class RestSerializer
             $value = base64_encode($value);
         }
 
-        $opts['headers'][$member['locationName'] ?: $name] = $value;
+        $opts['headers'][$member['locationName'] ?: $name] = self::prepareHeaderValue($value);
     }
 
     /**
@@ -218,8 +234,40 @@ abstract class RestSerializer
     {
         $prefix = $member['locationName'];
         foreach ($value as $k => $v) {
-            $opts['headers'][$prefix . $k] = $v;
+            if ($v === null) {
+                continue;
+            }
+
+            $opts['headers'][$prefix . $k] = self::prepareHeaderValue($v);
         }
+    }
+
+    /**
+     * @return string|string[]
+     */
+    private static function prepareHeaderValue($value)
+    {
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                return '';
+            }
+
+            foreach ($value as $key => $item) {
+                if (!is_scalar($item)) {
+                    throw new \InvalidArgumentException('Header values must be scalar or an array of scalars.');
+                }
+
+                $value[$key] = (string) $item;
+            }
+
+            return $value;
+        }
+
+        throw new \InvalidArgumentException('Header values must be scalar or an array of scalars.');
     }
 
     private function applyQuery($name, Shape $member, $value, array &$opts)

--- a/src/Api/Serializer/RestXmlSerializer.php
+++ b/src/Api/Serializer/RestXmlSerializer.php
@@ -30,7 +30,7 @@ class RestXmlSerializer extends RestSerializer
     {
         $opts['headers']['Content-Type'] = 'application/xml';
         $body = $this->getXmlBody($member, $value);
-        $opts['headers']['Content-Length'] = strlen($body);
+        $opts['headers']['Content-Length'] = (string) strlen($body);
         $opts['body'] = $body;
     }
 

--- a/src/CloudSearchDomain/CloudSearchDomainClient.php
+++ b/src/CloudSearchDomain/CloudSearchDomainClient.php
@@ -78,7 +78,7 @@ class CloudSearchDomainClient extends AwsClient
         $query = $r->getUri()->getQuery();
         $req = $r->withMethod('POST')
             ->withBody(Psr7\Utils::streamFor($query))
-            ->withHeader('Content-Length', strlen($query))
+            ->withHeader('Content-Length', (string) strlen($query))
             ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
             ->withUri($r->getUri()->withQuery(''));
         return $req;

--- a/src/StreamRequestPayloadMiddleware.php
+++ b/src/StreamRequestPayloadMiddleware.php
@@ -74,7 +74,7 @@ class StreamRequestPayloadMiddleware
                     }
                     $request = $request->withHeader(
                         'Content-Length',
-                        $size
+                        (string) $size
                     );
                 }
             }

--- a/tests/Api/Serializer/JsonRpcSerializerTest.php
+++ b/tests/Api/Serializer/JsonRpcSerializerTest.php
@@ -49,6 +49,7 @@ class JsonRpcSerializerTest extends TestCase
             $request->getHeaderLine('Content-Type')
         );
         $this->assertSame('test.foo', $request->getHeaderLine('X-Amz-Target'));
+        $this->assertSame(['13'], $request->getHeader('Content-Length'));
         $this->assertSame('{"baz":"bam"}', (string) $request->getBody());
     }
 

--- a/tests/Api/Serializer/QuerySerializerTest.php
+++ b/tests/Api/Serializer/QuerySerializerTest.php
@@ -47,6 +47,7 @@ class QuerySerializerTest extends TestCase
         $request = $q($cmd);
         $this->assertSame('POST', $request->getMethod());
         $this->assertSame('http://foo.com/', (string) $request->getUri());
+        $this->assertSame(['25'], $request->getHeader('Content-Length'));
         $this->assertSame('Action=foo&Version=1&baz=', (string) $request->getBody());
     }
 

--- a/tests/Api/Serializer/RestJsonSerializerTest.php
+++ b/tests/Api/Serializer/RestJsonSerializerTest.php
@@ -63,6 +63,18 @@ class RestJsonSerializerTest extends TestCase
                         'http' => ['method' => 'POST'],
                         'input' => ['shape' => 'BoolHeaderInput']
                     ],
+                    'intHeader' => [
+                        'http' => ['method' => 'POST'],
+                        'input' => ['shape' => 'IntHeaderInput']
+                    ],
+                    'nullHeader' => [
+                        'http' => ['method' => 'POST'],
+                        'input' => ['shape' => 'NullHeaderInput']
+                    ],
+                    'listHeader' => [
+                        'http' => ['method' => 'POST'],
+                        'input' => ['shape' => 'ListHeaderInput']
+                    ],
                     'requestUriOperation' =>[
                         'http' => [
                             'method' => 'POST',
@@ -182,9 +194,44 @@ class RestJsonSerializerTest extends TestCase
                             ],
                         ]
                     ],
+                    'IntHeaderInput' => [
+                        'type' => 'structure',
+                        'members' => [
+                            'int' => [
+                                'shape' => 'IntShape',
+                                'location' => 'header',
+                                'locationName' => 'Is-Int',
+                            ],
+                        ]
+                    ],
+                    'NullHeaderInput' => [
+                        'type' => 'structure',
+                        'members' => [
+                            'null' => [
+                                'shape' => 'BazShape',
+                                'location' => 'header',
+                                'locationName' => 'Is-Null',
+                            ],
+                        ]
+                    ],
+                    'ListHeaderInput' => [
+                        'type' => 'structure',
+                        'members' => [
+                            'list' => [
+                                'shape' => 'ListShape',
+                                'location' => 'header',
+                                'locationName' => 'Is-List',
+                            ],
+                        ]
+                    ],
                     'BlobShape' => ['type' => 'blob'],
                     'BazShape'  => ['type' => 'string'],
                     'BoolShape' => ['type' => 'boolean'],
+                    'IntShape' => ['type' => 'integer'],
+                    'ListShape' => [
+                        'type' => 'list',
+                        'member' => ['shape' => 'BazShape'],
+                    ],
                     'PathSegmentShape'  => ['type' => 'string'],
                 ]
             ],
@@ -223,6 +270,7 @@ class RestJsonSerializerTest extends TestCase
             'application/json',
             $request->getHeaderLine('Content-Type')
         );
+        $this->assertSame(['13'], $request->getHeader('Content-Length'));
     }
 
     public function testPreparesRequestsWithEndpointWithPath(): void
@@ -407,6 +455,38 @@ class RestJsonSerializerTest extends TestCase
             [true, 'true'],
             [false, 'false']
         ];
+    }
+
+    public function testSerializesIntegerHeaderValueToString(): void
+    {
+        $request = $this->getRequest('intHeader', ['int' => 5]);
+        $this->assertSame(['5'], $request->getHeader('Is-Int'));
+    }
+
+    public function testOmitsNullHeaderValue(): void
+    {
+        $request = $this->getRequest('nullHeader', ['null' => null]);
+        $this->assertFalse($request->hasHeader('Is-Null'));
+    }
+
+    public function testSerializesEmptyHeaderListToEmptyString(): void
+    {
+        $request = $this->getRequest('listHeader', ['list' => []]);
+        $this->assertSame([''], $request->getHeader('Is-List'));
+    }
+
+    public function testSerializesHeaderListValuesToStrings(): void
+    {
+        $request = $this->getRequest('listHeader', ['list' => ['foo', 5, true, false]]);
+        $this->assertSame(['foo', '5', '1', ''], $request->getHeader('Is-List'));
+    }
+
+    public function testRejectsInvalidHeaderListValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header values must be scalar or an array of scalars.');
+
+        $this->getRequest('listHeader', ['list' => ['foo', null]]);
     }
 
     public function testDoesNotOverrideScheme(): void

--- a/tests/Api/Serializer/RestXmlSerializerTest.php
+++ b/tests/Api/Serializer/RestXmlSerializerTest.php
@@ -80,6 +80,7 @@ class RestXmlSerializerTest extends TestCase
             'application/xml',
             $request->getHeaderLine('Content-Type')
         );
+        $this->assertSame([(string) strlen((string) $request->getBody())], $request->getHeader('Content-Length'));
     }
 
     /**

--- a/tests/Api/Serializer/RpcV2CborSerializerTest.php
+++ b/tests/Api/Serializer/RpcV2CborSerializerTest.php
@@ -561,6 +561,6 @@ class RpcV2CborSerializerTest extends TestCase
             'rpc-v2-cbor',
             $request->getHeaderLine('Smithy-Protocol')
         );
-        $this->assertTrue($request->hasHeader('Content-Length'));
+        $this->assertSame([(string) strlen((string) $request->getBody())], $request->getHeader('Content-Length'));
     }
 }

--- a/tests/CloudSearchDomain/CloudSearchDomainTest.php
+++ b/tests/CloudSearchDomain/CloudSearchDomainTest.php
@@ -40,6 +40,7 @@ class CloudSearchDomainTest extends TestCase
         $request = CloudSearchDomainClient::convertGetToPost($request);
         $this->assertSame('POST', $request->getMethod());
         $this->assertSame('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        $this->assertSame(['7'], $request->getHeader('Content-Length'));
         $this->assertSame('7', $request->getHeaderLine('Content-Length'));
         $this->assertSame('foo=bar', (string)$request->getBody());
         $this->assertSame('', $request->getUri()->getQuery());

--- a/tests/StreamRequestPayloadMiddlewareTest.php
+++ b/tests/StreamRequestPayloadMiddlewareTest.php
@@ -76,7 +76,7 @@ class StreamRequestPayloadMiddlewareTest extends TestCase
                         'InputStream' => $inputStream,
                     ]
                 ],
-                [ 'Content-Length' => [26] ],
+                [ 'Content-Length' => ['26'] ],
                 [ 'transfer-encoding' ],
             ],
             [
@@ -86,7 +86,7 @@ class StreamRequestPayloadMiddlewareTest extends TestCase
                         'InputStream' => $inputStream,
                     ]
                 ],
-                [ 'Content-Length' => [26] ],
+                [ 'Content-Length' => ['26'] ],
                 [ 'transfer-encoding' ],
             ],
             [
@@ -96,7 +96,7 @@ class StreamRequestPayloadMiddlewareTest extends TestCase
                         'InputStream' => $inputStream,
                     ]
                 ],
-                [ 'Content-Length' => [26] ],
+                [ 'Content-Length' => ['26'] ],
                 [ 'transfer-encoding' ],
             ],
         ];


### PR DESCRIPTION
Hi there. The Guzzle maintainer here again. I am working on the next major version of Guzzle with a focus on security hardening and reducing security-foot guns. As part of those changes, the next major version will disallow non-string header values. I will be triggering deprecations soon on the current major version series, which will start to impact the AWS PHP SDK, unless it is first modified to stop passing non-string header values. And thus, that is what this PR does.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
