### PR TITLE
Cloudfront signer hash algo

### DIFF
--- a/.changes/nextrelease/cloudfront-signer.json
+++ b/.changes/nextrelease/cloudfront-signer.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "CloudFront",
+    "description": "Adds SHA-256 support to `Signer`."
+  }
+]

--- a/src/CloudFront/CloudFrontClient.php
+++ b/src/CloudFront/CloudFrontClient.php
@@ -361,9 +361,8 @@ class CloudFrontClient extends AwsClient
      *   URLs for private distributions.
      * - private_key: (string) The filepath to the private key used to sign
      *   CloudFront URLs for private distributions.
-     * - algorithm: (int|string) OpenSSL signature algorithm constant (e.g.
-     *   OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or algorithm name string
-     *   (e.g. "sha256"). Defaults to OPENSSL_ALGO_SHA1.
+     * - algorithm: (int|string) Algorithm (name or openssl constant) to be used.
+     *   Defaults to SHA1. Supported algorithms are SHA1 and SHA256.
      *
      * @param array $options Array of configuration options used when signing
      *
@@ -383,7 +382,7 @@ class CloudFrontClient extends AwsClient
         $urlSigner = new UrlSigner(
             $options['key_pair_id'],
             $options['private_key'],
-            isset($options['algorithm']) ? $options['algorithm'] : OPENSSL_ALGO_SHA1
+            $options['algorithm'] ?? Signer::DEFAULT_ALGORITHM,
         );
 
         return $urlSigner->getSignedUrl(
@@ -430,7 +429,7 @@ class CloudFrontClient extends AwsClient
         $cookieSigner = new CookieSigner(
             $options['key_pair_id'],
             $options['private_key'],
-            isset($options['algorithm']) ? $options['algorithm'] : OPENSSL_ALGO_SHA1
+            $options['algorithm'] ?? Signer::DEFAULT_ALGORITHM,
         );
 
         return $cookieSigner->getSignedCookie(

--- a/src/CloudFront/CloudFrontClient.php
+++ b/src/CloudFront/CloudFrontClient.php
@@ -361,6 +361,9 @@ class CloudFrontClient extends AwsClient
      *   URLs for private distributions.
      * - private_key: (string) The filepath to the private key used to sign
      *   CloudFront URLs for private distributions.
+     * - algorithm: (int|string) OpenSSL signature algorithm constant (e.g.
+     *   OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or algorithm name string
+     *   (e.g. "sha256"). Defaults to OPENSSL_ALGO_SHA1.
      *
      * @param array $options Array of configuration options used when signing
      *
@@ -379,7 +382,8 @@ class CloudFrontClient extends AwsClient
 
         $urlSigner = new UrlSigner(
             $options['key_pair_id'],
-            $options['private_key']
+            $options['private_key'],
+            isset($options['algorithm']) ? $options['algorithm'] : OPENSSL_ALGO_SHA1
         );
 
         return $urlSigner->getSignedUrl(
@@ -404,6 +408,9 @@ class CloudFrontClient extends AwsClient
      *   URLs for private distributions.
      * - private_key: (string) The filepath ot the private key used to sign
      *   CloudFront URLs for private distributions.
+     * - algorithm: (int|string) OpenSSL signature algorithm constant (e.g.
+     *   OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or algorithm name string
+     *   (e.g. "sha256"). Defaults to OPENSSL_ALGO_SHA1.
      *
      * @param array $options Array of configuration options used when signing
      *
@@ -422,7 +429,8 @@ class CloudFrontClient extends AwsClient
 
         $cookieSigner = new CookieSigner(
             $options['key_pair_id'],
-            $options['private_key']
+            $options['private_key'],
+            isset($options['algorithm']) ? $options['algorithm'] : OPENSSL_ALGO_SHA1
         );
 
         return $cookieSigner->getSignedCookie(

--- a/src/CloudFront/CookieSigner.php
+++ b/src/CloudFront/CookieSigner.php
@@ -14,15 +14,13 @@ class CookieSigner
     /**
      * @param $keyPairId  string     ID of the key pair
      * @param $privateKey string     Path to the private key used for signing
-     * @param $algorithm  int|string OpenSSL signature algorithm constant (e.g.
-     *                               OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or
-     *                               algorithm name string (e.g. "sha256").
-     *                               Defaults to OPENSSL_ALGO_SHA1.
+     * @param $algorithm  int|string Algorithm (name or openssl constant) to be used. Defaults to SHA1.
+     *                               Supported algorithms are SHA1 and SHA256.
      *
      * @throws \RuntimeException if the openssl extension is missing
-     * @throws \InvalidArgumentException if the private key cannot be found.
+     * @throws \InvalidArgumentException if the private key cannot be found or the passed algorithm is not supported.
      */
-    public function __construct($keyPairId, $privateKey, $algorithm = OPENSSL_ALGO_SHA1)
+    public function __construct($keyPairId, $privateKey, $algorithm = Signer::DEFAULT_ALGORITHM)
     {
         $this->signer = new Signer($keyPairId, $privateKey, '', $algorithm);
     }

--- a/src/CloudFront/CookieSigner.php
+++ b/src/CloudFront/CookieSigner.php
@@ -12,15 +12,19 @@ class CookieSigner
     ];
 
     /**
-     * @param $keyPairId  string ID of the key pair
-     * @param $privateKey string Path to the private key used for signing
+     * @param $keyPairId  string     ID of the key pair
+     * @param $privateKey string     Path to the private key used for signing
+     * @param $algorithm  int|string OpenSSL signature algorithm constant (e.g.
+     *                               OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or
+     *                               algorithm name string (e.g. "sha256").
+     *                               Defaults to OPENSSL_ALGO_SHA1.
      *
      * @throws \RuntimeException if the openssl extension is missing
      * @throws \InvalidArgumentException if the private key cannot be found.
      */
-    public function __construct($keyPairId, $privateKey)
+    public function __construct($keyPairId, $privateKey, $algorithm = OPENSSL_ALGO_SHA1)
     {
-        $this->signer = new Signer($keyPairId, $privateKey);
+        $this->signer = new Signer($keyPairId, $privateKey, '', $algorithm);
     }
 
     /**

--- a/src/CloudFront/CookieSigner.php
+++ b/src/CloudFront/CookieSigner.php
@@ -12,18 +12,25 @@ class CookieSigner
     ];
 
     /**
-     * @param $keyPairId  string     ID of the key pair
-     * @param $privateKey string     Path to the private key used for signing
-     * @param $algorithm  int|string Algorithm (name or openssl constant) to be used. Defaults to SHA1.
-     *                               Supported algorithms are SHA1 and SHA256.
+     * @param string     $keyPairId  ID of the key pair.
+     * @param string     $privateKey Path to the private key used for signing,
+     *                               or a PEM-encoded key string.
+     * @param int|string $algorithm  Signing hash algorithm. Accepts either an
+     *                               OpenSSL constant (OPENSSL_ALGO_SHA1,
+     *                               OPENSSL_ALGO_SHA256) or the canonical name
+     *                               string ("SHA1", "SHA256"). Defaults to SHA1.
      *
-     * @throws \RuntimeException if the openssl extension is missing
-     * @throws \InvalidArgumentException if the private key cannot be found or the passed algorithm is not supported.
+     * @throws \RuntimeException if the openssl extension is missing.
+     * @throws \InvalidArgumentException if the private key cannot be found,
+     *                                   the key type is not supported by
+     *                                   CloudFront (RSA or ECDSA P-256), or
+     *                                   the requested algorithm is not supported.
      */
     public function __construct($keyPairId, $privateKey, $algorithm = Signer::DEFAULT_ALGORITHM)
     {
         $this->signer = new Signer($keyPairId, $privateKey, '', $algorithm);
     }
+
 
     /**
      * Create a signed Amazon CloudFront Cookie.

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -8,19 +8,24 @@ class Signer
 {
     private $keyPairId;
     private $pkHandle;
+    private $algorithm;
 
     /**
      * A signer for creating the signature values used in CloudFront signed URLs
      * and signed cookies.
      *
-     * @param $keyPairId  string ID of the key pair
-     * @param $privateKey string Path to the private key used for signing
-     * @param $passphrase string Passphrase to private key file, if one exists
+     * @param $keyPairId  string     ID of the key pair
+     * @param $privateKey string     Path to the private key used for signing
+     * @param $passphrase string     Passphrase to private key file, if one exists
+     * @param $algorithm  int|string OpenSSL signature algorithm constant (e.g.
+     *                               OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or
+     *                               algorithm name string (e.g. "sha256").
+     *                               Defaults to OPENSSL_ALGO_SHA1.
      *
      * @throws \RuntimeException if the openssl extension is missing
      * @throws \InvalidArgumentException if the private key cannot be found.
      */
-    public function __construct($keyPairId, $privateKey, $passphrase = "")
+    public function __construct($keyPairId, $privateKey, $passphrase = "", $algorithm = OPENSSL_ALGO_SHA1)
     {
         if (!extension_loaded('openssl')) {
             //@codeCoverageIgnoreStart
@@ -30,6 +35,7 @@ class Signer
         }
 
         $this->keyPairId = $keyPairId;
+        $this->algorithm = $algorithm;
 
         if (!$this->pkHandle = openssl_pkey_get_private($privateKey, $passphrase)) {
             if (!file_exists($privateKey)) {
@@ -96,7 +102,38 @@ class Signer
         $signatureHash['Signature'] = $this->encode($this->sign($policy));
         $signatureHash['Key-Pair-Id'] = $this->keyPairId;
 
+        $hashAlgParam = $this->getCloudFrontAlgorithmParam();
+        if ($hashAlgParam !== null) {
+            $signatureHash['Hash-Algorithm'] = $hashAlgParam;
+        }
+
         return $signatureHash;
+    }
+
+    /**
+     * Maps the OpenSSL algorithm to the value CloudFront expects in the
+     * Hash-Algorithm query parameter / cookie attribute. Returns null for
+     * SHA1 (the default; no parameter needed for backward compatibility).
+     */
+    private function getCloudFrontAlgorithmParam()
+    {
+        static $map = [
+            OPENSSL_ALGO_SHA256 => 'SHA256',
+        ];
+
+        if (is_int($this->algorithm)) {
+            return isset($map[$this->algorithm]) ? $map[$this->algorithm] : null;
+        }
+
+        // Normalize string forms: "sha256", "SHA-256", "sha256WithRSAEncryption" → "SHA256"
+        $normalized = strtoupper(preg_replace('/[^a-zA-Z0-9]/', '', $this->algorithm));
+        foreach ($map as $param) {
+            if ($normalized === $param) {
+                return $param;
+            }
+        }
+
+        return null;
     }
 
     private function createCannedPolicy($resource, $expiration)
@@ -117,7 +154,7 @@ class Signer
     {
         $signature = '';
         
-        if(!openssl_sign($policy, $signature, $this->pkHandle)) {
+        if(!openssl_sign($policy, $signature, $this->pkHandle, $this->algorithm)) {
             $errorMessages = [];
             while(($newMessage = openssl_error_string()) !== false) {
                 $errorMessages[] = $newMessage;

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -10,6 +10,12 @@ class Signer
     private $pkHandle;
     private $algorithm;
 
+    public const DEFAULT_ALGORITHM = 'SHA1';
+    public const SUPPORTED_ALGORITHM = [
+        OPENSSL_ALGO_SHA1 => 'SHA1',
+        OPENSSL_ALGO_SHA256 => 'SHA256',
+    ];
+
     /**
      * A signer for creating the signature values used in CloudFront signed URLs
      * and signed cookies.
@@ -17,15 +23,13 @@ class Signer
      * @param $keyPairId  string     ID of the key pair
      * @param $privateKey string     Path to the private key used for signing
      * @param $passphrase string     Passphrase to private key file, if one exists
-     * @param $algorithm  int|string OpenSSL signature algorithm constant (e.g.
-     *                               OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or
-     *                               algorithm name string (e.g. "sha256").
-     *                               Defaults to OPENSSL_ALGO_SHA1.
+     * @param $algorithm  int|string Algorithm (name or openssl constant) to be used. Defaults to SHA1.
+     *                                Supported algorithms are SHA1 and SHA256.
      *
      * @throws \RuntimeException if the openssl extension is missing
-     * @throws \InvalidArgumentException if the private key cannot be found.
+     * @throws \InvalidArgumentException if the private key cannot be found or the passed algorithm is not supported.
      */
-    public function __construct($keyPairId, $privateKey, $passphrase = "", $algorithm = OPENSSL_ALGO_SHA1)
+    public function __construct($keyPairId, $privateKey, $passphrase = "", $algorithm = self::DEFAULT_ALGORITHM)
     {
         if (!extension_loaded('openssl')) {
             //@codeCoverageIgnoreStart
@@ -35,6 +39,12 @@ class Signer
         }
 
         $this->keyPairId = $keyPairId;
+
+        $algorithm = \strtoupper(self::SUPPORTED_ALGORITHM[$algorithm] ?? $algorithm);
+        if (!\in_array($algorithm, self::SUPPORTED_ALGORITHM)) {
+            throw new \InvalidArgumentException("Unsupported signature algorithm: $algorithm");
+        }
+
         $this->algorithm = $algorithm;
 
         if (!$this->pkHandle = openssl_pkey_get_private($privateKey, $passphrase)) {
@@ -102,38 +112,11 @@ class Signer
         $signatureHash['Signature'] = $this->encode($this->sign($policy));
         $signatureHash['Key-Pair-Id'] = $this->keyPairId;
 
-        $hashAlgParam = $this->getCloudFrontAlgorithmParam();
-        if ($hashAlgParam !== null) {
-            $signatureHash['Hash-Algorithm'] = $hashAlgParam;
+        if ($this->algorithm !== self::DEFAULT_ALGORITHM) {
+            $signatureHash['Hash-Algorithm'] = $this->algorithm;
         }
 
         return $signatureHash;
-    }
-
-    /**
-     * Maps the OpenSSL algorithm to the value CloudFront expects in the
-     * Hash-Algorithm query parameter / cookie attribute. Returns null for
-     * SHA1 (the default; no parameter needed for backward compatibility).
-     */
-    private function getCloudFrontAlgorithmParam()
-    {
-        static $map = [
-            OPENSSL_ALGO_SHA256 => 'SHA256',
-        ];
-
-        if (is_int($this->algorithm)) {
-            return isset($map[$this->algorithm]) ? $map[$this->algorithm] : null;
-        }
-
-        // Normalize string forms: "sha256", "SHA-256", "sha256WithRSAEncryption" → "SHA256"
-        $normalized = strtoupper(preg_replace('/[^a-zA-Z0-9]/', '', $this->algorithm));
-        foreach ($map as $param) {
-            if ($normalized === $param) {
-                return $param;
-            }
-        }
-
-        return null;
     }
 
     private function createCannedPolicy($resource, $expiration)

--- a/src/CloudFront/Signer.php
+++ b/src/CloudFront/Signer.php
@@ -11,8 +11,23 @@ class Signer
     private $algorithm;
 
     public const DEFAULT_ALGORITHM = 'SHA1';
-    public const SUPPORTED_ALGORITHM = [
-        OPENSSL_ALGO_SHA1 => 'SHA1',
+
+    /**
+     * Supported signing algorithms, keyed by their canonical (normalized)
+     * name. Values are unused sentinels — presence via isset() is the check.
+     */
+    public const SUPPORTED_ALGORITHMS = [
+        'SHA1'   => true,
+        'SHA256' => true,
+    ];
+
+    /**
+     * Mapping of OpenSSL algorithm integer constants to their canonical
+     * string name. Used to normalize callers who pass e.g. OPENSSL_ALGO_SHA256
+     * into the string form stored in {@see self::$algorithm}.
+     */
+    private const OPENSSL_ALGORITHM_NAMES = [
+        OPENSSL_ALGO_SHA1   => 'SHA1',
         OPENSSL_ALGO_SHA256 => 'SHA256',
     ];
 
@@ -20,17 +35,27 @@ class Signer
      * A signer for creating the signature values used in CloudFront signed URLs
      * and signed cookies.
      *
-     * @param $keyPairId  string     ID of the key pair
-     * @param $privateKey string     Path to the private key used for signing
-     * @param $passphrase string     Passphrase to private key file, if one exists
-     * @param $algorithm  int|string Algorithm (name or openssl constant) to be used. Defaults to SHA1.
-     *                                Supported algorithms are SHA1 and SHA256.
+     * @param string     $keyPairId  ID of the key pair.
+     * @param string     $privateKey Path to the private key used for signing,
+     *                               or a PEM-encoded key string.
+     * @param string     $passphrase Passphrase to private key file, if one exists.
+     * @param int|string $algorithm  Signing hash algorithm. Accepts either an
+     *                               OpenSSL constant (OPENSSL_ALGO_SHA1,
+     *                               OPENSSL_ALGO_SHA256) or the canonical name
+     *                               string ("SHA1", "SHA256"). Defaults to SHA1.
      *
-     * @throws \RuntimeException if the openssl extension is missing
-     * @throws \InvalidArgumentException if the private key cannot be found or the passed algorithm is not supported.
+     * @throws \RuntimeException if the openssl extension is missing.
+     * @throws \InvalidArgumentException if the private key cannot be found,
+     *                                   the key type is not supported by
+     *                                   CloudFront (RSA or ECDSA P-256), or
+     *                                   the requested algorithm is not supported.
      */
-    public function __construct($keyPairId, $privateKey, $passphrase = "", $algorithm = self::DEFAULT_ALGORITHM)
-    {
+    public function __construct(
+        $keyPairId,
+        $privateKey,
+        $passphrase = "",
+        string|int $algorithm = self::DEFAULT_ALGORITHM
+    ) {
         if (!extension_loaded('openssl')) {
             //@codeCoverageIgnoreStart
             throw new \RuntimeException('The openssl extension is required to '
@@ -40,9 +65,18 @@ class Signer
 
         $this->keyPairId = $keyPairId;
 
-        $algorithm = \strtoupper(self::SUPPORTED_ALGORITHM[$algorithm] ?? $algorithm);
-        if (!\in_array($algorithm, self::SUPPORTED_ALGORITHM)) {
-            throw new \InvalidArgumentException("Unsupported signature algorithm: $algorithm");
+        // Normalize an OpenSSL integer constant to its canonical string form,
+        // then uppercase for consistent comparison. After this, $algorithm is
+        // always the canonical string (matching DEFAULT_ALGORITHM's storage).
+        if (is_int($algorithm) && isset(self::OPENSSL_ALGORITHM_NAMES[$algorithm])) {
+            $algorithm = self::OPENSSL_ALGORITHM_NAMES[$algorithm];
+        }
+        $algorithm = strtoupper((string) $algorithm);
+        if (!isset(self::SUPPORTED_ALGORITHMS[$algorithm])) {
+            throw new \InvalidArgumentException(
+                "Unsupported signature algorithm: {$algorithm}. Supported algorithms are: "
+                . implode(', ', array_keys(self::SUPPORTED_ALGORITHMS)) . '.'
+            );
         }
 
         $this->algorithm = $algorithm;
@@ -61,13 +95,54 @@ class Signer
                 throw new \InvalidArgumentException(implode("\n",$errorMessages));
             }
         }
+
+        $this->validateKeyType($this->pkHandle);
     }
 
-    public function __destruct()
+    /**
+     * Ensures the loaded key is one CloudFront can verify: RSA of any modulus
+     * size, or ECDSA on the P-256 curve (prime256v1 / secp256r1). Anything
+     * else (DSA, EdDSA, EC on a non-P-256 curve, etc.) is rejected with an
+     * actionable error message rather than surfacing as an opaque openssl_sign
+     * failure at signing time.
+     *
+     * @param \OpenSSLAsymmetricKey|resource $pkHandle
+     *
+     * @throws \InvalidArgumentException on unsupported key material.
+     */
+    private function validateKeyType($pkHandle): void
     {
-        if (PHP_MAJOR_VERSION < 8) {
-            $this->pkHandle && openssl_pkey_free($this->pkHandle);
+        $details = openssl_pkey_get_details($pkHandle);
+        if ($details === false) {
+            throw new \InvalidArgumentException(
+                'Unable to read the details of the provided private key.'
+            );
         }
+
+        $type = $details['type'] ?? null;
+        if ($type === OPENSSL_KEYTYPE_RSA) {
+            return;
+        }
+
+        if (defined('OPENSSL_KEYTYPE_EC') && $type === OPENSSL_KEYTYPE_EC) {
+            $curve = $details['ec']['curve_name'] ?? 'unknown';
+            // OpenSSL reports the P-256 curve as either "prime256v1" (its
+            // canonical name) or "secp256r1" (SEC 2 alias); accept both.
+            if ($curve === 'prime256v1' || $curve === 'secp256r1') {
+                return;
+            }
+
+            throw new \InvalidArgumentException(
+                "Unsupported CloudFront key type: ECDSA on curve '{$curve}'. "
+                . 'CloudFront requires ECDSA keys to be on the P-256 curve '
+                . '(prime256v1 / secp256r1).'
+            );
+        }
+
+        throw new \InvalidArgumentException(
+            'Unsupported CloudFront key type. CloudFront requires an RSA or '
+            . 'ECDSA P-256 (prime256v1) private key.'
+        );
     }
 
     /**

--- a/src/CloudFront/UrlSigner.php
+++ b/src/CloudFront/UrlSigner.php
@@ -15,15 +15,13 @@ class UrlSigner
     /**
      * @param $keyPairId  string     ID of the key pair
      * @param $privateKey string     Path to the private key used for signing
-     * @param $algorithm  int|string OpenSSL signature algorithm constant (e.g.
-     *                               OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or
-     *                               algorithm name string (e.g. "sha256").
-     *                               Defaults to OPENSSL_ALGO_SHA1.
+     * @param $algorithm  int|string Algorithm (name or openssl constant) to be used. Defaults to SHA1.
+     *                               Supported algorithms are SHA1 and SHA256.
      *
      * @throws \RuntimeException if the openssl extension is missing
-     * @throws \InvalidArgumentException if the private key cannot be found.
+     * @throws \InvalidArgumentException if the private key cannot be found or the passed algorithm is not supported.
      */
-    public function __construct($keyPairId, $privateKey, $algorithm = OPENSSL_ALGO_SHA1)
+    public function __construct($keyPairId, $privateKey, $algorithm = Signer::DEFAULT_ALGORITHM)
     {
         $this->signer = new Signer($keyPairId, $privateKey, '', $algorithm);
     }

--- a/src/CloudFront/UrlSigner.php
+++ b/src/CloudFront/UrlSigner.php
@@ -13,15 +13,19 @@ class UrlSigner
     private $signer;
 
     /**
-     * @param $keyPairId  string ID of the key pair
-     * @param $privateKey string Path to the private key used for signing
+     * @param $keyPairId  string     ID of the key pair
+     * @param $privateKey string     Path to the private key used for signing
+     * @param $algorithm  int|string OpenSSL signature algorithm constant (e.g.
+     *                               OPENSSL_ALGO_SHA1, OPENSSL_ALGO_SHA256) or
+     *                               algorithm name string (e.g. "sha256").
+     *                               Defaults to OPENSSL_ALGO_SHA1.
      *
      * @throws \RuntimeException if the openssl extension is missing
      * @throws \InvalidArgumentException if the private key cannot be found.
      */
-    public function __construct($keyPairId, $privateKey)
+    public function __construct($keyPairId, $privateKey, $algorithm = OPENSSL_ALGO_SHA1)
     {
-        $this->signer = new Signer($keyPairId, $privateKey);
+        $this->signer = new Signer($keyPairId, $privateKey, '', $algorithm);
     }
 
     /**

--- a/src/CloudFront/UrlSigner.php
+++ b/src/CloudFront/UrlSigner.php
@@ -13,18 +13,25 @@ class UrlSigner
     private $signer;
 
     /**
-     * @param $keyPairId  string     ID of the key pair
-     * @param $privateKey string     Path to the private key used for signing
-     * @param $algorithm  int|string Algorithm (name or openssl constant) to be used. Defaults to SHA1.
-     *                               Supported algorithms are SHA1 and SHA256.
+     * @param string     $keyPairId  ID of the key pair.
+     * @param string     $privateKey Path to the private key used for signing,
+     *                               or a PEM-encoded key string.
+     * @param int|string $algorithm  Signing hash algorithm. Accepts either an
+     *                               OpenSSL constant (OPENSSL_ALGO_SHA1,
+     *                               OPENSSL_ALGO_SHA256) or the canonical name
+     *                               string ("SHA1", "SHA256"). Defaults to SHA1.
      *
-     * @throws \RuntimeException if the openssl extension is missing
-     * @throws \InvalidArgumentException if the private key cannot be found or the passed algorithm is not supported.
+     * @throws \RuntimeException if the openssl extension is missing.
+     * @throws \InvalidArgumentException if the private key cannot be found,
+     *                                   the key type is not supported by
+     *                                   CloudFront (RSA or ECDSA P-256), or
+     *                                   the requested algorithm is not supported.
      */
     public function __construct($keyPairId, $privateKey, $algorithm = Signer::DEFAULT_ALGORITHM)
     {
         $this->signer = new Signer($keyPairId, $privateKey, '', $algorithm);
     }
+
 
     /**
      * Create a signed Amazon CloudFront URL.

--- a/tests/CloudFront/CookieSignerTest.php
+++ b/tests/CloudFront/CookieSignerTest.php
@@ -74,6 +74,15 @@ class CookieSignerTest extends TestCase
 
     public function testSha256CookieIncludesHashAlgorithmAttribute()
     {
+        $s = new CookieSigner('a', $this->key, 'SHA256');
+        $cookie = $s->getSignedCookie('https://bar.com', strtotime('+10 minutes'));
+
+        $this->assertArrayHasKey('CloudFront-Hash-Algorithm', $cookie);
+        $this->assertSame('SHA256', $cookie['CloudFront-Hash-Algorithm']);
+    }
+
+    public function testSha256ConstantCookieIncludesHashAlgorithmAttribute()
+    {
         $s = new CookieSigner('a', $this->key, OPENSSL_ALGO_SHA256);
         $cookie = $s->getSignedCookie('https://bar.com', strtotime('+10 minutes'));
 

--- a/tests/CloudFront/CookieSignerTest.php
+++ b/tests/CloudFront/CookieSignerTest.php
@@ -72,6 +72,23 @@ class CookieSignerTest extends TestCase
         $this->assertArrayNotHasKey('CloudFront-Policy', $cookie);
     }
 
+    public function testSha256CookieIncludesHashAlgorithmAttribute()
+    {
+        $s = new CookieSigner('a', $this->key, OPENSSL_ALGO_SHA256);
+        $cookie = $s->getSignedCookie('https://bar.com', strtotime('+10 minutes'));
+
+        $this->assertArrayHasKey('CloudFront-Hash-Algorithm', $cookie);
+        $this->assertSame('SHA256', $cookie['CloudFront-Hash-Algorithm']);
+    }
+
+    public function testSha1CookieOmitsHashAlgorithmAttribute()
+    {
+        $s = new CookieSigner('a', $this->key);
+        $cookie = $s->getSignedCookie('https://bar.com', strtotime('+10 minutes'));
+
+        $this->assertArrayNotHasKey('CloudFront-Hash-Algorithm', $cookie);
+    }
+
     public function testReturnsHashWithCookieParameterNamesForCustomPolicy()
     {
         $s = new CookieSigner('a', $this->key);

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -95,6 +95,14 @@ class SignerTest extends TestCase
         $this->assertDoesNotMatchRegularExpression('/[\+\=\/]/', $signature['Signature']);
     }
 
+    public function testSignsWithUnsupportedAlgorithmThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported signature algorithm: SHA512');
+
+        new Signer('test', $this->testKeyFile, self::PASSPHRASE, 'sha512');
+    }
+
     public function testSha1SignatureOmitsHashAlgorithmParam()
     {
         $signature = $this->instance->getSignature('test.mp4', time() + 1000);

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -78,6 +78,30 @@ class SignerTest extends TestCase
         $this->assertArrayHasKey('Key-Pair-Id', $signature);
     }
 
+    public function testSignsWithAlternativeAlgorithm()
+    {
+        $sha256Signer = new Signer(
+            'test',
+            $this->testKeyFile,
+            self::PASSPHRASE,
+            OPENSSL_ALGO_SHA256
+        );
+        $signature = $sha256Signer->getSignature('test.mp4', time() + 1000);
+
+        $this->assertArrayHasKey('Signature', $signature);
+        $this->assertArrayHasKey('Key-Pair-Id', $signature);
+        $this->assertArrayHasKey('Hash-Algorithm', $signature);
+        $this->assertSame('SHA256', $signature['Hash-Algorithm']);
+        $this->assertDoesNotMatchRegularExpression('/[\+\=\/]/', $signature['Signature']);
+    }
+
+    public function testSha1SignatureOmitsHashAlgorithmParam()
+    {
+        $signature = $this->instance->getSignature('test.mp4', time() + 1000);
+
+        $this->assertArrayNotHasKey('Hash-Algorithm', $signature);
+    }
+
     /**
      * @return array<array<int|string>>
      */

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -86,13 +86,27 @@ class SignerTest extends TestCase
             self::PASSPHRASE,
             OPENSSL_ALGO_SHA256
         );
-        $signature = $sha256Signer->getSignature('test.mp4', time() + 1000);
+
+        $policy = '{"Statement":[{"Resource":"test.mp4","Condition":{"DateLessThan":{"AWS:EpochTime":1470000000}}}]}';
+        $signature = $sha256Signer->getSignature(null, null, $policy);
 
         $this->assertArrayHasKey('Signature', $signature);
         $this->assertArrayHasKey('Key-Pair-Id', $signature);
         $this->assertArrayHasKey('Hash-Algorithm', $signature);
         $this->assertSame('SHA256', $signature['Hash-Algorithm']);
-        $this->assertDoesNotMatchRegularExpression('/[\+\=\/]/', $signature['Signature']);
+
+        // Verify the signature using the public key
+        $pubKey = openssl_pkey_get_details(
+            openssl_pkey_get_private("file://{$this->testKeyFile}", self::PASSPHRASE)
+        )['key'];
+
+        $decodedSignature = base64_decode(strtr($signature['Signature'], '-_~', '+=/'));
+
+        $this->assertSame(1, openssl_verify($policy, $decodedSignature, $pubKey, OPENSSL_ALGO_SHA256));
+        $this->assertSame(
+            'FYeSxAa0dBVIgRRYx3MIZqLByin2vkrE1hNHa-tNuWkGYWVGjDowyx7RT6C5sbb3tOori74BJhoAYmG8QgmXKb6Gia69kOmgmVv4CkSvXsjb4AcRalDheZXVt7xaAQKSMk27uhleAiompseAhZY~GPlJe818JIIoq8BJpjvj1py8yX8p5Py~qDM1vbEkGCXz7sayzwQ8cLLfXa087aQW2PsUt6tUpdb~CAaJMjodlaTDAZg~3DtM4AHoYnf0~zuhbJDzmTgDjX19cejjU35WWyxBcyOloYgM8WCkl2DP4BX-wBLUxEDeH5hOlTMuqiCH4lBt2aBi~OD6yj20toQZiQ__',
+            $signature['Signature']
+        );
     }
 
     public function testSignsWithUnsupportedAlgorithmThrowsException()

--- a/tests/CloudFront/SignerTest.php
+++ b/tests/CloudFront/SignerTest.php
@@ -124,6 +124,70 @@ class SignerTest extends TestCase
         $this->assertArrayNotHasKey('Hash-Algorithm', $signature);
     }
 
+    public function testAcceptsEcdsaP256Key()
+    {
+        $key = openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name'       => 'prime256v1',
+        ]);
+        if ($key === false) {
+            $this->markTestSkipped('OpenSSL build does not support prime256v1 EC keys');
+        }
+        openssl_pkey_export($key, $pem);
+
+        // ECDSA + SHA-256 is the mandatory CloudFront combo per the SEP.
+        $signer = new Signer('kp', $pem, '', OPENSSL_ALGO_SHA256);
+
+        $resource = 'https://example.com/video.mp4';
+        $expires  = time() + 600;
+        $sig      = $signer->getSignature($resource, $expires);
+
+        $this->assertArrayHasKey('Signature', $sig);
+        $this->assertSame('SHA256', $sig['Hash-Algorithm']);
+
+        // ECDSA signatures are non-deterministic, so cryptographically verify
+        // against the public key rather than assert a fixed expected value.
+        $pubPem  = openssl_pkey_get_details($key)['key'];
+        $decoded = base64_decode(strtr($sig['Signature'], '-_~', '+=/'));
+        $policy  = '{"Statement":[{"Resource":"' . $resource
+            . '","Condition":{"DateLessThan":{"AWS:EpochTime":' . $sig['Expires'] . '}}}]}';
+
+        $this->assertSame(1, openssl_verify($policy, $decoded, $pubPem, OPENSSL_ALGO_SHA256));
+    }
+
+    public function testRejectsEcdsaKeyOnNonP256Curve()
+    {
+        $key = @openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_EC,
+            'curve_name'       => 'secp384r1',
+        ]);
+        if ($key === false) {
+            $this->markTestSkipped('OpenSSL build does not support secp384r1 EC keys');
+        }
+        openssl_pkey_export($key, $pem);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/ECDSA on curve 'secp384r1'.*P-256/s");
+        new Signer('kp', $pem);
+    }
+
+    public function testRejectsDsaKey()
+    {
+        $key = @openssl_pkey_new([
+            'private_key_type' => OPENSSL_KEYTYPE_DSA,
+            'private_key_bits' => 1024,
+        ]);
+        if ($key === false) {
+            $this->markTestSkipped('OpenSSL build does not support DSA key generation');
+        }
+        openssl_pkey_export($key, $pem);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/RSA or ECDSA P-256/');
+        new Signer('kp', $pem);
+    }
+
+
     /**
      * @return array<array<int|string>>
      */


### PR DESCRIPTION
*Issue #, if available:*
#3315 

*Description of changes:*
Adds SHA-256 support for CloudFront `Signer`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
