### PR TITLE
bugfix: Update parameter type for options in dir_opendir docblock

### DIFF
--- a/src/S3/StreamWrapper.php
+++ b/src/S3/StreamWrapper.php
@@ -401,7 +401,7 @@ class StreamWrapper
      *
      * @param string $path    The path to the directory
      *                        (e.g. "s3://dir[</prefix>]")
-     * @param string $options Unused option variable
+     * @param int    $options Unused option variable
      *
      * @return bool true on success
      * @see http://www.php.net/manual/en/function.opendir.php


### PR DESCRIPTION
#3336

Update parameter type for $options in dir_opendir() docblock to align with PHP https://www.php.net/manual/en/streamwrapper.dir-opendir.php

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
