### PR TITLE
fix: Can't use a profile that used aws login for temporary credentials (closes #3300)

### DIFF
--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -745,9 +745,24 @@ class CredentialProvider
             $config['preferStaticCredentials'] = true;
             $sourceCredentials = null;
             if (!empty($roleProfile['source_profile'])){
-                $sourceCredentials = call_user_func(
-                    CredentialProvider::ini($sourceProfileName, $filename, $config)
-                )->wait();
+                $sourceProfile = $profiles[$sourceProfileName];
+                if (isset($sourceProfile['login_session'])) {
+                    // Profile was configured by `aws login` - use login credential provider
+                    $sourceCredentials = call_user_func(
+                        CredentialProvider::login($sourceProfileName, $config)
+                    )->wait();
+                } elseif (isset($sourceProfile['sso_session'])
+                    || isset($sourceProfile['sso_start_url'])
+                ) {
+                    // Profile uses SSO - use sso credential provider
+                    $sourceCredentials = call_user_func(
+                        CredentialProvider::sso($sourceProfileName, $filename, $config)
+                    )->wait();
+                } else {
+                    $sourceCredentials = call_user_func(
+                        CredentialProvider::ini($sourceProfileName, $filename, $config)
+                    )->wait();
+                }
             } else {
                 $sourceCredentials = self::getCredentialsFromSource(
                     $profileName,


### PR DESCRIPTION
Fixes #3300

---
This fix was implemented autonomously by **[Conduct AI](https://conductai.ai)** — an open-source platform that turns AI agents into reusable team automations via YAML playbooks.
- 🔗 Platform: [conductai.ai](https://conductai.ai)
- 📦 Source: [github.com/sseshachala/conductai](https://github.com/sseshachala/conductai)
> Want Conduct AI to automate fixes in your repo too? [Get started free →](https://conductai.ai)

