### PR TITLE
Set DEFAULT_TOKEN_TTL_SECONDS const as string type

### DIFF
--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -7,8 +7,8 @@ use Aws\Exception\InvalidJsonException;
 use Aws\Sdk;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -26,7 +26,7 @@ class InstanceProfileProvider
     const CFG_EC2_METADATA_SERVICE_ENDPOINT_MODE = 'ec2_metadata_service_endpoint_mode';
     const DEFAULT_TIMEOUT = 1.0;
     const DEFAULT_RETRIES = 3;
-    const DEFAULT_TOKEN_TTL_SECONDS = 21600;
+    const DEFAULT_TOKEN_TTL_SECONDS = '21600';
     const DEFAULT_AWS_EC2_METADATA_V1_DISABLED = false;
     const ENDPOINT_MODE_IPv4 = 'IPv4';
     const ENDPOINT_MODE_IPv6 = 'IPv6';


### PR DESCRIPTION
This deprecation warning appears on the `x-aws-ec2-metadata-token-ttl-seconds` header for PHP 8.2: 

```
Since guzzlehttp/psr7 2.11: Passing int to MessageInterface::withHeader() is deprecated; guzzlehttp/psr7 3.0 requires string|string[]. in /var/app/current/vendor/symfony/deprecation-contracts/function.php on line 25
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
