### PR TITLE
bugfix: closed resource handles

### DIFF
--- a/.changes/nextrelease/bugfix-stream-close.json
+++ b/.changes/nextrelease/bugfix-stream-close.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "bugfix",
+    "category": "",
+    "description": "Fixes issue where after #3290, user-provided resource handles were closed on Guzzle `StreamInterface` destruct."
+  }
+]

--- a/src/Api/Serializer/RestSerializer.php
+++ b/src/Api/Serializer/RestSerializer.php
@@ -164,7 +164,13 @@ abstract class RestSerializer
 
             // Streaming bodies or payloads that are strings are
             // always just a stream of data.
-            $opts['body'] = Psr7\Utils::streamFor($body);
+            $stream = Psr7\Utils::streamFor($body);
+            // User-owned resource which should be detached instead of closed
+            // during garbage-collection
+            if (is_resource($body)) {
+                $stream = \Aws\detach_on_close_stream($stream);
+            }
+            $opts['body'] = $stream;
             return;
         }
 

--- a/src/Crypto/EncryptionTrait.php
+++ b/src/Crypto/EncryptionTrait.php
@@ -4,6 +4,7 @@ namespace Aws\Crypto;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\AppendStream;
 use GuzzleHttp\Psr7\Stream;
+use Psr\Http\Message\StreamInterface;
 
 trait EncryptionTrait
 {
@@ -49,7 +50,7 @@ trait EncryptionTrait
      * @internal
      */
     public function encrypt(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         array $cipherOptions,
         MaterialsProvider $provider,
         MetadataEnvelope $envelope
@@ -142,7 +143,7 @@ trait EncryptionTrait
      * @internal
      */
     protected function getEncryptingStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         $cek,
         &$cipherOptions
     ) {

--- a/src/Crypto/EncryptionTraitV2.php
+++ b/src/Crypto/EncryptionTraitV2.php
@@ -54,7 +54,7 @@ trait EncryptionTraitV2
      * @internal
      */
     public function encrypt(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         array $options,
         MaterialsProviderV2 $provider,
         MetadataEnvelope $envelope
@@ -155,7 +155,7 @@ trait EncryptionTraitV2
      * @internal
      */
     protected function getEncryptingStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         $cek,
         &$cipherOptions
     ) {

--- a/src/Crypto/EncryptionTraitV3.php
+++ b/src/Crypto/EncryptionTraitV3.php
@@ -43,7 +43,7 @@ trait EncryptionTraitV3
      * Builds an AesStreamInterface and populates encryption metadata into the
      * supplied envelope.
      *
-     * @param Stream $plaintext Plain-text data to be encrypted using the
+     * @param StreamInterface $plaintext Plain-text data to be encrypted using the
      *                          materials, algorithm, and data provided.
      * @param AlgorithmSuite $algorithmSuite Algorithm Suite for use in encryption
      * @param array $options    Options for use in encryption, including cipher
@@ -61,7 +61,7 @@ trait EncryptionTraitV3
      * @internal
      */
     public function encrypt(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         AlgorithmSuite $algorithmSuite,
         array $options,
         MaterialsProviderV3 $provider,
@@ -143,7 +143,7 @@ trait EncryptionTraitV3
     }
 
     private function encryptNonCommitingStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         array &$cipherOptions,
         array $keys,
         array $materialsDescription,
@@ -202,7 +202,7 @@ trait EncryptionTraitV3
     }
 
     private function encryptCommitingStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         AlgorithmSuite $algorithmSuite,
         array &$options,
         array $keys,
@@ -276,7 +276,7 @@ trait EncryptionTraitV3
      * Generates a stream that wraps the plaintext with the proper cipher and
      * uses the content encryption key (CEK) to encrypt the data when read.
      *
-     * @param Stream $plaintext Plain-text data to be encrypted using the
+     * @param StreamInterface $plaintext Plain-text data to be encrypted using the
      *                          materials, algorithm, and data provided.
      * @param string $cek A content encryption key for use by the stream for
      *                    encrypting the plaintext data.
@@ -288,7 +288,7 @@ trait EncryptionTraitV3
      * @internal
      */
     protected function getNonCommittingEncryptingStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         string $cek,
         array &$cipherOptions
     ): AppendStream
@@ -346,7 +346,7 @@ trait EncryptionTraitV3
      * Generates a stream that wraps the plaintext with the proper cipher and
      * uses the content encryption key (CEK) to encrypt the data when read.
      *
-     * @param Stream $plaintext Plain-text data to be encrypted using the
+     * @param StreamInterface $plaintext Plain-text data to be encrypted using the
      *                          materials, algorithm, and data provided.
      * @param string $cek A content encryption key for use by the stream for
      *                    encrypting the plaintext data.
@@ -361,7 +361,7 @@ trait EncryptionTraitV3
      * @internal
      */
     protected function getCommitingEncryptionStream(
-        Stream $plaintext,
+        StreamInterface $plaintext,
         string $dek,
         array &$cipherOptions,
         string $messageId,

--- a/src/Multipart/AbstractUploader.php
+++ b/src/Multipart/AbstractUploader.php
@@ -132,10 +132,14 @@ abstract class AbstractUploader extends AbstractUploadManager
         // Use the contents of a file as the data source.
         if (is_string($source)) {
             $source = Psr7\Utils::tryFopen($source, 'r');
+            $stream = Psr7\Utils::streamFor($source);
+        } elseif (is_resource($source)) {
+            // User-owned resource — don't fclose on destruct.
+            $stream = \Aws\detach_on_close_stream(Psr7\Utils::streamFor($source));
+        } else {
+            $stream = Psr7\Utils::streamFor($source);
         }
 
-        // Create a source stream.
-        $stream = Psr7\Utils::streamFor($source);
         if (!$stream->isReadable()) {
             throw new IAE('Source stream must be readable.');
         }

--- a/src/S3/Crypto/S3EncryptionClient.php
+++ b/src/S3/Crypto/S3EncryptionClient.php
@@ -127,8 +127,15 @@ class S3EncryptionClient extends AbstractCryptoClient
 
         $envelope = new MetadataEnvelope();
 
+        $bodyStream = Psr7\Utils::streamFor($args['Body']);
+        // User-owned resource which should be detached instead of closed
+        // during garbage-collection
+        if (is_resource($args['Body'])) {
+            $bodyStream = \Aws\detach_on_close_stream($bodyStream);
+        }
+
         return Promise\Create::promiseFor($this->encrypt(
-            Psr7\Utils::streamFor($args['Body']),
+            $bodyStream,
             $args['@CipherOptions'] ?: [],
             $provider,
             $envelope

--- a/src/S3/Crypto/S3EncryptionClientV2.php
+++ b/src/S3/Crypto/S3EncryptionClientV2.php
@@ -189,8 +189,15 @@ class S3EncryptionClientV2 extends AbstractCryptoClientV2
 
         $envelope = new MetadataEnvelope();
 
+        $bodyStream = Psr7\Utils::streamFor($args['Body']);
+        // User-owned resource which should be detached instead of closed
+        // during garbage-collection
+        if (is_resource($args['Body'])) {
+            $bodyStream = \Aws\detach_on_close_stream($bodyStream);
+        }
+
         return Promise\Create::promiseFor($this->encrypt(
-            Psr7\Utils::streamFor($args['Body']),
+            $bodyStream,
             $args,
             $provider,
             $envelope

--- a/src/S3/Crypto/S3EncryptionClientV3.php
+++ b/src/S3/Crypto/S3EncryptionClientV3.php
@@ -250,12 +250,19 @@ class S3EncryptionClientV3 extends AbstractCryptoClientV3
 
         $envelope = new MetadataEnvelope();
 
+        $bodyStream = Psr7\Utils::streamFor($args['Body']);
+        // User-owned resource which should be detached instead of closed
+        // during garbage-collection
+        if (is_resource($args['Body'])) {
+            $bodyStream = \Aws\detach_on_close_stream($bodyStream);
+        }
+
         return Promise\Create::promiseFor(
             //= ../specification/s3-encryption/client.md#required-api-operations
             //= type=implication
             //# - PutObject MUST encrypt its input data before it is uploaded to S3.
             $this->encrypt(
-                Psr7\Utils::streamFor($args['Body']),
+                $bodyStream,
                 $algorithmSuite,
                 $options,
                 $provider,

--- a/src/S3/ObjectUploader.php
+++ b/src/S3/ObjectUploader.php
@@ -4,7 +4,6 @@ namespace Aws\S3;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
 use GuzzleHttp\Psr7;
-use GuzzleHttp\Psr7\FnStream;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -102,8 +101,7 @@ class ObjectUploader implements PromisorInterface
     }
 
     /**
-     * Creates a stream from the provided body, ensuring that user-provided
-     * PHP stream resources are not closed when the stream is destructed.
+     * Creates a stream from the provided body.
      *
      * @param mixed $body
      *
@@ -112,17 +110,10 @@ class ObjectUploader implements PromisorInterface
     private function createStream($body): StreamInterface
     {
         $stream = Psr7\Utils::streamFor($body);
-
-        // When the user provides a raw PHP resource, we should not take
-        // ownership of it (i.e., we should not fclose it on destruct).
-        // Decorate with a no-op close to prevent the underlying Stream
-        // from closing the user's resource handle.
+        // User-owned resource which should be detached instead of closed
+        // during garbage-collection
         if (is_resource($body)) {
-            return FnStream::decorate($stream, [
-                'close' => function () use ($stream) {
-                    $stream->detach();
-                },
-            ]);
+            return \Aws\detach_on_close_stream($stream);
         }
 
         return $stream;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,8 +1,10 @@
 <?php
 namespace Aws;
 
+use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Utils;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
 
 //-----------------------------------------------------------------------------
@@ -565,4 +567,21 @@ function is_associative(array $array): bool
     }
 
     return !array_is_list($array);
+}
+
+/**
+ * Decorates a PSR-7 stream so close() detaches the underlying resource
+ * instead of fclose()-ing it. Use at sites where the SDK wraps a
+ * user-owned PHP resource.
+ *
+ * @param StreamInterface $stream
+ * @return StreamInterface
+ */
+function detach_on_close_stream(StreamInterface $stream): StreamInterface
+{
+    return FnStream::decorate($stream, [
+        'close' => static function () use ($stream) {
+            $stream->detach();
+        },
+    ]);
 }

--- a/tests/Api/Serializer/RestJsonSerializerTest.php
+++ b/tests/Api/Serializer/RestJsonSerializerTest.php
@@ -352,6 +352,22 @@ class RestJsonSerializerTest extends TestCase
         );
     }
 
+    public function testDoesNotCloseUserProvidedResourceHandleForBlobPayload(): void
+    {
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, 'hello');
+        fseek($fp, 0);
+
+        $request = $this->getRequest('bar', ['baz' => $fp]);
+        $this->assertSame('hello', (string) $request->getBody());
+
+        unset($request);
+        gc_collect_cycles();
+
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+    }
+
     /**
      * @param $input
      * @param $expectedOutput

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversFunction('Aws\parse_ini_file')]
 #[CoversFunction('Aws\parse_ini_section_with_subsections')]
 #[CoversFunction('Aws\is_associative')]
+#[CoversFunction('Aws\detach_on_close_stream')]
 class FunctionsTest extends TestCase
 {
     public function testCreatesRecursiveDirIterator()
@@ -468,13 +469,53 @@ EOT
     {
         return [
            [[], false],
-           [['foo' => 'bar'], true],
-           [[1, 2, 3, 5], false],
-           [['foo', 'bar', 'baz'], false],
-           [['1' => 1, '2' => 2, '3'], true],
-           [['0' => 0, '1' => 2], false],
-           [[0 => 1, 1 => 2], false],
-           [[1 => 0, 2 => 2], true],
+            [['foo' => 'bar'], true],
+            [[1, 2, 3, 5], false],
+            [['foo', 'bar', 'baz'], false],
+            [['1' => 1, '2' => 2, '3'], true],
+            [['0' => 0, '1' => 2], false],
+            [[0 => 1, 1 => 2], false],
+            [[1 => 0, 2 => 2], true],
         ];
+    }
+
+    public function testDetachOnCloseStreamLeavesResourceOpenAfterClose()
+    {
+        $fp = fopen('php://memory', 'r+');
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($fp);
+
+        $decorated = Aws\detach_on_close_stream($stream);
+        $decorated->close();
+
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+    }
+
+    public function testDetachOnCloseStreamLeavesResourceOpenAfterDestruct()
+    {
+        $fp = fopen('php://memory', 'r+');
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($fp);
+
+        $decorated = Aws\detach_on_close_stream($stream);
+        unset($decorated, $stream);
+        gc_collect_cycles();
+
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+    }
+
+    public function testDetachOnCloseStreamPassesThroughReads()
+    {
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, 'hello');
+        fseek($fp, 0);
+
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($fp);
+        $decorated = Aws\detach_on_close_stream($stream);
+
+        $this->assertSame('hello', (string) $decorated);
+
+        $decorated->close();
+        fclose($fp);
     }
 }

--- a/tests/Multipart/AbstractUploaderTest.php
+++ b/tests/Multipart/AbstractUploaderTest.php
@@ -188,6 +188,40 @@ class AbstractUploaderTest extends TestCase
         $this->assertInstanceOf('InvalidArgumentException', $exception);
     }
 
+    public function testDoesNotCloseUserProvidedResourceHandle()
+    {
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, 'data');
+        fseek($fp, 0);
+
+        $uploader = $this->getTestUploader(
+            $fp,
+            ['bucket' => 'foo', 'key' => 'bar']
+        );
+
+        /** @var StreamInterface $source */
+        $source = $this->getPropertyValue($uploader, 'source');
+        $source->close();
+
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+    }
+
+    public function testClosesSdkOwnedResourceForFilenameSource()
+    {
+        $uploader = $this->getTestUploader(
+            __FILE__,
+            ['bucket' => 'foo', 'key' => 'bar']
+        );
+
+        /** @var StreamInterface $source */
+        $source = $this->getPropertyValue($uploader, 'source');
+        $handle = $source->detach();
+
+        $this->assertIsResource($handle);
+        fclose($handle);
+    }
+
     #[DataProvider('getPartGeneratorTestCases')]
     public function testCommandGeneratorYieldsExpectedUploadCommands(
         $seekable,

--- a/tests/S3/Crypto/S3EncryptionClientTest.php
+++ b/tests/S3/Crypto/S3EncryptionClientTest.php
@@ -782,4 +782,34 @@ EOXML;
             '@MaterialsProvider' => $provider
         ]);
     }
+
+    public function testPutObjectDoesNotCloseUserProvidedResourceHandle(): void
+    {
+        $s3 = $this->getS3Client();
+        $this->addMockResults($s3, [
+            new Result(['ObjectURL' => 'file_url'])
+        ]);
+
+        $kms = $this->getKmsClient();
+        $provider = new KmsMaterialsProvider($kms, 'test-key');
+        $this->addMockResults($kms, [
+            new Result(['CiphertextBlob' => 'encrypted'])
+        ]);
+
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, 'plaintext');
+        fseek($fp, 0);
+
+        $client = @new S3EncryptionClient($s3);
+        $client->putObject([
+            'Bucket' => 'foo',
+            'Key' => 'bar',
+            'Body' => $fp,
+            '@MaterialsProvider' => $provider,
+            '@CipherOptions' => ['Cipher' => 'cbc'],
+        ]);
+
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+    }
 }

--- a/tests/S3/Crypto/S3EncryptionClientV2Test.php
+++ b/tests/S3/Crypto/S3EncryptionClientV2Test.php
@@ -1091,4 +1091,38 @@ EOXML;
             '@SecurityProfile' => 'V2',
         ]);
     }
+
+    public function testPutObjectDoesNotCloseUserProvidedResourceHandle(): void
+    {
+        $s3 = $this->getS3Client();
+        $this->addMockResults($s3, [
+            new Result(['ObjectURL' => 'file_url'])
+        ]);
+
+        $kms = $this->getKmsClient();
+        $provider = new KmsMaterialsProviderV2($kms, 'test-key');
+        $this->addMockResults($kms, [
+            new Result([
+                'CiphertextBlob' => 'encrypted',
+                'Plaintext' => random_bytes(32),
+            ])
+        ]);
+
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, 'plaintext');
+        fseek($fp, 0);
+
+        $client = @new S3EncryptionClientV2($s3);
+        $client->putObject([
+            'Bucket' => 'foo',
+            'Key' => 'bar',
+            'Body' => $fp,
+            '@MaterialsProvider' => $provider,
+            '@CipherOptions' => ['Cipher' => 'gcm'],
+            '@KmsEncryptionContext' => [],
+        ]);
+
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+    }
 }

--- a/tests/S3/Crypto/S3EncryptionClientV3Test.php
+++ b/tests/S3/Crypto/S3EncryptionClientV3Test.php
@@ -2173,4 +2173,39 @@ EOXML;
 
         $this->assertTrue($this->mockQueueEmpty());
     }
+
+    public function testPutObjectDoesNotCloseUserProvidedResourceHandle(): void
+    {
+        $s3 = $this->getS3Client();
+        $this->addMockResults($s3, [
+            new Result(['ObjectURL' => 'file_url'])
+        ]);
+
+        $kms = $this->getKmsClient();
+        $provider = new KmsMaterialsProviderV3($kms, 'test-key-id');
+        $this->addMockResults($kms, [
+            new Result([
+                'CiphertextBlob' => 'encrypted',
+                'Plaintext' => random_bytes(32),
+            ])
+        ]);
+
+        $fp = fopen('php://memory', 'r+');
+        fwrite($fp, 'plaintext');
+        fseek($fp, 0);
+
+        $client = new S3EncryptionClientV3($s3);
+        $client->putObject([
+            'Bucket' => 'foo',
+            'Key' => 'bar',
+            'Body' => $fp,
+            '@MaterialsProvider' => $provider,
+            '@CommitmentPolicy' => 'FORBID_ENCRYPT_ALLOW_DECRYPT',
+            '@CipherOptions' => ['Cipher' => 'gcm'],
+            '@KmsEncryptionContext' => [],
+        ]);
+
+        $this->assertTrue(is_resource($fp));
+        fclose($fp);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3295 

*Description of changes:*
After #3290, `Stream` objects were no longer kept alive indefinitely by circular references in our middleware stack, which caused user-provided file handles to be closed when the Guzzle streams we wrapped them with were garbage-collected.

The fix takes user-provided resource handles and uses a decorator on the `Stream` objects we wrap them with to detach rather than close the resource when garbage-collected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
