### PR TITLE
bugfix: retry behavior

### DIFF
--- a/.changes/nextrelease/bugfix-retries.json
+++ b/.changes/nextrelease/bugfix-retries.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "enhancement",
+    "category": "Retries",
+    "description": "Updated the opt-in retry path (AWS_NEW_RETRIES_2026) to emit SEP-compliant retry headers, honor AWS_MAX_ATTEMPTS and shared-config max_attempts, and align long-polling retry behavior with the new retry spec."
+  }
+]

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -265,7 +265,7 @@ final class Middleware
                 RequestInterface $request
             ) use ($handler){
                 return $handler($command, $request->withHeader(
-                    'aws-sdk-invocation-id',
+                    'amz-sdk-invocation-id',
                     md5(uniqid(gethostname(), true))
                 ));
             };

--- a/src/Retry/ConfigurationProvider.php
+++ b/src/Retry/ConfigurationProvider.php
@@ -108,17 +108,21 @@ class ConfigurationProvider extends AbstractConfigurationProvider
         return function () {
             // Use config from environment variables, if available
             $mode = getenv(self::ENV_MODE);
-            $maxAttempts = getenv(self::ENV_MAX_ATTEMPTS)
-                ? getenv(self::ENV_MAX_ATTEMPTS)
-                : self::DEFAULT_MAX_ATTEMPTS;
-            if (!empty($mode)) {
+            $maxAttempts = getenv(self::ENV_MAX_ATTEMPTS);
+            $hasMode = $mode !== false && $mode !== '';
+            $hasMaxAttempts = $maxAttempts !== false && $maxAttempts !== '';
+
+            if ($hasMode || $hasMaxAttempts) {
                 return Promise\Create::promiseFor(
-                    new Configuration($mode, $maxAttempts)
-                );
+                    new Configuration(
+                        $hasMode ? $mode : self::getDefaultMode(),
+                        $hasMaxAttempts ? $maxAttempts : self::DEFAULT_MAX_ATTEMPTS
+                    ));
             }
 
             return self::reject('Could not find environment variable config'
-                . ' in ' . self::ENV_MODE);
+                . ' in ' . self::ENV_MODE
+                . ' or ' . self::ENV_MAX_ATTEMPTS);
         };
     }
 
@@ -175,18 +179,27 @@ class ConfigurationProvider extends AbstractConfigurationProvider
             if (!isset($data[$profile])) {
                 return self::reject("'$profile' not found in config file");
             }
-            if (!isset($data[$profile][self::INI_MODE])) {
+            $hasMode = isset($data[$profile][self::INI_MODE])
+                && $data[$profile][self::INI_MODE] !== '';
+            $hasMaxAttempts = array_key_exists(
+                self::INI_MAX_ATTEMPTS,
+                $data[$profile]
+            ) && $data[$profile][self::INI_MAX_ATTEMPTS] !== '';
+
+            if (!$hasMode && !$hasMaxAttempts) {
                 return self::reject("Required retry config values
                     not present in INI profile '{$profile}' ({$filename})");
             }
 
-            $maxAttempts = isset($data[$profile][self::INI_MAX_ATTEMPTS])
+            $maxAttempts = $hasMaxAttempts
                 ? $data[$profile][self::INI_MAX_ATTEMPTS]
                 : self::DEFAULT_MAX_ATTEMPTS;
 
             return Promise\Create::promiseFor(
                 new Configuration(
-                    $data[$profile][self::INI_MODE],
+                    $hasMode
+                        ? $data[$profile][self::INI_MODE]
+                        : self::getDefaultMode(),
                     $maxAttempts
                 )
             );

--- a/src/Retry/RetryHelperTrait.php
+++ b/src/Retry/RetryHelperTrait.php
@@ -6,9 +6,14 @@ use Aws\ResultInterface;
 
 trait RetryHelperTrait
 {
-    private function addRetryHeader($request, $retries, $delayBy)
+    private function addRetryHeader($request, $retries, $maxAttempts = null)
     {
-        return $request->withHeader('aws-sdk-retry', "{$retries}/{$delayBy}");
+        $header = ['attempt=' . ($retries + 1)];
+        if ($maxAttempts !== null) {
+            $header[] = 'max=' . $maxAttempts;
+        }
+
+        return $request->withHeader('amz-sdk-request', implode('; ', $header));
     }
 
 

--- a/src/Retry/V3/RetryMiddleware.php
+++ b/src/Retry/V3/RetryMiddleware.php
@@ -75,6 +75,16 @@ class RetryMiddleware
 
     public static function wrap(ConfigurationInterface $config, array $options): \Closure
     {
+        if (!isset($options['quota_manager'])) {
+            $options['quota_manager'] = new QuotaManager();
+        }
+
+        if ($config->getMode() === 'adaptive'
+            && !isset($options['rate_limiter'])
+        ) {
+            $options['rate_limiter'] = new RateLimiter();
+        }
+
         return function (callable $handler) use ($config, $options) {
             return new static($config, $handler, $options);
         };
@@ -134,7 +144,7 @@ class RetryMiddleware
         $requestStats = [];
         $capacityUsed = null;
 
-        $req = $this->addRetryHeader($req, 0, 0);
+        $req = $this->addRetryHeader($req, 0, $this->resolveMaxAttempts($cmd));
 
         $callback = function ($value) use (
             $handler,
@@ -200,9 +210,7 @@ class RetryMiddleware
             }
 
             // Max attempts is checked before retry quota.
-            $maxAttempts = ($cmd['@retries'] !== null)
-                ? $cmd['@retries'] + 1
-                : $this->maxAttempts;
+            $maxAttempts = $this->resolveMaxAttempts($cmd);
 
             if ($attempts >= $maxAttempts) {
                 if ($value instanceof AwsException) {
@@ -256,7 +264,11 @@ class RetryMiddleware
                 $this->updateStats($attempts - 1, $delayByMs, $requestStats);
             }
 
-            $req = $this->addRetryHeader($req, $attempts - 1, $delayByMs);
+            $req = $this->addRetryHeader(
+                $req,
+                $attempts - 1,
+                $maxAttempts
+            );
 
             if ($this->mode === 'adaptive') {
                 $this->rateLimiter->getSendToken();
@@ -414,5 +426,12 @@ class RetryMiddleware
         }
 
         return false;
+    }
+
+    private function resolveMaxAttempts(CommandInterface $cmd): int
+    {
+        return ($cmd['@retries'] !== null)
+            ? $cmd['@retries'] + 1
+            : $this->maxAttempts;
     }
 }

--- a/src/RetryMiddleware.php
+++ b/src/RetryMiddleware.php
@@ -190,7 +190,11 @@ class RetryMiddleware
         $decider = $this->decider;
         $delay = $this->delay;
 
-        $request = $this->addRetryHeader($request, 0, 0);
+        $request = $this->addRetryHeader(
+            $request,
+            0,
+            $command['@retries'] !== null ? $command['@retries'] + 1 : null
+        );
 
         $g = function ($value) use (
             $handler,
@@ -234,7 +238,11 @@ class RetryMiddleware
             }
 
             // Update retry header with retry count and delayBy
-            $request = $this->addRetryHeader($request, $retries, $delayBy);
+            $request = $this->addRetryHeader(
+                $request,
+                $retries,
+                $command['@retries'] !== null ? $command['@retries'] + 1 : null
+            );
 
             return $handler($command, $request)->then($g, $g);
         };

--- a/src/RetryMiddlewareV2.php
+++ b/src/RetryMiddlewareV2.php
@@ -168,7 +168,7 @@ class RetryMiddlewareV2
         $monitoringEvents = [];
         $requestStats = [];
 
-        $req = $this->addRetryHeader($req, 0, 0);
+        $req = $this->addRetryHeader($req, 0, $this->resolveMaxAttempts($cmd));
 
         $callback = function ($value) use (
             $handler,
@@ -215,7 +215,11 @@ class RetryMiddlewareV2
             }
 
             // Update retry header with retry count and delayBy
-            $req = $this->addRetryHeader($req, $attempts - 1, $delayBy);
+            $req = $this->addRetryHeader(
+                $req,
+                $attempts - 1,
+                $this->resolveMaxAttempts($cmd)
+            );
 
             // Get token from rate limiter, which will sleep if necessary
             if ($this->mode === 'adaptive') {
@@ -351,5 +355,12 @@ class RetryMiddlewareV2
         }
 
         return false;
+    }
+
+    private function resolveMaxAttempts(CommandInterface $cmd)
+    {
+        return $cmd['@retries'] !== null
+            ? $cmd['@retries'] + 1
+            : $this->maxAttempts;
     }
 }

--- a/src/Signature/SignatureV4.php
+++ b/src/Signature/SignatureV4.php
@@ -66,8 +66,8 @@ class SignatureV4 implements SignatureInterface
             'referer'               => true,
             'user-agent'            => true,
             'x-amzn-trace-id'       => true,
-            'aws-sdk-invocation-id' => true,
-            'aws-sdk-retry'         => true,
+            'amz-sdk-invocation-id' => true,
+            'amz-sdk-request'       => true,
         ];
     }
 
@@ -498,8 +498,8 @@ class SignatureV4 implements SignatureInterface
     {
         static $illegalV4aHeaders = [
             self::AMZ_CONTENT_SHA256_HEADER,
-            'aws-sdk-invocation-id',
-            'aws-sdk-retry',
+            'amz-sdk-invocation-id',
+            'amz-sdk-request',
             'x-amz-region-set',
             'transfer-encoding',
         ];

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -79,7 +79,7 @@ class MiddlewareTest extends TestCase
     {
         $list = new HandlerList();
         $mock = function ($command, $request) {
-            $this->assertTrue($request->hasHeader('aws-sdk-invocation-id'));
+            $this->assertTrue($request->hasHeader('amz-sdk-invocation-id'));
             return Promise\Create::promiseFor(
                 new Result(['@metadata' => ['statusCode' => 200]])
             );

--- a/tests/Retry/ConfigurationProviderTest.php
+++ b/tests/Retry/ConfigurationProviderTest.php
@@ -92,6 +92,17 @@ EOT;
         $this->assertSame($expected->toArray(), $result->toArray());
     }
 
+    public function testCreatesFromEnvironmentMaxAttemptsUsingDefaultMode()
+    {
+        $this->clearEnv();
+        putenv(OptIn::ENV . '=true');
+        OptIn::reset();
+        $expected = new Configuration('standard', 17);
+        putenv(ConfigurationProvider::ENV_MAX_ATTEMPTS . '=17');
+        $result = call_user_func(ConfigurationProvider::env())->wait();
+        $this->assertSame($expected->toArray(), $result->toArray());
+    }
+
     public function testRejectsOnNoEnvironmentVars()
     {
         $this->clearEnv();
@@ -199,6 +210,19 @@ EOT;
         /** @var ConfigurationInterface $result */
         $result = call_user_func(ConfigurationProvider::ini())->wait();
         $this->assertEquals($expected->toArray(), $result->toArray());
+        unlink($dir . '/config');
+    }
+
+    public function testCreatesFromIniFileWithMaxAttemptsOnlyUsingDefaultMode()
+    {
+        $dir = $this->clearEnv();
+        putenv(OptIn::ENV . '=true');
+        OptIn::reset();
+        $expected = new Configuration('standard', 7);
+        file_put_contents($dir . '/config', "[default]\nmax_attempts = 7\n");
+        putenv('HOME=' . dirname($dir));
+        $result = call_user_func(ConfigurationProvider::ini(null, null))->wait();
+        $this->assertSame($expected->toArray(), $result->toArray());
         unlink($dir . '/config');
     }
 

--- a/tests/Retry/V3/RetryMiddlewareTest.php
+++ b/tests/Retry/V3/RetryMiddlewareTest.php
@@ -12,6 +12,7 @@ use Aws\ResultInterface;
 use Aws\Retry\Configuration;
 use Aws\Retry\ConfigurationProvider;
 use Aws\Retry\V3\QuotaManager;
+use Aws\Retry\V3\OptIn;
 use Aws\Retry\V3\RetryMiddleware;
 use Aws\Retry\RateLimiter;
 use GuzzleHttp\Promise\RejectedPromise;
@@ -27,6 +28,23 @@ use PHPUnit\Framework\Attributes\CoversClass;
 class RetryMiddlewareTest extends TestCase
 {
     use UsesServiceTrait;
+
+    private string $previousOptIn;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousOptIn = getenv(OptIn::ENV) ?: '';
+        putenv(OptIn::ENV . '=');
+        OptIn::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv(OptIn::ENV . '=' . $this->previousOptIn);
+        OptIn::reset();
+        parent::tearDown();
+    }
 
     /**
      * @param CommandInterface $command
@@ -711,8 +729,10 @@ class RetryMiddlewareTest extends TestCase
 
     public function testAddRetryHeader()
     {
-        $nextHandler = function (CommandInterface $command, RequestInterface $request) {
-            $this->assertTrue($request->hasHeader('aws-sdk-retry'));
+        $observedHeaders = [];
+        $nextHandler = function (CommandInterface $command, RequestInterface $request) use (&$observedHeaders) {
+            $this->assertTrue($request->hasHeader('amz-sdk-request'));
+            $observedHeaders[] = $request->getHeaderLine('amz-sdk-request');
             return new RejectedPromise(
                 new AwsException('e', $command, ['connection_error' => true])
             );
@@ -729,6 +749,17 @@ class RetryMiddlewareTest extends TestCase
             $retryMW(new Command('SomeCommand'), new Request('GET', ''))->wait();
             $this->fail();
         } catch (AwsException $e) { }
+
+        $this->assertSame(
+            [
+                'attempt=1; max=5',
+                'attempt=2; max=5',
+                'attempt=3; max=5',
+                'attempt=4; max=5',
+                'attempt=5; max=5',
+            ],
+            $observedHeaders
+        );
     }
 
     public function testDeciderRetriesWhenStatusCodeMatches()
@@ -1534,6 +1565,48 @@ class RetryMiddlewareTest extends TestCase
         ];
     }
 
+    public function testWrapSharesQuotaManagerState()
+    {
+        $this->enableOptInFlag();
+        $factory = RetryMiddleware::wrap(
+            new Configuration('standard', 3),
+            []
+        );
+
+        $first = $factory(static fn ($cmd, $req) => null);
+        $second = $factory(static fn ($cmd, $req) => null);
+
+        $this->assertInstanceOf(
+            QuotaManager::class,
+            $this->getPrivateProperty($first, 'quotaManager')
+        );
+        $this->assertSame(
+            $this->getPrivateProperty($first, 'quotaManager'),
+            $this->getPrivateProperty($second, 'quotaManager')
+        );
+    }
+
+    public function testWrapSharesAdaptiveRateLimiterState()
+    {
+        $this->enableOptInFlag();
+        $factory = RetryMiddleware::wrap(
+            new Configuration('adaptive', 3),
+            []
+        );
+
+        $first = $factory(static fn ($cmd, $req) => null);
+        $second = $factory(static fn ($cmd, $req) => null);
+
+        $this->assertInstanceOf(
+            RateLimiter::class,
+            $this->getPrivateProperty($first, 'rateLimiter')
+        );
+        $this->assertSame(
+            $this->getPrivateProperty($first, 'rateLimiter'),
+            $this->getPrivateProperty($second, 'rateLimiter')
+        );
+    }
+
     public function testRetryAfterHeaderClamping()
     {
         $command = new Command('foo');
@@ -1639,5 +1712,20 @@ class RetryMiddlewareTest extends TestCase
         $wrapped($command, $request)->wait();
         // retry-after=0 clamped to [50, 5050] = 50ms (the computed delay minimum)
         $this->assertSame(50, $delays[0]);
+    }
+
+    private function enableOptInFlag(): void
+    {
+        putenv(OptIn::ENV . '=true');
+        OptIn::reset();
+    }
+
+    private function getPrivateProperty(object $object, string $property): mixed
+    {
+        $reflection = new \ReflectionClass($object);
+        $prop = $reflection->getProperty($property);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($object);
     }
 }

--- a/tests/RetryMiddlewareTest.php
+++ b/tests/RetryMiddlewareTest.php
@@ -22,8 +22,10 @@ class RetryMiddlewareTest extends TestCase
 {
     public function testAddRetryHeader()
     {
-        $nextHandler = function (CommandInterface $command, RequestInterface $request) {
-            $this->assertTrue($request->hasHeader('aws-sdk-retry'));
+        $observedHeaders = [];
+        $nextHandler = function (CommandInterface $command, RequestInterface $request) use (&$observedHeaders) {
+            $this->assertTrue($request->hasHeader('amz-sdk-request'));
+            $observedHeaders[] = $request->getHeaderLine('amz-sdk-request');
             return new RejectedPromise(
                 new AwsException('e', $command, ['connection_error' => true])
             );
@@ -39,6 +41,11 @@ class RetryMiddlewareTest extends TestCase
             $retryMW(new Command('SomeCommand'), new Request('GET', ''))->wait();
             $this->fail();
         } catch (AwsException $e) { }
+
+        $this->assertSame(
+            ['attempt=1', 'attempt=2', 'attempt=3', 'attempt=4'],
+            $observedHeaders
+        );
     }
 
     public function testDeciderRetriesWhenStatusCodeMatches()

--- a/tests/RetryMiddlewareV2Test.php
+++ b/tests/RetryMiddlewareV2Test.php
@@ -455,8 +455,10 @@ class RetryMiddlewareV2Test extends TestCase
 
     public function testAddRetryHeader()
     {
-        $nextHandler = function (CommandInterface $command, RequestInterface $request) {
-            $this->assertTrue($request->hasHeader('aws-sdk-retry'));
+        $observedHeaders = [];
+        $nextHandler = function (CommandInterface $command, RequestInterface $request) use (&$observedHeaders) {
+            $this->assertTrue($request->hasHeader('amz-sdk-request'));
+            $observedHeaders[] = $request->getHeaderLine('amz-sdk-request');
             return new RejectedPromise(
                 new AwsException('e', $command, ['connection_error' => true])
             );
@@ -473,6 +475,17 @@ class RetryMiddlewareV2Test extends TestCase
             $retryMW(new Command('SomeCommand'), new Request('GET', ''))->wait();
             $this->fail();
         } catch (AwsException $e) { }
+
+        $this->assertSame(
+            [
+                'attempt=1; max=5',
+                'attempt=2; max=5',
+                'attempt=3; max=5',
+                'attempt=4; max=5',
+                'attempt=5; max=5',
+            ],
+            $observedHeaders
+        );
     }
 
     public function testDeciderRetriesWhenStatusCodeMatches()

--- a/tests/Signature/SignatureV4Test.php
+++ b/tests/Signature/SignatureV4Test.php
@@ -673,8 +673,8 @@ class SignatureV4Test extends TestCase
 
         static $headers = [
             'X-Amz-Content-Sha256' => 'blah',
-            'aws-sdk-invocation-id' => '1',
-            'aws-sdk-retry' => 'foo',
+            'amz-sdk-invocation-id' => '1',
+            'amz-sdk-request' => 'foo',
             'transfer-encoding' => 'chunked'
         ];
         $sig = new SignatureV4('foo', 'bar', ['use_v4a' => true]);

--- a/tests/Sts/StsClientTest.php
+++ b/tests/Sts/StsClientTest.php
@@ -477,4 +477,5 @@ class StsClientTest extends TestCase
 
         return $tokenPath;
     }
+
 }


### PR DESCRIPTION
*Description of changes:*
Aligns the PHP SDK’s new retry implementation with retry compliance tests by updating the opt-in V3 path to emit compliant retry headers, honor `AWS_MAX_ATTEMPTS` and shared-config max_attempts without requiring `retry_mode`, and preserve retry quota/rate-limiter state correctly across operations on the same client. The change also updates the PHP retry tests to cover the new behavior and long-polling/quota flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
