### PR TITLE
Drop support for vulnerable `mtdowling/jmespath.php` versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "guzzlehttp/guzzle": "^7.4.5",
         "guzzlehttp/psr7": "^2.4.5",
         "guzzlehttp/promises": "^2.0",
-        "mtdowling/jmespath.php": "^2.8.0",
+        "mtdowling/jmespath.php": "^2.9.1",
         "ext-pcre": "*",
         "ext-json": "*",
         "ext-simplexml": "*",


### PR DESCRIPTION
Mythos (via a grant from the Linux Foundation to the PHP Foundation) has discovered an RCE vulnerability in `mtdowling/jmespath.php` which I patched this morning.

> https://github.com/jmespath/jmespath.php/security/advisories/GHSA-pcw8-m77r-2528


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
