### PR TITLE
bugfix: prevent ObjectUploader from closing user-provided resource handles

### DIFF
--- a/.changes/nextrelease/fix-objectuploader-stream.json
+++ b/.changes/nextrelease/fix-objectuploader-stream.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "S3",
+    "description": "Prevents resources provided to `ObjectUploader` from being closed by Guzzle."
+  }
+]

--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -4,6 +4,7 @@ namespace Aws\S3;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\FnStream;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -57,7 +58,7 @@ class ObjectUploader implements PromisorInterface
         $this->client = $client;
         $this->bucket = $bucket;
         $this->key = $key;
-        $this->body = Psr7\Utils::streamFor($body);
+        $this->body = $this->createStream($body);
         $this->acl = $acl;
         $this->options = $options + self::$defaults;
         // Handle "add_content_md5" option.
@@ -98,6 +99,33 @@ class ObjectUploader implements PromisorInterface
     public function upload()
     {
         return $this->promise()->wait();
+    }
+
+    /**
+     * Creates a stream from the provided body, ensuring that user-provided
+     * PHP stream resources are not closed when the stream is destructed.
+     *
+     * @param mixed $body
+     *
+     * @return StreamInterface
+     */
+    private function createStream($body): StreamInterface
+    {
+        $stream = Psr7\Utils::streamFor($body);
+
+        // When the user provides a raw PHP resource, we should not take
+        // ownership of it (i.e., we should not fclose it on destruct).
+        // Decorate with a no-op close to prevent the underlying Stream
+        // from closing the user's resource handle.
+        if (is_resource($body)) {
+            return FnStream::decorate($stream, [
+                'close' => function () use ($stream) {
+                    $stream->detach();
+                },
+            ]);
+        }
+
+        return $stream;
     }
 
     /**

--- a/tests/S3/ObjectUploaderTest.php
+++ b/tests/S3/ObjectUploaderTest.php
@@ -381,4 +381,70 @@ class ObjectUploaderTest extends TestCase
             restore_error_handler();
         }
     }
+
+    /**
+     * Tests that a user-provided PHP resource handle is NOT closed by
+     * ObjectUploader after the upload completes (PutObject path).
+     *
+     * Regression test for: https://github.com/aws/aws-sdk-php/issues/XXXX
+     * The cyclic reference fix (PR #3290) caused Stream::__destruct() to fire
+     * promptly, which closed user-provided resource handles.
+     */
+    public function testUploadDoesNotCloseUserProvidedResourceHandle()
+    {
+        $client = $this->getTestClient('S3');
+        $this->addMockResults($client, [new Result()]);
+
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, 'Hello, World!');
+        fseek($fp, 0);
+
+        (new ObjectUploader($client, 'bucket', 'key', $fp))->upload();
+
+        $this->assertTrue(
+            is_resource($fp),
+            'User-provided resource handle should remain open after upload()'
+        );
+
+        // Clean up
+        fclose($fp);
+    }
+
+    /**
+     * Tests that a user-provided PHP resource handle is NOT closed by
+     * ObjectUploader after the upload completes (multipart path).
+     */
+    public function testMultipartUploadDoesNotCloseUserProvidedResourceHandle()
+    {
+        $client = $this->getTestClient('S3');
+        $this->addMockResults($client, [
+            new Result(['UploadId' => 'foo']),
+            new Result(['ETag' => 'bar']),
+            new Result(['ETag' => 'bar']),
+            new Result(['Location' => 'https://bucket.s3.amazonaws.com/key']),
+        ]);
+
+        // Create a resource with content larger than the multipart threshold
+        $fp = fopen('php://temp', 'r+');
+        $data = str_repeat('x', 6 * self::MB);
+        fwrite($fp, $data);
+        fseek($fp, 0);
+
+        (new ObjectUploader(
+            $client,
+            'bucket',
+            'key',
+            $fp,
+            'private',
+            ['mup_threshold' => 4 * self::MB]
+        ))->upload();
+
+        $this->assertTrue(
+            is_resource($fp),
+            'User-provided resource handle should remain open after multipart upload()'
+        );
+
+        // Clean up
+        fclose($fp);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
closes #3295 

*Description of changes:*
`ObjectUploader` wraps user-provided PHP resources in a `Psr7\Stream` via `Utils::streamFor()`. `Stream::__destruct()` calls `fclose()` on the underlying resource. Before #3290, a cyclic reference in the retry middleware kept the Stream alive indefinitely, so `__destruct()` never fired during the request lifecycle. After #3290 fixed the cycle, the Stream destructs promptly and closes the user's handle before `upload()` returns.

This change wraps user-provided resources with `FnStream::decorate()`, overriding `close()` to call `detach()` instead of `fclose()`. The SDK no longer takes ownership of resources it did not open.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.