### PR TITLE
Add support for transport sharing

### DIFF
--- a/.changes/nextrelease/transport-sharing.json
+++ b/.changes/nextrelease/transport-sharing.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "feature",
+        "category": "Handler",
+        "description": "Adds support for Guzzle transport sharing (persistent connections) via the new transport_sharing client option."
+    }
+]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,11 @@ jobs:
             composer-options: '--prefer-lowest'
           - php-versions: '8.5'
             composer-options: ''
+          - php-versions: '8.4'
+            composer-options: ''
+            guzzle-version: '>=7.11 <8'
     # set the name for each job
-    name: PHP ${{ matrix.php-versions }} ${{ matrix.composer-options }}
+    name: PHP ${{ matrix.php-versions }} ${{ matrix.composer-options }} ${{ matrix.guzzle-version }}
     # set up environment variables used by unit tests
     env:
       AWS_ACCESS_KEY_ID: foo
@@ -79,6 +82,9 @@ jobs:
             fi
           else
             composer update ${{ matrix.composer-options }} --no-interaction --prefer-dist
+          fi
+          if [[ -n "${{ matrix.guzzle-version }}" ]]; then
+            composer require "guzzlehttp/guzzle:${{ matrix.guzzle-version }}" --no-interaction --with-all-dependencies
           fi
 
       # run tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,4 +28,7 @@ parameters:
     # These exception classes only exist in Guzzle 8, but instances cannot occur under Guzzle 7
     - '#Class GuzzleHttp\\Exception\\(NetworkException|ResponseException|ResponseTransferException) not found\.#'
 
+    # The transport sharing class only exists in Guzzle 7.11+ and 8; usage is guarded by feature detection
+    - '#Class GuzzleHttp\\TransportSharing not found\.#'
+
   reportUnmatchedIgnoredErrors: false

--- a/src/AwsClient.php
+++ b/src/AwsClient.php
@@ -204,6 +204,13 @@ class AwsClient implements AwsClientInterface
      *   signature version to use with a service (e.g., v4). Note that
      *   per/operation signature version MAY override this requested signature
      *   version.
+     * - transport_sharing: (string) Set to a transport sharing mode ("none",
+     *   "handler_prefer", "handler_require", "persistent_prefer", or
+     *   "persistent_require") to enable connection sharing on the default
+     *   HTTP handler. The "*_prefer" modes degrade gracefully when the
+     *   installed version of Guzzle or the runtime cannot honor them, and
+     *   the "*_require" modes throw. This option only applies when the SDK
+     *   creates the default HTTP handler.
      * - use_aws_shared_config_files: (bool, default=bool(true)) Set to false to
      *   disable checking for shared config file in '~/.aws/config' and
      *   '~/.aws/credentials'.  This will override the AWS_CONFIG_FILE

--- a/src/ClientResolver.php
+++ b/src/ClientResolver.php
@@ -30,6 +30,7 @@ use Aws\EndpointV2\EndpointDefinitionProvider;
 use Aws\EndpointV2\EndpointProviderV2;
 use Aws\Exception\AwsException;
 use Aws\Exception\InvalidRegionException;
+use Aws\Handler\HttpTransportSharing;
 use Aws\Retry\ConfigurationInterface as RetryConfigInterface;
 use Aws\Retry\ConfigurationProvider as RetryConfigProvider;
 use Aws\Retry\V3\OptIn as NewRetriesOptIn;
@@ -292,6 +293,12 @@ class ClientResolver
             'valid'   => ['array'],
             'default' => [],
             'doc'     => 'Set to an array of SDK request options to apply to each request (e.g., proxy, verify, etc.).',
+        ],
+        'transport_sharing' => [
+            'type'    => 'value',
+            'valid'   => ['string'],
+            'doc'     => 'Set to a transport sharing mode ("none", "handler_prefer", "handler_require", "persistent_prefer", or "persistent_require") to enable connection sharing on the default HTTP handler. The "*_prefer" modes degrade gracefully when the installed version of Guzzle or the runtime cannot honor them, and the "*_require" modes throw. This option only applies when the SDK creates the default HTTP handler, and the "*_require" modes throw when combined with a custom "handler" or "http_handler" option.',
+            'fn'      => [__CLASS__, '_apply_transport_sharing'],
         ],
         'http_handler' => [
             'type'    => 'value',
@@ -988,7 +995,7 @@ class ClientResolver
     public static function _default_handler(array &$args)
     {
         return new WrappedHttpHandler(
-            default_http_handler(),
+            default_http_handler($args['transport_sharing'] ?? null),
             $args['parser'],
             $args['error_parser'],
             $args['exception_class'],
@@ -1005,6 +1012,21 @@ class ClientResolver
             $args['exception_class'],
             $args['stats']['http']
         );
+    }
+
+    public static function _apply_transport_sharing($value, array &$args)
+    {
+        HttpTransportSharing::validate($value);
+
+        if ((isset($args['http_handler']) || isset($args['handler']))
+            && HttpTransportSharing::isRequired($value)
+        ) {
+            throw new IAE('The "transport_sharing" option can only'
+                . ' require transport sharing when the SDK creates the'
+                . ' default HTTP handler. Remove the "handler" or'
+                . ' "http_handler" option, or configure transport sharing'
+                . ' on the custom handler instead.');
+        }
     }
 
     public static function _apply_app_id($value, array &$args)

--- a/src/Handler/Guzzle/GuzzleHandler.php
+++ b/src/Handler/Guzzle/GuzzleHandler.php
@@ -2,6 +2,7 @@
 namespace Aws\Handler\Guzzle;
 
 use Aws\Handler\HttpHandlerError;
+use Aws\Handler\HttpTransportSharing;
 use GuzzleHttp\Utils;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Client;
@@ -18,11 +19,23 @@ class GuzzleHandler
     private $client;
 
     /**
-     * @param ClientInterface $client
+     * @param ClientInterface|null $client
+     * @param string|null          $transportSharing
      */
-    public function __construct(?ClientInterface $client = null)
-    {
-        $this->client = $client ?: new Client();
+    public function __construct(
+        ?ClientInterface $client = null,
+        ?string $transportSharing = null
+    ) {
+        if ($client !== null && HttpTransportSharing::isRequired($transportSharing)) {
+            throw new \InvalidArgumentException('The provided transport'
+                . ' sharing mode cannot require sharing when a client is'
+                . ' provided. Configure the "transport_sharing" option on'
+                . ' the provided client instead.');
+        }
+
+        $this->client = $client ?: new Client(
+            HttpTransportSharing::toClientConfig($transportSharing)
+        );
     }
 
     /**

--- a/src/Handler/HttpTransportSharing.php
+++ b/src/Handler/HttpTransportSharing.php
@@ -1,0 +1,118 @@
+<?php
+namespace Aws\Handler;
+
+use GuzzleHttp\TransportSharing;
+
+/**
+ * @internal
+ */
+final class HttpTransportSharing
+{
+    private const NONE = 'none';
+    private const HANDLER_PREFER = 'handler_prefer';
+    private const HANDLER_REQUIRE = 'handler_require';
+    private const PERSISTENT_PREFER = 'persistent_prefer';
+    private const PERSISTENT_REQUIRE = 'persistent_require';
+
+    private const MODES = [
+        self::NONE,
+        self::HANDLER_PREFER,
+        self::HANDLER_REQUIRE,
+        self::PERSISTENT_PREFER,
+        self::PERSISTENT_REQUIRE,
+    ];
+
+    public static function isRequired(?string $mode): bool
+    {
+        return $mode === self::HANDLER_REQUIRE
+            || $mode === self::PERSISTENT_REQUIRE;
+    }
+
+    /**
+     * Validates a requested transport sharing mode without resolving it
+     * against the capabilities of the installed version of Guzzle.
+     */
+    public static function validate(?string $mode): void
+    {
+        if ($mode !== null && !in_array($mode, self::MODES, true)) {
+            throw new \InvalidArgumentException('The provided transport'
+                . ' sharing mode "' . $mode . '" is invalid. Valid modes are:'
+                . ' "none", "handler_prefer", "handler_require",'
+                . ' "persistent_prefer", "persistent_require".');
+        }
+    }
+
+    /**
+     * Resolves a requested transport sharing mode to the mode that should be
+     * passed to the installed version of Guzzle, or null when no mode should
+     * be passed. The "*_prefer" modes degrade gracefully when the installed
+     * version of Guzzle cannot honor them, and the "*_require" modes throw.
+     */
+    public static function resolve(?string $mode): ?string
+    {
+        self::validate($mode);
+
+        if ($mode === null || $mode === self::NONE) {
+            return null;
+        }
+
+        // Guzzle 8: all modes are understood, and Guzzle enforces the
+        // runtime requirements of the "*_require" modes itself.
+        if (self::supportsPersistentSharing()) {
+            return $mode;
+        }
+
+        // Guzzle 7.11+: handler-lifetime sharing only.
+        if (self::supportsHandlerSharing()) {
+            if ($mode === self::PERSISTENT_PREFER) {
+                return self::HANDLER_PREFER;
+            }
+
+            if ($mode === self::PERSISTENT_REQUIRE) {
+                throw new \RuntimeException('The "persistent_require"'
+                    . ' transport sharing mode requires guzzlehttp/guzzle'
+                    . ' ^8.0.');
+            }
+
+            return $mode;
+        }
+
+        // Guzzle < 7.11: no transport sharing support.
+        if ($mode === self::PERSISTENT_REQUIRE) {
+            throw new \RuntimeException('The "persistent_require" transport'
+                . ' sharing mode requires guzzlehttp/guzzle ^8.0.');
+        }
+
+        if ($mode === self::HANDLER_REQUIRE) {
+            throw new \RuntimeException('The "handler_require" transport'
+                . ' sharing mode requires guzzlehttp/guzzle ^7.11 || ^8.0.');
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves a requested transport sharing mode to a Guzzle client
+     * constructor configuration array.
+     */
+    public static function toClientConfig(?string $mode): array
+    {
+        $mode = self::resolve($mode);
+
+        return $mode === null ? [] : ['transport_sharing' => $mode];
+    }
+
+    private static function supportsPersistentSharing(): bool
+    {
+        static $supported;
+
+        return $supported ??= defined(TransportSharing::class . '::PERSISTENT_PREFER');
+    }
+
+    private static function supportsHandlerSharing(): bool
+    {
+        static $supported;
+
+        return $supported ??= class_exists(TransportSharing::class);
+    }
+}

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -884,7 +884,10 @@ class Sdk
         $this->args = $args;
 
         if (!isset($args['handler']) && !isset($args['http_handler'])) {
-            $this->args['http_handler'] = default_http_handler();
+            $this->args['http_handler'] = default_http_handler(
+                $args['transport_sharing'] ?? null
+            );
+            unset($this->args['transport_sharing']);
         }
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -270,11 +270,17 @@ function describe_type($input)
 /**
  * Creates a default HTTP handler based on the available clients.
  *
+ * @param string|null $transportSharing Optional transport sharing mode
+ *        ("none", "handler_prefer", "handler_require", "persistent_prefer",
+ *        or "persistent_require") to apply to the underlying HTTP client.
+ *        The "*_prefer" modes degrade gracefully when the installed version
+ *        of Guzzle cannot honor them, and the "*_require" modes throw.
+ *
  * @return callable
  */
-function default_http_handler()
+function default_http_handler(?string $transportSharing = null)
 {
-    return new \Aws\Handler\Guzzle\GuzzleHandler();
+    return new \Aws\Handler\Guzzle\GuzzleHandler(null, $transportSharing);
 }
 
 /**

--- a/tests/ClientResolverTest.php
+++ b/tests/ClientResolverTest.php
@@ -749,6 +749,85 @@ EOT;
         $this->assertSame('bar', $conf['http']['foo']);
     }
 
+    public function testAppliesTransportSharingToDefaultHandler()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $conf = $r->resolve([
+            'service' => 'sqs',
+            'region' => 'x',
+            'version' => 'latest',
+            'transport_sharing' => 'handler_prefer',
+        ], new HandlerList());
+
+        $this->assertSame('handler_prefer', $conf['transport_sharing']);
+    }
+
+    public function testPreservesRequestedTransportSharingMode()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $conf = $r->resolve([
+            'service' => 'sqs',
+            'region' => 'x',
+            'version' => 'latest',
+            'transport_sharing' => 'persistent_prefer',
+        ], new HandlerList());
+
+        $this->assertSame('persistent_prefer', $conf['transport_sharing']);
+    }
+
+    public function testTransportSharingCannotRequireWithCustomHandler()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('can only require transport sharing');
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $r->resolve([
+            'service' => 'sqs',
+            'region' => 'x',
+            'version' => 'latest',
+            'http_handler' => function () {},
+            'transport_sharing' => 'handler_require',
+        ], new HandlerList());
+    }
+
+    #[DoesNotPerformAssertions]
+    public function testTransportSharingPreferIsIgnoredWithCustomHandler()
+    {
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $r->resolve([
+            'service' => 'sqs',
+            'region' => 'x',
+            'version' => 'latest',
+            'http_handler' => function () {},
+            'transport_sharing' => 'persistent_prefer',
+        ], new HandlerList());
+    }
+
+    public function testTransportSharingRejectsInvalidMode()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided transport sharing mode "always" is invalid.');
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $r->resolve([
+            'service' => 'sqs',
+            'region' => 'x',
+            'version' => 'latest',
+            'transport_sharing' => 'always',
+        ], new HandlerList());
+    }
+
+    public function testTransportSharingRejectsNonStringValue()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid configuration value provided for "transport_sharing". Expected string, but got int(1)');
+        $r = new ClientResolver(ClientResolver::getDefaultArguments());
+        $r->resolve([
+            'service' => 'sqs',
+            'region' => 'x',
+            'version' => 'latest',
+            'transport_sharing' => 1,
+        ], new HandlerList());
+    }
+
     public function testCanAddConfigOptions()
     {
         $c = new S3Client([

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -201,6 +201,21 @@ class FunctionsTest extends TestCase
         );
     }
 
+    public function testGuzzleHttpHandlerWithTransportSharing()
+    {
+        if (!class_exists('GuzzleHttp\Handler\StreamHandler')) {
+            $this->markTestSkipped();
+        }
+        $this->assertInstanceOf(
+            Aws\Handler\Guzzle\GuzzleHandler::class,
+            Aws\default_http_handler('none')
+        );
+        $this->assertInstanceOf(
+            Aws\Handler\Guzzle\GuzzleHandler::class,
+            Aws\default_http_handler('persistent_prefer')
+        );
+    }
+
     public function testSerializesHttpRequests()
     {
         $mock = new MockHandler([new Result([])]);

--- a/tests/Handler/Guzzle/HandlerTest.php
+++ b/tests/Handler/Guzzle/HandlerTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\TransferStats;
+use GuzzleHttp\TransportSharing;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -203,5 +204,46 @@ class HandlerTest extends TestCase
         $handler($request, $options)->wait();
 
         $this->assertTrue($wasCalled);
+    }
+
+    public function testTransportSharingCannotRequireWithProvidedClient()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot require sharing when a client is provided');
+
+        new GuzzleHandler(new Client(), 'handler_require');
+    }
+
+    public function testTransportSharingPreferIsIgnoredWithProvidedClient()
+    {
+        $mock = new MockHandler([new Response(200)]);
+        $client = new Client(['handler' => $mock]);
+        $handler = new GuzzleHandler($client, 'persistent_prefer');
+
+        $response = $handler(new Request('GET', 'http://example.com'))->wait();
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testCreatesClientWithTransportSharing()
+    {
+        $this->assertInstanceOf(
+            GuzzleHandler::class,
+            new GuzzleHandler(null, 'persistent_prefer')
+        );
+    }
+
+    public function testGuzzleEnforcesPersistentRequireEagerly()
+    {
+        if (!defined(TransportSharing::class . '::PERSISTENT_REQUIRE')) {
+            $this->markTestSkipped('Persistent transport sharing is only available in Guzzle 8.');
+        }
+        if (PHP_VERSION_ID >= 80500) {
+            $this->markTestSkipped('Persistent share handles may be supported on PHP 8.5+.');
+        }
+
+        // Proves the mode is forwarded to Guzzle: only Guzzle itself throws here.
+        $this->expectException(\InvalidArgumentException::class);
+
+        new GuzzleHandler(null, 'persistent_require');
     }
 }

--- a/tests/Handler/HttpTransportSharingTest.php
+++ b/tests/Handler/HttpTransportSharingTest.php
@@ -1,0 +1,106 @@
+<?php
+namespace Aws\Test\Handler;
+
+use Aws\Handler\HttpTransportSharing;
+use GuzzleHttp\TransportSharing;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+#[CoversClass(HttpTransportSharing::class)]
+class HttpTransportSharingTest extends TestCase
+{
+    public function testResolvesNullAndNoneToNull()
+    {
+        $this->assertNull(HttpTransportSharing::resolve(null));
+        $this->assertNull(HttpTransportSharing::resolve('none'));
+        $this->assertSame([], HttpTransportSharing::toClientConfig(null));
+        $this->assertSame([], HttpTransportSharing::toClientConfig('none'));
+    }
+
+    public function testRejectsInvalidMode()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The provided transport sharing mode "always" is invalid.');
+
+        HttpTransportSharing::resolve('always');
+    }
+
+    public function testDetectsRequiredModes()
+    {
+        $this->assertTrue(HttpTransportSharing::isRequired('handler_require'));
+        $this->assertTrue(HttpTransportSharing::isRequired('persistent_require'));
+        $this->assertFalse(HttpTransportSharing::isRequired('handler_prefer'));
+        $this->assertFalse(HttpTransportSharing::isRequired('persistent_prefer'));
+        $this->assertFalse(HttpTransportSharing::isRequired('none'));
+        $this->assertFalse(HttpTransportSharing::isRequired(null));
+    }
+
+    public function testPassesHandlerModesThroughWhenSupported()
+    {
+        if (!class_exists(TransportSharing::class)) {
+            $this->markTestSkipped('Transport sharing requires Guzzle 7.11+.');
+        }
+
+        $this->assertSame('handler_prefer', HttpTransportSharing::resolve('handler_prefer'));
+        $this->assertSame('handler_require', HttpTransportSharing::resolve('handler_require'));
+        $this->assertSame(
+            ['transport_sharing' => 'handler_prefer'],
+            HttpTransportSharing::toClientConfig('handler_prefer')
+        );
+    }
+
+    public function testPreferModesDegradeToNullWhenUnsupported()
+    {
+        if (class_exists(TransportSharing::class)) {
+            $this->markTestSkipped('Transport sharing is supported by the installed Guzzle.');
+        }
+
+        $this->assertNull(HttpTransportSharing::resolve('handler_prefer'));
+        $this->assertNull(HttpTransportSharing::resolve('persistent_prefer'));
+    }
+
+    public function testHandlerRequireThrowsWhenUnsupported()
+    {
+        if (class_exists(TransportSharing::class)) {
+            $this->markTestSkipped('Transport sharing is supported by the installed Guzzle.');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('requires guzzlehttp/guzzle ^7.11 || ^8.0');
+
+        HttpTransportSharing::resolve('handler_require');
+    }
+
+    public function testPersistentPreferDegradesToHandlerPreferOnGuzzle7()
+    {
+        if (!class_exists(TransportSharing::class)
+            || defined(TransportSharing::class . '::PERSISTENT_PREFER')
+        ) {
+            $this->markTestSkipped('Requires Guzzle 7.11 through 7.15.');
+        }
+
+        $this->assertSame('handler_prefer', HttpTransportSharing::resolve('persistent_prefer'));
+    }
+
+    public function testPersistentModesPassThroughOnGuzzle8()
+    {
+        if (!defined(TransportSharing::class . '::PERSISTENT_PREFER')) {
+            $this->markTestSkipped('Persistent transport sharing is only available in Guzzle 8.');
+        }
+
+        $this->assertSame('persistent_prefer', HttpTransportSharing::resolve('persistent_prefer'));
+        $this->assertSame('persistent_require', HttpTransportSharing::resolve('persistent_require'));
+    }
+
+    public function testPersistentRequireThrowsWithoutGuzzle8()
+    {
+        if (defined(TransportSharing::class . '::PERSISTENT_PREFER')) {
+            $this->markTestSkipped('Persistent transport sharing is available in the installed Guzzle.');
+        }
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('requires guzzlehttp/guzzle ^8.0');
+
+        HttpTransportSharing::resolve('persistent_require');
+    }
+}

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -5,6 +5,7 @@ use Aws\AwsClientInterface;
 use Aws\MultiRegionClient;
 use Aws\S3\S3MultiRegionClient;
 use Aws\Sdk;
+use GuzzleHttp\TransportSharing;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -87,5 +88,35 @@ class SdkTest extends TestCase
             'https://foo',
             (string) $copy->createDynamoDb()->getEndpoint()
         );
+    }
+
+    public function testAppliesTransportSharingToSharedHttpHandler()
+    {
+        $sdk = new Sdk([
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'transport_sharing' => 'persistent_prefer',
+        ]);
+
+        $this->assertInstanceOf(
+            AwsClientInterface::class,
+            $sdk->createDynamoDb()
+        );
+    }
+
+    public function testSdkConsumesTransportSharingWhenCreatingSharedHandler()
+    {
+        if (!class_exists(TransportSharing::class)) {
+            $this->markTestSkipped('Transport sharing requires Guzzle 7.11+.');
+        }
+
+        $sdk = new Sdk([
+            'region' => 'us-east-1',
+            'version' => 'latest',
+            'transport_sharing' => 'handler_prefer',
+        ]);
+        $client = $sdk->createDynamoDb();
+
+        $this->assertNull($client->getConfig('transport_sharing'));
     }
 }


### PR DESCRIPTION
Guzzle 8 added transport sharing, which lets the built-in handlers share DNS, SSL session, and connection cache state, including persistent cURL share handles on PHP 8.5+ that survive across php-fpm requests. Guzzle 7.11 supports the handler-lifetime subset of the feature. This PR exposes the capability through a new `transport_sharing` client option with five string modes matching Guzzle's vocabulary: `none`, `handler_prefer`, `handler_require`, `persistent_prefer`, and `persistent_require`.

The option's semantics are independent of the installed Guzzle version. The SDK feature-detects what the installed Guzzle supports, degrades the prefer modes gracefully (`persistent_prefer` falls back to handler-lifetime sharing on Guzzle 7.11+ and to no sharing on older versions), and throws for the require modes when they cannot be honored, so `persistent_require` is a deployment assertion that connection re-use is actually happening. The option applies when the SDK creates the default HTTP handler, since transport sharing is configured on the Guzzle client constructor rather than per request, and the require modes reject custom `handler` or `http_handler` options. `Aws\Sdk` applies the option to the HTTP handler it shares across the clients it creates. The name `transport_sharing` mirrors Guzzle's client option; renaming it to `http_transport_sharing` to group with the other HTTP options would be a two-token change if preferred. A separate commit adds a CI matrix leg pinning Guzzle to `>=7.11 <8` so the handler-lifetime degradation path is exercised; it can be dropped if unwanted, since the affected tests skip themselves based on feature detection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
