### PR TITLE
bugfix: skip error parsing for 2xx responses on rejected promises

### DIFF
--- a/.changes/nextrelease/fix-wrappedhttphandler-2xx-error-parse.json
+++ b/.changes/nextrelease/fix-wrappedhttphandler-2xx-error-parse.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "",
+        "description": "Fixed WrappedHttpHandler buffering the entire partial response body into memory when a 2xx response was attached to a rejected promise, which could exhaust memory on a transport failure during a large streamed download."
+    }
+]

--- a/src/WrappedHttpHandler.php
+++ b/src/WrappedHttpHandler.php
@@ -168,8 +168,14 @@ class WrappedHttpHandler
 
         $serviceError = "AWS HTTP error:\n";
 
-        if (!isset($err['response'])) {
-            $parts = ['response' => null];
+        // A 2xx status on a rejected promise means the transport failed
+        // mid-body after a success response was received; there is no error
+        // document to parse, and parsing one would buffer the entire partial
+        // body into memory.
+        if (!isset($err['response'])
+            || $err['response']->getStatusCode() < 300
+        ) {
+            $parts = ['response' => $err['response'] ?? null];
             $serviceError .= $err['exception']->getMessage();
         } else {
             try {

--- a/tests/WrappedHttpHandlerTest.php
+++ b/tests/WrappedHttpHandlerTest.php
@@ -93,6 +93,29 @@ class WrappedHttpHandlerTest extends TestCase
         }
     }
 
+    public function testDoesNotParseErrorWhenRejectedWithSuccessResponse()
+    {
+        $e = new \Exception('cURL error 18: transfer closed with outstanding read data remaining');
+        $cmd = new Command('foo');
+        $req = new Request('GET', 'http://foo.com');
+        $res = new Response(200, [], 'partial body');
+        $handler = function () use ($e, $res) {
+            return new RejectedPromise(['exception' => $e, 'response' => $res]);
+        };
+        $parser = $errorParser = [$this, 'fail'];
+        $wrapped = new WrappedHttpHandler($handler, $parser, $errorParser);
+        try {
+            $wrapped($cmd, $req)->wait();
+            $this->fail();
+        } catch (AwsException $e) {
+            $this->assertSame($cmd, $e->getCommand());
+            $this->assertSame($req, $e->getRequest());
+            $this->assertSame($res, $e->getResponse());
+            $this->assertNull($e->getResult());
+            $this->assertStringContainsString('cURL error 18', $e->getMessage());
+        }
+    }
+
     #[DataProvider('responseAndParserProvider')]
     public function testCanRejectWithAndParseResponse(
         Response $res,


### PR DESCRIPTION
*Issue #, if available:*
closes #3319

*Description of changes:*
When a streamed download like GetObject with SaveAs fails mid-transfer after the server already sent a 200 status, WrappedHttpHandler::parseError still ran the response through the error parser, which reads the entire body into memory. For a large partial download that means buffering everything received so far, which can exhaust memory_limit on a transient network failure. This skips the error parser when the attached response status is under 300, the same check parseResponse already uses on the success path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.