### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/.changes/nextrelease/guzzle-8.json
+++ b/.changes/nextrelease/guzzle-8.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "feature",
+        "category": "Handler",
+        "description": "Adds Guzzle 8 support."
+    }
+]

--- a/build/packager.php
+++ b/build/packager.php
@@ -29,11 +29,22 @@ $burgomaster->recursiveCopy('vendor/guzzlehttp/psr7/src', 'GuzzleHttp/Psr7');
 $burgomaster->recursiveCopy('vendor/guzzlehttp/promises/src', 'GuzzleHttp/Promise');
 $burgomaster->recursiveCopy('vendor/psr/http-message/src', 'Psr/Http/Message');
 
+if (file_exists($projectRoot . 'vendor/psr/http-factory/src')) {
+    $burgomaster->recursiveCopy(
+        $projectRoot . 'vendor/psr/http-factory/src',
+        'Psr/Http/Message'
+    );
+}
+
 $autoloaderContents = [
     'Aws/functions.php',
-    'GuzzleHttp/functions_include.php',
-    'JmesPath/JmesPath.php',
 ];
+
+if (file_exists($projectRoot . 'vendor/guzzlehttp/guzzle/src/functions_include.php')) {
+    $autoloaderContents[] = 'GuzzleHttp/functions_include.php';
+}
+
+$autoloaderContents[] = 'JmesPath/JmesPath.php';
 
 if (file_exists($projectRoot . 'vendor/symfony/polyfill-intl-idn')) {
     $burgomaster->recursiveCopy($projectRoot . 'vendor/symfony/polyfill-intl-idn', 'Symfony/Polyfill/Intl/Idn');

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     },
     "require": {
         "php": ">=8.1",
-        "guzzlehttp/guzzle": "^7.4.5",
-        "guzzlehttp/psr7": "^2.4.5",
-        "guzzlehttp/promises": "^2.0",
+        "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+        "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+        "guzzlehttp/promises": "^2.0.3 || ^3.0",
         "mtdowling/jmespath.php": "^2.8.0",
         "ext-pcre": "*",
         "ext-json": "*",

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     },
     "require": {
         "php": ">=8.1",
-        "guzzlehttp/guzzle": "^7.4.5",
-        "guzzlehttp/psr7": "^2.4.5",
-        "guzzlehttp/promises": "^2.0",
+        "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+        "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+        "guzzlehttp/promises": "^2.0.3 || ^3.0",
         "mtdowling/jmespath.php": "^2.9.1",
         "ext-pcre": "*",
         "ext-json": "*",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,4 +25,7 @@ parameters:
     - '#Access to undefined constant GuzzleHttp\\ClientInterface::MAJOR_VERSION#'
     - '#Access to undefined constant GuzzleHttp\\ClientInterface::VERSION\.#'
 
+    # These exception classes only exist in Guzzle 8, but instances cannot occur under Guzzle 7
+    - '#Class GuzzleHttp\\Exception\\(NetworkException|ResponseException|ResponseTransferException) not found\.#'
+
   reportUnmatchedIgnoredErrors: false

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -3,7 +3,7 @@ namespace Aws\Credentials;
 
 use Aws\Arn\Arn;
 use Aws\Exception\CredentialsException;
-use GuzzleHttp\Exception\ConnectException;
+use Aws\Handler\HttpHandlerError;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise;
@@ -104,13 +104,14 @@ class EcsCredentialProvider
                             CredentialSources::ECS
                         );
                     })->otherwise(function ($reason) {
-                        $reason = is_array($reason) ? $reason['exception'] : $reason;
+                        $connectionError = is_array($reason) && !empty($reason['connection_error']);
+                        $exception = is_array($reason) ? ($reason['exception'] ?? null) : $reason;
+                        $isRetryable = $connectionError || ($exception instanceof \Throwable && HttpHandlerError::isConnectionError($exception));
 
-                        $isRetryable = $reason instanceof ConnectException;
                         if ($isRetryable && ($this->attempts < $this->retries)) {
                             sleep((int)pow(1.2, $this->attempts));
                         } else {
-                            $msg = $reason->getMessage();
+                            $msg = $exception instanceof \Throwable ? $exception->getMessage() : \Aws\describe_type($reason);
                             throw new CredentialsException(
                                 sprintf('Error retrieving credentials from container metadata after attempt %d/%d (%s)', $this->attempts, $this->retries, $msg)
                             );

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -3,7 +3,7 @@ namespace Aws\Credentials;
 
 use Aws\Arn\Arn;
 use Aws\Exception\CredentialsException;
-use GuzzleHttp\Exception\ConnectException;
+use Aws\Handler\HttpHandlerError;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise;
@@ -105,13 +105,14 @@ class EcsCredentialProvider
                             CredentialSources::ECS
                         );
                     })->otherwise(function ($reason) {
-                        $reason = is_array($reason) ? $reason['exception'] : $reason;
+                        $connectionError = is_array($reason) && !empty($reason['connection_error']);
+                        $exception = is_array($reason) ? ($reason['exception'] ?? null) : $reason;
+                        $isRetryable = $connectionError || ($exception instanceof \Throwable && HttpHandlerError::isConnectionError($exception));
 
-                        $isRetryable = $reason instanceof ConnectException;
                         if ($isRetryable && ($this->attempts < $this->retries)) {
                             sleep((int)pow(1.2, $this->attempts));
                         } else {
-                            $msg = $reason->getMessage();
+                            $msg = $exception instanceof \Throwable ? $exception->getMessage() : \Aws\describe_type($reason);
                             throw new CredentialsException(
                                 sprintf('Error retrieving credentials from container metadata after attempt %d/%d (%s)', $this->attempts, $this->retries, $msg)
                             );

--- a/src/Handler/Guzzle/GuzzleHandler.php
+++ b/src/Handler/Guzzle/GuzzleHandler.php
@@ -1,9 +1,7 @@
 <?php
 namespace Aws\Handler\Guzzle;
 
-use Exception;
-use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use Aws\Handler\HttpHandlerError;
 use GuzzleHttp\Utils;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Client;
@@ -31,7 +29,7 @@ class GuzzleHandler
      * @param Psr7Request $request
      * @param array       $options
      *
-     * @return Promise\Promise
+     * @return Promise\PromiseInterface
      */
     public function __invoke(Psr7Request $request, array $options = [])
     {
@@ -43,21 +41,12 @@ class GuzzleHandler
 
         return $this->client->sendAsync($request, $this->parseOptions($options))
             ->otherwise(
-                static function ($e) {
-                    $error = [
+                static function (\Throwable $e) {
+                    return new Promise\RejectedPromise([
                         'exception'        => $e,
-                        'connection_error' => $e instanceof ConnectException,
-                        'response'         => null,
-                    ];
-
-                    if (
-                        ($e instanceof RequestException)
-                        && $e->getResponse()
-                    ) {
-                        $error['response'] = $e->getResponse();
-                    }
-
-                    return new Promise\RejectedPromise($error);
+                        'connection_error' => HttpHandlerError::isConnectionError($e),
+                        'response'         => HttpHandlerError::getResponse($e),
+                    ]);
                 }
             );
     }

--- a/src/Handler/HttpHandlerError.php
+++ b/src/Handler/HttpHandlerError.php
@@ -1,0 +1,56 @@
+<?php
+namespace Aws\Handler;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\ResponseTransferException;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @internal
+ */
+final class HttpHandlerError
+{
+    private const CURLE_RECV_ERROR = 56;
+
+    public static function isConnectionError(\Throwable $exception): bool
+    {
+        // Guzzle 8: transfer failures have dedicated exception classes.
+        if ($exception instanceof NetworkException || $exception instanceof ResponseTransferException) {
+            return true;
+        }
+
+        // Guzzle 7: connection establishment failures use ConnectException.
+        if ($exception instanceof ConnectException) {
+            return true;
+        }
+
+        // Guzzle 7: mid-response receive failures identifiable by cURL handler context.
+        if ($exception instanceof RequestException && is_callable([$exception, 'getHandlerContext'])
+        ) {
+            $context = $exception->getHandlerContext();
+
+            return !empty($context['errno']) && $context['errno'] === self::CURLE_RECV_ERROR;
+        }
+
+        return false;
+    }
+
+    public static function getResponse(\Throwable $exception): ?ResponseInterface
+    {
+        // Guzzle 8: response-aware failures expose the response through ResponseException.
+        if ($exception instanceof ResponseException) {
+            return $exception->getResponse();
+        }
+
+        // Guzzle 7: RequestException directly carried an optional response.
+        if ($exception instanceof RequestException && is_callable([$exception, 'getResponse'])
+        ) {
+            return $exception->getResponse();
+        }
+
+        return null;
+    }
+}

--- a/src/Retry/V3/RetryMiddleware.php
+++ b/src/Retry/V3/RetryMiddleware.php
@@ -8,7 +8,6 @@ use Aws\ResultInterface;
 use Aws\Retry\ConfigurationInterface;
 use Aws\Retry\RateLimiter;
 use Aws\Retry\RetryHelperTrait;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -72,7 +71,6 @@ class RetryMiddleware
     private array $options;
     private QuotaManager $quotaManager;
     private ?RateLimiter $rateLimiter = null;
-    private array $retryCurlErrors;
     private ?string $service;
 
     public static function wrap(ConfigurationInterface $config, array $options): \Closure
@@ -84,23 +82,17 @@ class RetryMiddleware
 
     /**
      * Returns a closure that decides retryability for a given result based
-     * on the standard error codes, status codes, and curl errors. Quota and
-     * max-attempts decisions are handled by the middleware itself, not by
-     * this closure.
+     * on the standard error codes and status codes. Quota and max-attempts
+     * decisions are handled by the middleware itself, not by this closure.
      */
     public static function createDefaultDecider(array $options = []): \Closure
     {
-        $retryCurlErrors = [];
-        if (extension_loaded('curl')) {
-            $retryCurlErrors[CURLE_RECV_ERROR] = true;
-        }
-
         return function (
             int $attempts,
             CommandInterface $command,
             mixed $result
-        ) use ($options, $retryCurlErrors): bool {
-            return self::isRetryable($result, $retryCurlErrors, $options);
+        ) use ($options): bool {
+            return self::isRetryable($result, $options);
         };
     }
 
@@ -127,16 +119,6 @@ class RetryMiddleware
         $this->delayer = isset($options['delayer'])
             ? ($options['delayer'])(...)
             : null;
-
-        $this->retryCurlErrors = [];
-        if (extension_loaded('curl')) {
-            $this->retryCurlErrors[CURLE_RECV_ERROR] = true;
-        }
-        if (!empty($options['curl_errors']) && is_array($options['curl_errors'])) {
-            foreach ($options['curl_errors'] as $code) {
-                $this->retryCurlErrors[$code] = true;
-            }
-        }
 
         if ($this->mode === 'adaptive') {
             $this->rateLimiter = $options['rate_limiter'] ?? new RateLimiter();
@@ -198,7 +180,6 @@ class RetryMiddleware
 
             $isRetryable = self::isRetryable(
                 $value,
-                $this->retryCurlErrors,
                 $this->options
             );
 
@@ -342,7 +323,6 @@ class RetryMiddleware
 
     private static function isRetryable(
         mixed $result,
-        array $retryCurlErrors,
         array $options = []
     ): bool
     {
@@ -371,14 +351,6 @@ class RetryMiddleware
             }
         }
 
-        if (!empty($options['curl_errors'])
-            && is_array($options['curl_errors'])
-        ) {
-            foreach ($options['curl_errors'] as $code) {
-                $retryCurlErrors[$code] = true;
-            }
-        }
-
         $isError = $result instanceof \Throwable;
 
         if (!$isError) {
@@ -404,24 +376,6 @@ class RetryMiddleware
         $status = $result->getStatusCode();
         if ($status !== null && isset($statusCodes[$status])) {
             return true;
-        }
-
-        if (count($retryCurlErrors)
-            && ($previous = $result->getPrevious())
-            && $previous instanceof RequestException
-        ) {
-            if (method_exists($previous, 'getHandlerContext')) {
-                $context = $previous->getHandlerContext();
-                return !empty($context['errno'])
-                    && isset($retryCurlErrors[$context['errno']]);
-            }
-
-            $message = $previous->getMessage();
-            foreach (array_keys($retryCurlErrors) as $curlError) {
-                if (str_starts_with($message, 'cURL error ' . $curlError . ':')) {
-                    return true;
-                }
-            }
         }
 
         if (!empty($errorShape = $result->getAwsErrorShape())) {

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -3,7 +3,6 @@ namespace Aws;
 
 use Aws\Exception\AwsException;
 use Aws\Retry\RetryHelperTrait;
-use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise;
@@ -67,9 +66,6 @@ class RetryMiddleware
      *   Optional.
      * - statusCodes: (int[]) An indexed array of HTTP status codes to retry.
      *   Optional.
-     * - curlErrors: (int[]) An indexed array of Curl error codes to retry. Note
-     *   these should be valid Curl constants. Optional.
-     *
      * @param int $maxRetries
      * @param array $extraConfig
      * @return callable
@@ -78,18 +74,13 @@ class RetryMiddleware
         $maxRetries = 3,
         $extraConfig = []
     ) {
-        $retryCurlErrors = [];
-        if (extension_loaded('curl')) {
-            $retryCurlErrors[CURLE_RECV_ERROR] = true;
-        }
-
         return function (
             $retries,
             CommandInterface $command,
             RequestInterface $request,
             ?ResultInterface $result = null,
             $error = null
-        ) use ($maxRetries, $retryCurlErrors, $extraConfig) {
+        ) use ($maxRetries, $extraConfig) {
             // Allow command-level options to override this value
             $maxRetries = null !== $command['@retries'] ?
                 $command['@retries']
@@ -98,7 +89,6 @@ class RetryMiddleware
             $isRetryable = self::isRetryable(
                 $result,
                 $error,
-                $retryCurlErrors,
                 $extraConfig
             );
 
@@ -119,7 +109,6 @@ class RetryMiddleware
     private static function isRetryable(
         $result,
         $error,
-        $retryCurlErrors,
         $extraConfig = []
     ) {
         $errorCodes = self::$retryCodes;
@@ -137,14 +126,6 @@ class RetryMiddleware
         ) {
             foreach($extraConfig['status_codes'] as $code) {
                 $statusCodes[$code] = true;
-            }
-        }
-
-        if (!empty($extraConfig['curl_errors'])
-            && is_array($extraConfig['curl_errors'])
-        ) {
-            foreach($extraConfig['curl_errors'] as $code) {
-                $retryCurlErrors[$code] = true;
             }
         }
 
@@ -171,24 +152,6 @@ class RetryMiddleware
         $status = $error->getStatusCode();
         if (!is_null($status) && isset($statusCodes[$status])) {
             return true;
-        }
-
-        if (count($retryCurlErrors)
-            && ($previous = $error->getPrevious())
-            && $previous instanceof RequestException
-        ) {
-            if (method_exists($previous, 'getHandlerContext')) {
-                $context = $previous->getHandlerContext();
-                return !empty($context['errno'])
-                    && isset($retryCurlErrors[$context['errno']]);
-            }
-
-            $message = $previous->getMessage();
-            foreach (array_keys($retryCurlErrors) as $curlError) {
-                if (strpos($message, 'cURL error ' . $curlError . ':') === 0) {
-                    return true;
-                }
-            }
         }
 
         return false;

--- a/src/RetryMiddlewareV2.php
+++ b/src/RetryMiddlewareV2.php
@@ -7,7 +7,6 @@ use Aws\Retry\QuotaManager;
 use Aws\Retry\RateLimiter;
 use Aws\Retry\RetryHelperTrait;
 use Exception;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise;
 use Psr\Http\Message\RequestInterface;
 
@@ -80,16 +79,11 @@ class RetryMiddlewareV2
         $maxAttempts = 3,
         $options = []
     ) {
-        $retryCurlErrors = [];
-        if (extension_loaded('curl')) {
-            $retryCurlErrors[CURLE_RECV_ERROR] = true;
-        }
-
         return function(
             $attempts,
             CommandInterface $command,
             $result
-        ) use ($options, $quotaManager, $retryCurlErrors, $maxAttempts) {
+        ) use ($options, $quotaManager, $maxAttempts) {
 
             // Release retry tokens back to quota on a successful result
             $quotaManager->releaseToQuota($result);
@@ -102,7 +96,6 @@ class RetryMiddlewareV2
 
             $isRetryable = self::isRetryable(
                 $result,
-                $retryCurlErrors,
                 $options
             );
 
@@ -261,7 +254,6 @@ class RetryMiddlewareV2
 
     private static function isRetryable(
         $result,
-        $retryCurlErrors,
         $options = []
     ) {
         $errorCodes = self::$standardThrottlingErrors + self::$standardTransientErrors;
@@ -286,14 +278,6 @@ class RetryMiddlewareV2
         ) {
             foreach($options['status_codes'] as $code) {
                 $statusCodes[$code] = true;
-            }
-        }
-
-        if (!empty($options['curl_errors'])
-            && is_array($options['curl_errors'])
-        ) {
-            foreach($options['curl_errors'] as $code) {
-                $retryCurlErrors[$code] = true;
             }
         }
 
@@ -326,24 +310,6 @@ class RetryMiddlewareV2
         $status = $result->getStatusCode();
         if (!is_null($status) && isset($statusCodes[$status])) {
             return true;
-        }
-
-        if (count($retryCurlErrors)
-            && ($previous = $result->getPrevious())
-            && $previous instanceof RequestException
-        ) {
-            if (method_exists($previous, 'getHandlerContext')) {
-                $context = $previous->getHandlerContext();
-                return !empty($context['errno'])
-                    && isset($retryCurlErrors[$context['errno']]);
-            }
-
-            $message = $previous->getMessage();
-            foreach (array_keys($retryCurlErrors) as $curlError) {
-                if (strpos($message, 'cURL error ' . $curlError . ':') === 0) {
-                    return true;
-                }
-            }
         }
 
         // Check error shape for the retryable trait

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -444,9 +444,13 @@ class SignatureV4 implements SignatureInterface
             ->withoutHeader('Authorization');
         $uri = $request->getUri();
 
+        $path = method_exists(Psr7\Uri::class, 'rawPath')
+            ? Psr7\Uri::rawPath($uri)
+            : $uri->getPath();
+
         return [
             'method'  => $request->getMethod(),
-            'path'    => $uri->getPath(),
+            'path'    => $path,
             'query'   => Psr7\Query::parse($uri->getQuery()),
             'uri'     => $uri,
             'headers' => $request->getHeaders(),

--- a/tests/Api/Parser/RestJsonParserTest.php
+++ b/tests/Api/Parser/RestJsonParserTest.php
@@ -146,11 +146,10 @@ class RestJsonParserTest extends TestCase
 
         $response = new Response(200, [
             'Content-Length' => '0',
-            'X-Count' => 0,
+            'X-Count' => '0',
             'X-Enabled' => 'false',
             'X-Ratio' => '0.0',
-            'X-Tags' => null,  // Empty list
-            'X-Empty' => ''  // Empty string should still be skipped
+            'X-Empty' => ''
         ], '{}');
 
         $command = $this->getMockBuilder(CommandInterface::class)->getMock();

--- a/tests/Api/Parser/RestXmlParserTest.php
+++ b/tests/Api/Parser/RestXmlParserTest.php
@@ -84,8 +84,7 @@ class RestXmlParserTest extends TestCase
             'X-Count' => '0',
             'X-Enabled' => 'false',
             'X-Ratio' => '0.0',
-            'X-Tags' => null,  // Empty list
-            'X-Empty' => ''  // Empty string should still be skipped
+            'X-Empty' => ''
         ], '<?xml version="1.0" encoding="UTF-8"?><response/>');
 
         $command = $this->getMockBuilder(CommandInterface::class)->getMock();

--- a/tests/CreatesGuzzleExceptionsTrait.php
+++ b/tests/CreatesGuzzleExceptionsTrait.php
@@ -1,0 +1,26 @@
+<?php
+namespace Aws\Test;
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+trait CreatesGuzzleExceptionsTrait
+{
+    private static function createRequestException(
+        string $message,
+        RequestInterface $request,
+        ?ResponseInterface $response = null
+    ): RequestException {
+        if ($response !== null && class_exists(ResponseException::class)) {
+            return new ResponseException($message, $request, $response);
+        }
+
+        if ($response === null) {
+            return new RequestException($message, $request);
+        }
+
+        return new RequestException($message, $request, $response);
+    }
+}

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -6,10 +6,10 @@ use Aws\Credentials\CredentialsInterface;
 use Aws\Credentials\EcsCredentialProvider;
 use Aws\Exception\CredentialsException;
 use Aws\Handler\Guzzle\GuzzleHandler;
+use Aws\Test\CreatesGuzzleExceptionsTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
@@ -24,6 +24,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(EcsCredentialProvider::class)]
 class EcsCredentialProviderTest extends TestCase
 {
+    use CreatesGuzzleExceptionsTrait;
+
     private $uripath;
     private $fulluripath;
     private $authtokenpath;
@@ -447,13 +449,18 @@ EOF;
         $creds = ['foo_key', 'baz_secret', 'qux_token', "@{$expiry}"];
         $credsObject = new Credentials($creds[0], $creds[1], $creds[2], $expiry);
 
+        $rejectionConnectionError = Promise\Create::rejectionFor([
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
+        ]);
         $connectException = new ConnectException(
             'cURL error 28: Connection timed out after 1000 milliseconds',
             new Psr7\Request('GET', '/latest')
         );
-        $rejectionConnection = Promise\Create::rejectionFor([
+        $rejectionWrappedConnectException = Promise\Create::rejectionFor([
             'exception' => $connectException,
         ]);
+        $rejectionRawConnectException = Promise\Create::rejectionFor($connectException);
 
         $promiseCreds = Promise\Create::promiseFor(
             new Response(200, [], Psr7\Utils::streamFor(
@@ -472,22 +479,42 @@ EOF;
                 ],
                 $credsObject
             ],
-            'With retries for ConnectException (Guzzle 7)' => [
+            'With retries for connection_error metadata' => [
                 [
                     'responses' => [
-                        $rejectionConnection,
+                        $rejectionConnectionError,
                         $promiseCreds
                     ],
                     'credentials' => $creds
                 ],
                 $credsObject
             ],
-            'With 4 retries for ConnectException (Guzzle 7)' => [
+            'With retries for wrapped ConnectException' => [
                 [
                     'responses' => [
-                        $rejectionConnection,
-                        $rejectionConnection,
-                        $rejectionConnection,
+                        $rejectionWrappedConnectException,
+                        $promiseCreds
+                    ],
+                    'credentials' => $creds
+                ],
+                $credsObject
+            ],
+            'With retries for raw ConnectException' => [
+                [
+                    'responses' => [
+                        $rejectionRawConnectException,
+                        $promiseCreds
+                    ],
+                    'credentials' => $creds
+                ],
+                $credsObject
+            ],
+            'With 4 retries for connection_error metadata' => [
+                [
+                    'responses' => [
+                        $rejectionConnectionError,
+                        $rejectionConnectionError,
+                        $rejectionConnectionError,
                         $promiseCreds
                     ],
                     'credentials' => $creds
@@ -529,18 +556,15 @@ EOF;
         $getRequest = new Psr7\Request('GET', '/latest');
 
         $rejectionCreds = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '401 Unathorized',
                 $getRequest,
                 new Psr7\Response(401)
             )
         ]);
-        $connectException = new ConnectException(
-            'cURL error 28: Connection timed out after 1000 milliseconds',
-            new Psr7\Request('GET', '/latest')
-        );
         $rejectionConnection = Promise\Create::rejectionFor([
-            'exception' => $connectException,
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
         ]);
 
         return [
@@ -568,12 +592,9 @@ EOF;
     {
         putenv('AWS_METADATA_SERVICE_NUM_ATTEMPTS=1');
 
-        $connectException = new ConnectException(
-            'cURL error 28: Connection timed out after 1000 milliseconds',
-            new Psr7\Request('GET', '/latest')
-        );
         $rejectionConnection = Promise\Create::rejectionFor([
-            'exception' => $connectException,
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
         ]);
 
         $provider = new EcsCredentialProvider([
@@ -608,12 +629,9 @@ EOF;
 
         $credsObject = new Credentials($creds[0], $creds[1], $creds[2], $expiry);
 
-        $connectException = new ConnectException(
-            'cURL error 28: Connection timed out after 1000 milliseconds',
-            new Psr7\Request('GET', '/latest')
-        );
         $rejectionConnection = Promise\Create::rejectionFor([
-            'exception' => $connectException,
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
         ]);
         $promiseCreds = Promise\Create::promiseFor(
             new Response(200, [], Psr7\Utils::streamFor(
@@ -689,6 +707,10 @@ EOF;
             $creds
         ) {
             if (!empty($responses)) {
+                if (!isset($responses[$getRequests])) {
+                    throw new \Exception('No responses');
+                }
+
                 return $responses[$getRequests++];
             }
             return Promise\Create::promiseFor(

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -6,10 +6,10 @@ use Aws\Credentials\CredentialsInterface;
 use Aws\Credentials\EcsCredentialProvider;
 use Aws\Exception\CredentialsException;
 use Aws\Handler\Guzzle\GuzzleHandler;
+use Aws\Test\CreatesGuzzleExceptionsTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
@@ -24,6 +24,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(EcsCredentialProvider::class)]
 class EcsCredentialProviderTest extends TestCase
 {
+    use CreatesGuzzleExceptionsTrait;
+
     private $uripath;
     private $fulluripath;
     private $authtokenpath;
@@ -406,13 +408,18 @@ EOF;
         $creds = ['foo_key', 'baz_secret', 'qux_token', "@{$expiry}"];
         $credsObject = new Credentials($creds[0], $creds[1], $creds[2], $expiry);
 
+        $rejectionConnectionError = Promise\Create::rejectionFor([
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
+        ]);
         $connectException = new ConnectException(
             'cURL error 28: Connection timed out after 1000 milliseconds',
             new Psr7\Request('GET', '/latest')
         );
-        $rejectionConnection = Promise\Create::rejectionFor([
+        $rejectionWrappedConnectException = Promise\Create::rejectionFor([
             'exception' => $connectException,
         ]);
+        $rejectionRawConnectException = Promise\Create::rejectionFor($connectException);
 
         $promiseCreds = Promise\Create::promiseFor(
             new Response(200, [], Psr7\Utils::streamFor(
@@ -431,22 +438,42 @@ EOF;
                 ],
                 $credsObject
             ],
-            'With retries for ConnectException (Guzzle 7)' => [
+            'With retries for connection_error metadata' => [
                 [
                     'responses' => [
-                        $rejectionConnection,
+                        $rejectionConnectionError,
                         $promiseCreds
                     ],
                     'credentials' => $creds
                 ],
                 $credsObject
             ],
-            'With 4 retries for ConnectException (Guzzle 7)' => [
+            'With retries for wrapped ConnectException' => [
                 [
                     'responses' => [
-                        $rejectionConnection,
-                        $rejectionConnection,
-                        $rejectionConnection,
+                        $rejectionWrappedConnectException,
+                        $promiseCreds
+                    ],
+                    'credentials' => $creds
+                ],
+                $credsObject
+            ],
+            'With retries for raw ConnectException' => [
+                [
+                    'responses' => [
+                        $rejectionRawConnectException,
+                        $promiseCreds
+                    ],
+                    'credentials' => $creds
+                ],
+                $credsObject
+            ],
+            'With 4 retries for connection_error metadata' => [
+                [
+                    'responses' => [
+                        $rejectionConnectionError,
+                        $rejectionConnectionError,
+                        $rejectionConnectionError,
                         $promiseCreds
                     ],
                     'credentials' => $creds
@@ -488,18 +515,15 @@ EOF;
         $getRequest = new Psr7\Request('GET', '/latest');
 
         $rejectionCreds = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '401 Unathorized',
                 $getRequest,
                 new Psr7\Response(401)
             )
         ]);
-        $connectException = new ConnectException(
-            'cURL error 28: Connection timed out after 1000 milliseconds',
-            new Psr7\Request('GET', '/latest')
-        );
         $rejectionConnection = Promise\Create::rejectionFor([
-            'exception' => $connectException,
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
         ]);
 
         return [
@@ -527,12 +551,9 @@ EOF;
     {
         putenv('AWS_METADATA_SERVICE_NUM_ATTEMPTS=1');
 
-        $connectException = new ConnectException(
-            'cURL error 28: Connection timed out after 1000 milliseconds',
-            new Psr7\Request('GET', '/latest')
-        );
         $rejectionConnection = Promise\Create::rejectionFor([
-            'exception' => $connectException,
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
         ]);
 
         $provider = new EcsCredentialProvider([
@@ -567,12 +588,9 @@ EOF;
 
         $credsObject = new Credentials($creds[0], $creds[1], $creds[2], $expiry);
 
-        $connectException = new ConnectException(
-            'cURL error 28: Connection timed out after 1000 milliseconds',
-            new Psr7\Request('GET', '/latest')
-        );
         $rejectionConnection = Promise\Create::rejectionFor([
-            'exception' => $connectException,
+            'connection_error' => true,
+            'exception' => new \Exception('cURL error 28: Connection timed out after 1000 milliseconds'),
         ]);
         $promiseCreds = Promise\Create::promiseFor(
             new Response(200, [], Psr7\Utils::streamFor(
@@ -648,6 +666,10 @@ EOF;
             $creds
         ) {
             if (!empty($responses)) {
+                if (!isset($responses[$getRequests])) {
+                    throw new \Exception('No responses');
+                }
+
                 return $responses[$getRequests++];
             }
             return Promise\Create::promiseFor(

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -10,6 +10,7 @@ use Aws\MockHandler;
 use Aws\Result;
 use Aws\S3\S3Client;
 use Aws\Sdk;
+use Aws\Test\CreatesGuzzleExceptionsTrait;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
@@ -24,6 +25,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(InstanceProfileProvider::class)]
 class InstanceProfileProviderTest extends TestCase
 {
+    use CreatesGuzzleExceptionsTrait;
+
     private $originalEnv = [];
     private $tempFiles = [];
     private $capturedUri = null;
@@ -165,7 +168,7 @@ class InstanceProfileProviderTest extends TestCase
                             $request
                         );
                     } else {
-                        $exception = new RequestException(
+                        $exception = self::createRequestException(
                             '401 Unauthorized - Valid unexpired token required',
                             $request,
                             new Response(401)
@@ -257,7 +260,7 @@ class InstanceProfileProviderTest extends TestCase
                         )
                     );
                 } else {
-                    $exception = new RequestException(
+                    $exception = self::createRequestException(
                         '404 Not Found',
                         // Needed for different interfaces in Guzzle V5 & V6
                         new $requestClass(
@@ -377,12 +380,12 @@ class InstanceProfileProviderTest extends TestCase
         $putRequest = new $requestClass('PUT', '/latest/meta-data/foo');
         $throttledResponse = new $responseClass(503);
 
-        $getThrottleException = new RequestException(
+        $getThrottleException = self::createRequestException(
             '503 ThrottlingException',
             $getRequest,
             $throttledResponse
         );
-        $putThrottleException = new RequestException(
+        $putThrottleException = self::createRequestException(
             '503 ThrottlingException',
             $putRequest,
             $throttledResponse
@@ -604,35 +607,35 @@ class InstanceProfileProviderTest extends TestCase
             new Response(200, [], Psr7\Utils::streamFor('{'))
         );
         $rejectionThrottleToken = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '503 ThrottlingException',
                 $putRequest,
                 new $responseClass(503)
             )
         ]);
         $rejectionProfile = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '401 Unathorized',
                 $getRequest,
                 new $responseClass(401)
             )
         ]);
         $rejectionThrottleProfile = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '503 ThrottlingException',
                 $getRequest,
                 new $responseClass(503)
             )
         ]);
         $rejectionCreds = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '401 Unathorized',
                 $getRequest,
                 new $responseClass(401)
             )
         ]);
         $rejectionThrottleCreds = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '503 ThrottlingException',
                 $getRequest,
                 new $responseClass(503)
@@ -855,7 +858,7 @@ class InstanceProfileProviderTest extends TestCase
             ) {
                 if ($reqNumber === 1) {
                     return Promise\Create::rejectionFor([
-                        'exception' => new RequestException('404 Not Found',
+                        'exception' => self::createRequestException('404 Not Found',
                             $putRequest,
                             new $responseClass(404)
                         )
@@ -868,7 +871,7 @@ class InstanceProfileProviderTest extends TestCase
             }
             if ($request->getMethod() === 'GET') {
                 return Promise\Create::rejectionFor([
-                    'exception' => new RequestException(
+                    'exception' => self::createRequestException(
                         '401 Unauthorized - Valid unexpired token required',
                         $getRequest,
                         new $responseClass(401)
@@ -1150,14 +1153,14 @@ class InstanceProfileProviderTest extends TestCase
         $putRequest = new $requestClass('PUT', '/latest/meta-data/foo');
 
         $profileRejection500 = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '500 internal server error',
                 $putRequest,
                 new $responseClass(500)
             )
         ]);
         $credsRejection500 = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '500 internal server error',
                 $getRequest,
                 new $responseClass(500)
@@ -1338,14 +1341,14 @@ class InstanceProfileProviderTest extends TestCase
         $mockHandler = function (RequestInterface $request) use (&$firstTokenTry, $mockToken, $TOKEN_HEADER_KEY) {
             $fnRejectionTokenNotProvided = function () use ($mockToken, $TOKEN_HEADER_KEY, $request) {
                 return Promise\Create::rejectionFor(
-                    ['exception' => new RequestException("Token with value $mockToken is expected as header $TOKEN_HEADER_KEY", $request, new Response(400))]
+                    ['exception' => self::createRequestException("Token with value $mockToken is expected as header $TOKEN_HEADER_KEY", $request, new Response(400))]
                 );
             };
             if ($request->getMethod() === 'PUT' && $request->getUri()->getPath() === '/latest/api/token') {
                 if ($firstTokenTry) {
                     $firstTokenTry = false;
 
-                    return Promise\Create::rejectionFor(['exception' => new RequestException("Unexpected error!", $request, new Response(401))]);
+                    return Promise\Create::rejectionFor(['exception' => self::createRequestException("Unexpected error!", $request, new Response(401))]);
                 } else {
                     return Promise\Create::promiseFor(new Response(200, [], Psr7\Utils::streamFor($mockToken)));
                 }

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -10,6 +10,7 @@ use Aws\MockHandler;
 use Aws\Result;
 use Aws\S3\S3Client;
 use Aws\Sdk;
+use Aws\Test\CreatesGuzzleExceptionsTrait;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
@@ -24,6 +25,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(InstanceProfileProvider::class)]
 class InstanceProfileProviderTest extends TestCase
 {
+    use CreatesGuzzleExceptionsTrait;
+
     private $originalEnv = [];
     private $tempFiles = [];
     private $capturedUri = null;
@@ -165,7 +168,7 @@ class InstanceProfileProviderTest extends TestCase
                             $request
                         );
                     } else {
-                        $exception = new RequestException(
+                        $exception = self::createRequestException(
                             '401 Unauthorized - Valid unexpired token required',
                             $request,
                             new Response(401)
@@ -257,7 +260,7 @@ class InstanceProfileProviderTest extends TestCase
                         )
                     );
                 } else {
-                    $exception = new RequestException(
+                    $exception = self::createRequestException(
                         '404 Not Found',
                         // Needed for different interfaces in Guzzle V5 & V6
                         new $requestClass(
@@ -377,12 +380,12 @@ class InstanceProfileProviderTest extends TestCase
         $putRequest = new $requestClass('PUT', '/latest/meta-data/foo');
         $throttledResponse = new $responseClass(503);
 
-        $getThrottleException = new RequestException(
+        $getThrottleException = self::createRequestException(
             '503 ThrottlingException',
             $getRequest,
             $throttledResponse
         );
-        $putThrottleException = new RequestException(
+        $putThrottleException = self::createRequestException(
             '503 ThrottlingException',
             $putRequest,
             $throttledResponse
@@ -604,35 +607,35 @@ class InstanceProfileProviderTest extends TestCase
             new Response(200, [], Psr7\Utils::streamFor('{'))
         );
         $rejectionThrottleToken = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '503 ThrottlingException',
                 $putRequest,
                 new $responseClass(503)
             )
         ]);
         $rejectionProfile = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '401 Unathorized',
                 $getRequest,
                 new $responseClass(401)
             )
         ]);
         $rejectionThrottleProfile = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '503 ThrottlingException',
                 $getRequest,
                 new $responseClass(503)
             )
         ]);
         $rejectionCreds = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '401 Unathorized',
                 $getRequest,
                 new $responseClass(401)
             )
         ]);
         $rejectionThrottleCreds = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '503 ThrottlingException',
                 $getRequest,
                 new $responseClass(503)
@@ -855,7 +858,7 @@ class InstanceProfileProviderTest extends TestCase
             ) {
                 if ($reqNumber === 1) {
                     return Promise\Create::rejectionFor([
-                        'exception' => new RequestException('404 Not Found',
+                        'exception' => self::createRequestException('404 Not Found',
                             $putRequest,
                             new $responseClass(404)
                         )
@@ -868,7 +871,7 @@ class InstanceProfileProviderTest extends TestCase
             }
             if ($request->getMethod() === 'GET') {
                 return Promise\Create::rejectionFor([
-                    'exception' => new RequestException(
+                    'exception' => self::createRequestException(
                         '401 Unauthorized - Valid unexpired token required',
                         $getRequest,
                         new $responseClass(401)
@@ -1187,14 +1190,14 @@ class InstanceProfileProviderTest extends TestCase
         $putRequest = new $requestClass('PUT', '/latest/meta-data/foo');
 
         $profileRejection500 = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '500 internal server error',
                 $putRequest,
                 new $responseClass(500)
             )
         ]);
         $credsRejection500 = Promise\Create::rejectionFor([
-            'exception' => new RequestException(
+            'exception' => self::createRequestException(
                 '500 internal server error',
                 $getRequest,
                 new $responseClass(500)
@@ -1375,14 +1378,14 @@ class InstanceProfileProviderTest extends TestCase
         $mockHandler = function (RequestInterface $request) use (&$firstTokenTry, $mockToken, $TOKEN_HEADER_KEY) {
             $fnRejectionTokenNotProvided = function () use ($mockToken, $TOKEN_HEADER_KEY, $request) {
                 return Promise\Create::rejectionFor(
-                    ['exception' => new RequestException("Token with value $mockToken is expected as header $TOKEN_HEADER_KEY", $request, new Response(400))]
+                    ['exception' => self::createRequestException("Token with value $mockToken is expected as header $TOKEN_HEADER_KEY", $request, new Response(400))]
                 );
             };
             if ($request->getMethod() === 'PUT' && $request->getUri()->getPath() === '/latest/api/token') {
                 if ($firstTokenTry) {
                     $firstTokenTry = false;
 
-                    return Promise\Create::rejectionFor(['exception' => new RequestException("Unexpected error!", $request, new Response(401))]);
+                    return Promise\Create::rejectionFor(['exception' => self::createRequestException("Unexpected error!", $request, new Response(401))]);
                 } else {
                     return Promise\Create::promiseFor(new Response(200, [], Psr7\Utils::streamFor($mockToken)));
                 }

--- a/tests/Handler/Guzzle/HandlerTest.php
+++ b/tests/Handler/Guzzle/HandlerTest.php
@@ -2,8 +2,12 @@
 namespace Aws\Test\Handler\Guzzle;
 
 use Aws\Handler\Guzzle\GuzzleHandler;
+use Aws\Test\CreatesGuzzleExceptionsTrait;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseTransferException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Promise\RejectionException;
 use GuzzleHttp\Psr7;
@@ -16,6 +20,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(GuzzleHandler::class)]
 class HandlerTest extends TestCase
 {
+    use CreatesGuzzleExceptionsTrait;
+
     public function testHandlerWorksWithSuccessfulRequest()
     {
         $mock = new MockHandler([new Response(200, [], Psr7\Utils::streamFor('foo'))]);
@@ -37,10 +43,10 @@ class HandlerTest extends TestCase
     {
         $wasRejected = false;
         $request = new Request('PUT', 'http://example.com');
-        $mock = new MockHandler([new RequestException(
+        $mock = new MockHandler([self::createRequestException(
             'message',
             $request,
-            new Response('500')
+            new Response(500)
         )]);
         $client = new Client(['handler' => $mock]);
         $handler = new GuzzleHandler($client);
@@ -62,6 +68,103 @@ class HandlerTest extends TestCase
         }
 
         $this->assertTrue($wasRejected, 'Reject callback was not triggered.');
+    }
+
+    public function testHandlerMarksConnectExceptionAsConnectionError()
+    {
+        $request = new Request('PUT', 'http://example.com');
+        $mock = new MockHandler([
+            new ConnectException('message', $request),
+        ]);
+        $client = new Client(['handler' => $mock]);
+        $handler = new GuzzleHandler($client);
+
+        $promise = $handler($request);
+
+        try {
+            $promise->wait();
+            $this->fail('An exception should have been thrown.');
+        } catch (RejectionException $e) {
+            $error = $e->getReason();
+            $this->assertTrue($error['connection_error']);
+            $this->assertNull($error['response']);
+        }
+    }
+
+    public function testHandlerMarksCurlRecvErrorAsConnectionError()
+    {
+        $request = new Request('PUT', 'http://example.com');
+        $exception = new class ('message', $request) extends RequestException {
+            public function getHandlerContext(): array
+            {
+                return ['errno' => 56];
+            }
+        };
+        $mock = new MockHandler([$exception]);
+        $client = new Client(['handler' => $mock]);
+        $handler = new GuzzleHandler($client);
+
+        $promise = $handler($request);
+
+        try {
+            $promise->wait();
+            $this->fail('An exception should have been thrown.');
+        } catch (RejectionException $e) {
+            $error = $e->getReason();
+            $this->assertTrue($error['connection_error']);
+            $this->assertNull($error['response']);
+        }
+    }
+
+    public function testHandlerMarksNetworkExceptionAsConnectionError()
+    {
+        if (!class_exists(NetworkException::class)) {
+            $this->markTestSkipped('NetworkException is only available in Guzzle 8.');
+        }
+
+        $request = new Request('PUT', 'http://example.com');
+        $mock = new MockHandler([
+            new NetworkException('message', $request),
+        ]);
+        $client = new Client(['handler' => $mock]);
+        $handler = new GuzzleHandler($client);
+
+        $promise = $handler($request);
+
+        try {
+            $promise->wait();
+            $this->fail('An exception should have been thrown.');
+        } catch (RejectionException $e) {
+            $error = $e->getReason();
+            $this->assertTrue($error['connection_error']);
+            $this->assertNull($error['response']);
+        }
+    }
+
+    public function testHandlerMarksResponseTransferExceptionAsConnectionError()
+    {
+        if (!class_exists(ResponseTransferException::class)) {
+            $this->markTestSkipped('ResponseTransferException is only available in Guzzle 8.');
+        }
+
+        $request = new Request('PUT', 'http://example.com');
+        $response = new Response(200);
+        $mock = new MockHandler([
+            new ResponseTransferException('message', $request, $response),
+        ]);
+        $client = new Client(['handler' => $mock]);
+        $handler = new GuzzleHandler($client);
+
+        $promise = $handler($request);
+
+        try {
+            $promise->wait();
+            $this->fail('An exception should have been thrown.');
+        } catch (RejectionException $e) {
+            $error = $e->getReason();
+            $this->assertTrue($error['connection_error']);
+            $this->assertSame($response, $error['response']);
+        }
     }
 
     public function testHandlerWillInvokeOnTransferStatsCallback()

--- a/tests/Handler/HttpHandlerErrorTest.php
+++ b/tests/Handler/HttpHandlerErrorTest.php
@@ -1,0 +1,99 @@
+<?php
+namespace Aws\Test\Handler;
+
+use Aws\Handler\HttpHandlerError;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\NetworkException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
+use GuzzleHttp\Exception\ResponseTransferException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+#[CoversClass(HttpHandlerError::class)]
+class HttpHandlerErrorTest extends TestCase
+{
+    public function testDetectsConnectException()
+    {
+        $exception = new ConnectException(
+            'test',
+            new Request('GET', 'http://example.com')
+        );
+
+        $this->assertTrue(HttpHandlerError::isConnectionError($exception));
+    }
+
+    public function testDetectsNetworkException()
+    {
+        if (!class_exists(NetworkException::class)) {
+            $this->markTestSkipped('NetworkException is only available in Guzzle 8.');
+        }
+
+        $exception = new NetworkException(
+            'test',
+            new Request('GET', 'http://example.com')
+        );
+
+        $this->assertTrue(HttpHandlerError::isConnectionError($exception));
+    }
+
+    public function testDetectsGuzzle7CurlRecvErrorFromRequestException()
+    {
+        $exception = new class ('test', new Request('GET', 'http://example.com')) extends RequestException {
+            public function getHandlerContext(): array
+            {
+                return ['errno' => 56];
+            }
+        };
+
+        $this->assertTrue(HttpHandlerError::isConnectionError($exception));
+    }
+
+    public function testIgnoresGuzzle7NonRecvCurlErrorFromRequestException()
+    {
+        $exception = new class ('test', new Request('GET', 'http://example.com')) extends RequestException {
+            public function getHandlerContext(): array
+            {
+                return ['errno' => 23];
+            }
+        };
+
+        $this->assertFalse(HttpHandlerError::isConnectionError($exception));
+    }
+
+    public function testDetectsResponseTransferExceptionAndResponse()
+    {
+        if (!class_exists(ResponseTransferException::class)) {
+            $this->markTestSkipped('ResponseTransferException is only available in Guzzle 8.');
+        }
+
+        $response = new Response(200);
+        $exception = new ResponseTransferException(
+            'test',
+            new Request('GET', 'http://example.com'),
+            $response
+        );
+
+        $this->assertTrue(HttpHandlerError::isConnectionError($exception));
+        $this->assertSame($response, HttpHandlerError::getResponse($exception));
+    }
+
+    public function testGenericResponseExceptionIsNotConnectionError()
+    {
+        if (!class_exists(ResponseException::class)) {
+            $this->markTestSkipped('ResponseException is only available in Guzzle 8.');
+        }
+
+        $response = new Response(500);
+        $exception = new ResponseException(
+            'test',
+            new Request('GET', 'http://example.com'),
+            $response
+        );
+
+        $this->assertFalse(HttpHandlerError::isConnectionError($exception));
+        $this->assertSame($response, HttpHandlerError::getResponse($exception));
+    }
+}

--- a/tests/Retry/V3/RetryMiddlewareTest.php
+++ b/tests/Retry/V3/RetryMiddlewareTest.php
@@ -14,7 +14,6 @@ use Aws\Retry\ConfigurationProvider;
 use Aws\Retry\V3\QuotaManager;
 use Aws\Retry\V3\RetryMiddleware;
 use Aws\Retry\RateLimiter;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -769,71 +768,6 @@ class RetryMiddlewareTest extends TestCase
             $err = new \Error('e');
             $this->assertFalse($decider(0, $command, $err));
         }
-    }
-
-    public function testDeciderRetriesWhenCurlErrorCodeMatches()
-    {
-        if (!extension_loaded('curl')) {
-            $this->markTestSkipped('Test skipped on no cURL extension');
-        }
-        $decider = RetryMiddleware::createDefaultDecider();
-        $command = new Command('foo');
-        $request = new Request('GET', 'http://www.example.com');
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_RECV_ERROR]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertTrue($decider(0, $command, $err));
-    }
-
-    public function testDeciderRetriesForCustomCurlErrors()
-    {
-        if (!extension_loaded('curl')) {
-            $this->markTestSkipped('Test skipped on no cURL extension');
-        }
-        $decider = RetryMiddleware::createDefaultDecider(
-            ['curl_errors' => [CURLE_BAD_CONTENT_ENCODING]]
-        );
-        $command = new Command('foo');
-        $request = new Request('GET', 'http://www.example.com');
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_BAD_CONTENT_ENCODING]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertTrue($decider(0, $command, $err));
-
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_ABORTED_BY_CALLBACK]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertFalse($decider(0, $command, $err));
     }
 
     public static function awsErrorCodeProvider(): array

--- a/tests/Retry/V3/RetryMiddlewareTest.php
+++ b/tests/Retry/V3/RetryMiddlewareTest.php
@@ -173,7 +173,7 @@ class RetryMiddlewareTest extends TestCase
                 [
                     'response' => (new Response(
                         500,
-                    ))->withHeader('x-amz-retry-after', $value),
+                    ))->withHeader('x-amz-retry-after', (string) $value),
                 ],
             );
         };

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -9,7 +9,6 @@ use Aws\Result;
 use Aws\ResultInterface;
 use Aws\RetryMiddleware;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -82,71 +81,6 @@ class RetryMiddlewareTest extends TestCase
             $err = new \Error('e');
             $this->assertFalse($decider(0, $command, $request, null, $err));
         }
-    }
-
-    public function testDeciderRetriesWhenCurlErrorCodeMatches()
-    {
-        if (!extension_loaded('curl')) {
-            $this->markTestSkipped('Test skipped on no cURL extension');
-        }
-        $decider = RetryMiddleware::createDefaultDecider();
-        $command = new Command('foo');
-        $request = new Request('GET', 'http://www.example.com');
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_RECV_ERROR]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertTrue($decider(0, $command, $request, null, $err));
-    }
-
-    public function testDeciderRetriesForCustomCurlErrors()
-    {
-        if (!extension_loaded('curl')) {
-            $this->markTestSkipped('Test skipped on no cURL extension');
-        }
-        $decider = RetryMiddleware::createDefaultDecider(
-            3,
-            ['curl_errors' => [CURLE_BAD_CONTENT_ENCODING]]
-        );
-        $command = new Command('foo');
-        $request = new Request('GET', 'http://www.example.com');
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_BAD_CONTENT_ENCODING]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertTrue($decider(0, $command, $request, null, $err));
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_ABORTED_BY_CALLBACK]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertFalse($decider(0, $command, $request, null, $err));
     }
 
     public static function awsErrorCodeProvider(): array

--- a/tests/RetryMiddlewareV2Test.php
+++ b/tests/RetryMiddlewareV2Test.php
@@ -13,7 +13,6 @@ use Aws\Retry\Configuration;
 use Aws\Retry\QuotaManager;
 use Aws\Retry\RateLimiter;
 use Aws\RetryMiddlewareV2;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -513,73 +512,6 @@ class RetryMiddlewareV2Test extends TestCase
             $err = new \Error('e');
             $this->assertFalse($decider(0, $command, $err));
         }
-    }
-
-    public function testDeciderRetriesWhenCurlErrorCodeMatches()
-    {
-        if (!extension_loaded('curl')) {
-            $this->markTestSkipped('Test skipped on no cURL extension');
-        }
-        $decider = RetryMiddlewareV2::createDefaultDecider(new QuotaManager());
-        $command = new Command('foo');
-        $request = new Request('GET', 'http://www.example.com');
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_RECV_ERROR]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertTrue($decider(0, $command, $err));
-    }
-
-    public function testDeciderRetriesForCustomCurlErrors()
-    {
-        if (!extension_loaded('curl')) {
-            $this->markTestSkipped('Test skipped on no cURL extension');
-        }
-        $decider = RetryMiddlewareV2::createDefaultDecider(
-            new QuotaManager(),
-            3,
-            ['curl_errors' => [CURLE_BAD_CONTENT_ENCODING]]
-        );
-        $command = new Command('foo');
-        $request = new Request('GET', 'http://www.example.com');
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_BAD_CONTENT_ENCODING]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertTrue($decider(0, $command, $err));
-
-        $previous = new RequestException(
-            'test',
-            $request,
-            null,
-            null,
-            ['errno' => CURLE_ABORTED_BY_CALLBACK]
-        );
-        $err = new AwsException(
-            'e',
-            $command,
-            ['connection_error' => false],
-            $previous
-        );
-        $this->assertFalse($decider(0, $command, $err));
     }
 
     public static function awsErrorCodeProvider(): array

--- a/tests/S3/Crypto/S3EncryptionClientTestingTrait.php
+++ b/tests/S3/Crypto/S3EncryptionClientTestingTrait.php
@@ -14,7 +14,7 @@ trait S3EncryptionClientTestingTrait
         $fields[MetadataEnvelope::IV_HEADER]
             = base64_encode($provider->generateIv('aes-256-cbc'));
         $fields[MetadataEnvelope::CRYPTO_TAG_LENGTH_HEADER]
-            = 0;
+            = '0';
         $fields[MetadataEnvelope::CONTENT_KEY_V2_HEADER]
             = base64_encode('cek');
         $fields[MetadataEnvelope::MATERIALS_DESCRIPTION_HEADER]
@@ -33,7 +33,7 @@ trait S3EncryptionClientTestingTrait
         $fields[MetadataEnvelope::IV_HEADER]
             = base64_encode($provider->generateIv('aes-256-cbc'));
         $fields[MetadataEnvelope::CRYPTO_TAG_LENGTH_HEADER]
-            = 0;
+            = '0';
         $fields[MetadataEnvelope::CONTENT_KEY_V2_HEADER]
             = base64_encode('cek');
         $fields[MetadataEnvelope::MATERIALS_DESCRIPTION_HEADER]
@@ -52,7 +52,7 @@ trait S3EncryptionClientTestingTrait
         $fields[MetadataEnvelope::IV_HEADER]
             = base64_encode($provider->generateIv('aes-256-cbc'));
         $fields[MetadataEnvelope::CRYPTO_TAG_LENGTH_HEADER]
-            = 0;
+            = '0';
         $fields[MetadataEnvelope::CONTENT_KEY_V2_HEADER]
             = base64_encode('cek');
         $fields[MetadataEnvelope::MATERIALS_DESCRIPTION_HEADER]
@@ -71,7 +71,7 @@ trait S3EncryptionClientTestingTrait
         $fields[MetadataEnvelope::IV_HEADER]
             = base64_encode($provider->generateIv('aes-256-gcm'));
         $fields[MetadataEnvelope::CRYPTO_TAG_LENGTH_HEADER]
-            = 0;
+            = '0';
         $fields[MetadataEnvelope::CONTENT_KEY_V2_HEADER]
             = base64_encode('cek');
         $fields[MetadataEnvelope::MATERIALS_DESCRIPTION_HEADER]
@@ -90,7 +90,7 @@ trait S3EncryptionClientTestingTrait
         $fields[MetadataEnvelope::IV_HEADER]
             = base64_encode($provider->generateIv('aes-256-cbc'));
         $fields[MetadataEnvelope::CRYPTO_TAG_LENGTH_HEADER]
-            = 0;
+            = '0';
         $fields[MetadataEnvelope::CONTENT_KEY_V2_HEADER]
             = base64_encode('cek');
         $fields[MetadataEnvelope::MATERIALS_DESCRIPTION_HEADER]
@@ -109,7 +109,7 @@ trait S3EncryptionClientTestingTrait
         $fields[MetadataEnvelope::IV_HEADER]
             = base64_encode($provider->generateIv('aes-256-gcm'));
         $fields[MetadataEnvelope::CRYPTO_TAG_LENGTH_HEADER]
-            = 0;
+            = '0';
         $fields[MetadataEnvelope::CONTENT_KEY_V2_HEADER]
             = base64_encode('cek');
         $fields[MetadataEnvelope::MATERIALS_DESCRIPTION_HEADER]
@@ -128,7 +128,7 @@ trait S3EncryptionClientTestingTrait
         $fields[MetadataEnvelope::IV_HEADER]
             = base64_encode($provider->generateIv('aes-256-gcm'));
         $fields[MetadataEnvelope::CRYPTO_TAG_LENGTH_HEADER]
-            = 0;
+            = '0';
         $fields[MetadataEnvelope::CONTENT_KEY_V2_HEADER]
             = base64_encode('cek');
         $fields[MetadataEnvelope::MATERIALS_DESCRIPTION_HEADER]

--- a/tests/S3/S3ClientTest.php
+++ b/tests/S3/S3ClientTest.php
@@ -829,11 +829,10 @@ EOXML;
         array $retrySettings
     )
     {
-        $networkingError = $this->getMockBuilder(RequestException::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getHandlerContext'])
-            ->getMock();
-        $networkingError->method('getHandlerContext')->willReturn([]);
+        $networkingError = new RequestException(
+            'networking error',
+            new Psr7\Request('GET', 'http://www.example.com')
+        );
 
         $retries = $retrySettings['max_attempts'] - 1;
         $client = new S3Client([
@@ -870,11 +869,10 @@ EOXML;
     {
         $this->expectExceptionMessageMatches("/CompleteMultipartUpload/");
         $this->expectException(\Aws\S3\Exception\S3Exception::class);
-        $networkingError = $this->getMockBuilder(RequestException::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getHandlerContext'])
-            ->getMock();
-        $networkingError->method('getHandlerContext')->willReturn([]);
+        $networkingError = new RequestException(
+            'networking error',
+            new Psr7\Request('GET', 'http://www.example.com')
+        );
 
         $retries = $retrySettings['max_attempts'];
         $client = new S3Client([
@@ -910,11 +908,10 @@ EOXML;
     #[DataProvider('clientRetrySettingsProvider')]
     public function testErrorsWithUnparseableBodiesCanBeRetried($retrySettings)
     {
-        $networkingError = $this->getMockBuilder(RequestException::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getHandlerContext'])
-            ->getMock();
-        $networkingError->method('getHandlerContext')->willReturn([]);
+        $networkingError = new RequestException(
+            'networking error',
+            new Psr7\Request('GET', 'http://www.example.com')
+        );
 
         $retries = $retrySettings['max_attempts'];
         $client = new S3Client([

--- a/tests/S3/S3Transfer/S3TransferManagerTest.php
+++ b/tests/S3/S3Transfer/S3TransferManagerTest.php
@@ -3838,6 +3838,11 @@ EOF
             if ($newKey !== $key) {
                 $caseHeaders[$newKey] = $value;
                 unset($caseHeaders[$key]);
+                $key = $newKey;
+            }
+
+            if (!is_array($caseHeaders[$key])) {
+                $caseHeaders[$key] = (string) $caseHeaders[$key];
             }
         }
     }

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -673,7 +673,7 @@ class SignatureV4Test extends TestCase
 
         static $headers = [
             'X-Amz-Content-Sha256' => 'blah',
-            'aws-sdk-invocation-id' => 1,
+            'aws-sdk-invocation-id' => '1',
             'aws-sdk-retry' => 'foo',
             'transfer-encoding' => 'chunked'
         ];

--- a/tests/Signature/sig_hack.php
+++ b/tests/Signature/sig_hack.php
@@ -10,7 +10,7 @@ function gmdate($format, $ts = null)
         return \gmdate($format, $_SERVER['aws_time']);
     }
     return isset($_SERVER['aws_time'])
-        ? $_SERVER['aws_time']
+        ? (string) $_SERVER['aws_time']
         : \gmdate($format, $ts ?: time());
 }
 

--- a/tests/WaiterTest.php
+++ b/tests/WaiterTest.php
@@ -27,6 +27,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(Waiter::class)]
 class WaiterTest extends TestCase
 {
+    use CreatesGuzzleExceptionsTrait;
+
     use UsesServiceTrait;
     use MetricsBuilderTestTrait;
 
@@ -525,7 +527,7 @@ EOXML;
                 $response = new Response(200, [], $responseBody);
                 return new RejectedPromise([
                     'connection_error' => true,
-                    'exception' => new RequestException(
+                    'exception' => self::createRequestException(
                         'Error',
                         $request,
                         $response


### PR DESCRIPTION
Guzzle 8 is not yet released, but once it is, getting support in the AWS SDK is important, because it would otherwise block many other projects including Laravel from supporting Guzzle 8.

https://github.com/aws/aws-sdk-php/pull/3289 already makes a forward-compatible change that makes the SDK compatible with Guzzle 8's stricter requirement that headers be strings or lists of strings. The next change to be aware of is Guzzle 8's [changes to the exceptions](https://github.com/guzzle/guzzle/blob/8.0/UPGRADING.md#exception-hierarchy-and-classification). The `ResponseTransferException` exception was [added](https://github.com/guzzle/guzzle/pull/3546) specifically to accommodate the needs of the AWS SDK to want to retry this sub-class of failures, without needing to look at the handler context which is a leaky abstraction that was removed in Guzzle 8.

This PR makes changes to support the old and new exception design, and adjusts version constraints to support both Guzzle 7 and Guzzle 8. By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
