### PR TITLE
Normalize metadata service timeouts

### DIFF
--- a/.changes/nextrelease/normalize-timeouts.json
+++ b/.changes/nextrelease/normalize-timeouts.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "Credentials",
+    "description": "Normalizes numeric-string metadata timeouts to floats in the ECS and instance profile credential providers while preserving their existing configuration and environment precedence."
+  }
+]

--- a/src/Credentials/EcsCredentialProvider.php
+++ b/src/Credentials/EcsCredentialProvider.php
@@ -51,9 +51,8 @@ class EcsCredentialProvider
      */
     public function __construct(array $config = [])
     {
-        $this->timeout = (float) isset($config['timeout'])
-            ? $config['timeout']
-            : (getenv(self::ENV_TIMEOUT) ?: self::DEFAULT_ENV_TIMEOUT);
+        $timeout = $config['timeout'] ?? (getenv(self::ENV_TIMEOUT) ?: self::DEFAULT_ENV_TIMEOUT);
+        $this->timeout = is_string($timeout) && is_numeric($timeout) ? (float) $timeout : $timeout;
         $this->retries = (int) isset($config['retries'])
             ? $config['retries']
             : ((int) getenv(self::ENV_RETRIES) ?: self::DEFAULT_ENV_RETRIES);

--- a/src/Credentials/InstanceProfileProvider.php
+++ b/src/Credentials/InstanceProfileProvider.php
@@ -82,7 +82,8 @@ class InstanceProfileProvider
      */
     public function __construct(array $config = [])
     {
-        $this->timeout = (float) getenv(self::ENV_TIMEOUT) ?: ($config['timeout'] ?? self::DEFAULT_TIMEOUT);
+        $timeout = (float) getenv(self::ENV_TIMEOUT) ?: ($config['timeout'] ?? self::DEFAULT_TIMEOUT);
+        $this->timeout = is_string($timeout) && is_numeric($timeout) ? (float) $timeout : $timeout;
         $this->profile = $config['profile'] ?? null;
         $this->retries = (int) getenv(self::ENV_RETRIES) ?: ($config['retries'] ?? self::DEFAULT_RETRIES);
         $this->client = $config['client'] ?? \Aws\default_http_handler();

--- a/tests/Credentials/EcsCredentialProviderTest.php
+++ b/tests/Credentials/EcsCredentialProviderTest.php
@@ -108,6 +108,47 @@ class EcsCredentialProviderTest extends TestCase
         new EcsCredentialProvider();
     }
 
+    #[DataProvider('timeoutProvider')]
+    public function testNormalizesTimeout(array $config, $environmentTimeout)
+    {
+        $originalTimeout = getenv(EcsCredentialProvider::ENV_TIMEOUT);
+        if ($environmentTimeout === null) {
+            putenv(EcsCredentialProvider::ENV_TIMEOUT);
+        } else {
+            putenv(EcsCredentialProvider::ENV_TIMEOUT . '=' . $environmentTimeout);
+        }
+
+        try {
+            $expiration = time() + 1000;
+            $response = new Response(200, [], json_encode(
+                self::getCredentialArray('foo', 'baz', null, "@{$expiration}")
+            ));
+            $config['client'] = function (
+                RequestInterface $request,
+                array $options
+            ) use ($response) {
+                $this->assertSame(1.5, $options['timeout']);
+                return Promise\Create::promiseFor($response);
+            };
+
+            (new EcsCredentialProvider($config))()->wait();
+        } finally {
+            if ($originalTimeout === false) {
+                putenv(EcsCredentialProvider::ENV_TIMEOUT);
+            } else {
+                putenv(EcsCredentialProvider::ENV_TIMEOUT . '=' . $originalTimeout);
+            }
+        }
+    }
+
+    public static function timeoutProvider()
+    {
+        return [
+            'configuration' => [['timeout' => '1.5'], null],
+            'environment' => [[], '1.5'],
+        ];
+    }
+
     public function testRequestHeaderWithAuthorisationKey()
     {
         $TOKEN_VALUE = "GA%24102391AAA+BBBBB4==";

--- a/tests/Credentials/InstanceProfileProviderTest.php
+++ b/tests/Credentials/InstanceProfileProviderTest.php
@@ -949,6 +949,43 @@ class InstanceProfileProviderTest extends TestCase
         new InstanceProfileProvider();
     }
 
+    public function testNormalizesConfiguredTimeout()
+    {
+        $originalTimeout = getenv(InstanceProfileProvider::ENV_TIMEOUT);
+        putenv(InstanceProfileProvider::ENV_TIMEOUT);
+
+        try {
+            $expiration = time() + 1000;
+            $responses = [
+                new Response(200, [], 'token'),
+                new Response(200, [], json_encode(
+                    self::getCredentialArray('foo', 'baz', null, "@{$expiration}")
+                )),
+            ];
+            $client = function (
+                RequestInterface $request,
+                array $options
+            ) use (&$responses) {
+                $this->assertSame(1.5, $options['timeout']);
+                return Promise\Create::promiseFor(array_shift($responses));
+            };
+            $provider = new InstanceProfileProvider([
+                'client' => $client,
+                'profile' => 'MockProfile',
+                'timeout' => '1.5',
+            ]);
+
+            $credentials = $provider()->wait();
+            $this->assertSame('foo', $credentials->getAccessKeyId());
+        } finally {
+            if ($originalTimeout === false) {
+                putenv(InstanceProfileProvider::ENV_TIMEOUT);
+            } else {
+                putenv(InstanceProfileProvider::ENV_TIMEOUT . '=' . $originalTimeout);
+            }
+        }
+    }
+
     #[DoesNotPerformAssertions]
     public function testEnvDisableFlag()
     {


### PR DESCRIPTION
Guzzle 7.15 deprecates numeric strings for request timeouts, and Guzzle 8 rejects them. This normalizes numeric-string metadata timeouts to floats in the ECS and instance profile credential providers while preserving their existing configuration and environment precedence.