### PR TITLE
fix: Stop pinning HeadObject-derived VersionId on UploadPartCopy requests

### DIFF
--- a/.changes/nextrelease/multipart-copy-versionid-fix.json
+++ b/.changes/nextrelease/multipart-copy-versionid-fix.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "S3\\MultipartCopy",
+        "description": "Stop pinning HeadObject-derived VersionId on UploadPartCopy requests. Only user-provided versionId is now attached to copy-part requests."
+    }
+]

--- a/features/multipart/s3.feature
+++ b/features/multipart/s3.feature
@@ -109,3 +109,11 @@ Feature: S3 Multipart Uploads
     And I overwrite "versioned" in the versioned bucket with body "v2"
     When I call multipartCopy on the original version of "versioned" in the versioned bucket
     Then the copied file "versioned-copy" should contain "v1"
+
+  @versioned
+  Scenario: Copying without a source_version_id follows the current version
+    Given I have a versioning-enabled bucket
+    And I have an uploaded file named "current" in the versioned bucket with body "v1"
+    And I overwrite "current" in the versioned bucket with body "v2"
+    When I call multipartCopy on "current" in the versioned bucket without a version_id
+    Then the copied file "current-copy" should contain "v2"

--- a/src/S3/MultipartCopy.php
+++ b/src/S3/MultipartCopy.php
@@ -64,8 +64,10 @@ class MultipartCopy extends AbstractUploadManager
 
     /** @var string|array */
     private $source;
-    /** @var string|null */
+    /** @var string|null User-provided versionId (from source string or config). */
     private $sourceVersionId;
+    /** @var string|null HeadObject-derived versionId (used only for Phase 1 reads). */
+    private ?string $headDerivedVersionId = null;
     /** @var ResultInterface|null */
     private $sourceMetadata;
     /** @var string|null */
@@ -481,13 +483,17 @@ class MultipartCopy extends AbstractUploadManager
     /**
      * Captures VersionId and ETag from a source HeadObject result.
      *
+     * HeadObject-derived VersionId is used only for Phase 1 source reads
+     * (tags/annotations). Only user-provided versionId is attached to
+     * UploadPartCopy requests.
+     *
      * @param ResultInterface $r
      * @return void
      */
     private function captureSourceIdentifiers(ResultInterface $r): void
     {
-        if (empty($this->sourceVersionId) && !empty($r['VersionId'])) {
-            $this->sourceVersionId = $r['VersionId'];
+        if (!empty($r['VersionId'])) {
+            $this->headDerivedVersionId = $r['VersionId'];
         }
 
         if (!empty($r['ETag'])) {
@@ -536,6 +542,9 @@ class MultipartCopy extends AbstractUploadManager
     /**
      * Builds Bucket/Key (and VersionId if pinned) for source-side reads.
      *
+     * Uses the user-provided sourceVersionId if available, otherwise falls
+     * back to the HeadObject-derived versionId for Phase 1 consistency.
+     *
      * @return array
      */
     private function buildSourceObjectParams(): array
@@ -557,8 +566,9 @@ class MultipartCopy extends AbstractUploadManager
             ];
         }
 
-        if (!empty($this->sourceVersionId)) {
-            $p['VersionId'] = $this->sourceVersionId;
+        $versionId = $this->sourceVersionId ?? $this->headDerivedVersionId;
+        if (!empty($versionId)) {
+            $p['VersionId'] = $versionId;
         }
 
         return $p;

--- a/tests/Integ/MultipartContext.php
+++ b/tests/Integ/MultipartContext.php
@@ -800,6 +800,29 @@ class MultipartContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @When I call multipartCopy on :filename in the versioned bucket without a version_id
+     *
+     * Live-server regression for the fix that stops pinning HeadObject-derived
+     * VersionId on UploadPartCopy requests: when no source_version_id is
+     * supplied, the copy must follow the *current* version of the object
+     * (here, "v2") rather than whatever version HeadObject happened to see
+     * first.
+     */
+    public function iCallMultipartCopyOnInTheVersionedBucketWithoutAVersionId($filename)
+    {
+        $bucket = self::getVersionedResourceName();
+        $copier = new MultipartCopy(
+            $this->s3Client,
+            "/{$bucket}/{$filename}",
+            [
+                'bucket' => $bucket,
+                'key'    => $filename . '-copy',
+            ]
+        );
+        $this->runCopy($copier);
+    }
+
+    /**
      * @Then the copied file :destKey should contain :body
      */
     public function theCopiedFileShouldContain($destKey, $body)

--- a/tests/S3/MultipartCopyTest.php
+++ b/tests/S3/MultipartCopyTest.php
@@ -921,9 +921,12 @@ class MultipartCopyTest extends TestCase
         $this->assertArrayNotHasKey('ListObjectAnnotations', $counts);
     }
 
-    public function testVersionIdAndETagFromHeadObjectArePinnedOnUploadPartCopy()
+    public function testHeadObjectDerivedVersionIdIsNotPinnedOnUploadPartCopy()
     {
-        // Trigger a real HeadObject by NOT pre-supplying source_metadata.
+        // When the user does NOT specify a sourceVersionId, the SDK must NOT
+        // attach the HeadObject-derived versionId to UploadPartCopy requests.
+        // Only the ETag conditional (CopySourceIfMatch) is used for consistency.
+        // Regression test for: https://github.com/aws/aws-sdk-java-v2/issues/7117
         $client = $this->getTestClient('s3');
         $this->addMockResults($client, [
             new Result([
@@ -956,7 +959,50 @@ class MultipartCopyTest extends TestCase
 
         $this->assertNotEmpty($uploadPartCopyCmds);
         foreach ($uploadPartCopyCmds as $cmd) {
-            $this->assertStringContainsString('?versionId=src-version', $cmd['CopySource']);
+            $this->assertStringNotContainsString('?versionId=', $cmd['CopySource'],
+                'UploadPartCopy must NOT attach HeadObject-derived versionId');
+            $this->assertSame('"src-etag"', $cmd['CopySourceIfMatch']);
+        }
+    }
+
+    public function testUserProvidedVersionIdIsPinnedOnUploadPartCopy()
+    {
+        // When the user explicitly provides a versionId via the source string,
+        // it MUST be attached to UploadPartCopy requests.
+        $client = $this->getTestClient('s3');
+        $this->addMockResults($client, [
+            new Result([
+                'ContentLength' => 11 * self::MB,
+                'ContentType'   => 'text/plain',
+                'ETag'          => '"src-etag"',
+                'VersionId'     => 'user-version',
+            ]),
+            new Result(['UploadId' => 'baz']),
+            new Result(['CopyPartResult' => ['ETag' => 'A']]),
+            new Result(['CopyPartResult' => ['ETag' => 'B']]),
+            new Result(['CopyPartResult' => ['ETag' => 'C']]),
+            new Result(['Location' => 'http://foo/bar']),
+        ]);
+
+        $uploadPartCopyCmds = [];
+        $client->getHandlerList()->appendSign(Middleware::tap(
+            function (CommandInterface $cmd) use (&$uploadPartCopyCmds) {
+                if ($cmd->getName() === 'UploadPartCopy') {
+                    $uploadPartCopyCmds[] = $cmd->toArray();
+                }
+            }
+        ));
+
+        // User explicitly provides versionId in the source string
+        $uploader = new MultipartCopy($client, '/srcbucket/srckey?versionId=user-version', [
+            'bucket' => 'foo',
+            'key'    => 'bar',
+        ]);
+        $uploader->upload();
+
+        $this->assertNotEmpty($uploadPartCopyCmds);
+        foreach ($uploadPartCopyCmds as $cmd) {
+            $this->assertStringContainsString('?versionId=user-version', $cmd['CopySource']);
             $this->assertSame('"src-etag"', $cmd['CopySourceIfMatch']);
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
Internal PHP-3422

*Description of changes:*
Separates HeadObject-derived VersionId from user-provided VersionId in MultipartCopy. UploadPartCopy now only includes versionId when the user explicitly specifies it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
