### PR TITLE
chore: update empty endpoint properties assertion

### DIFF
--- a/tests/EndpointV2/EndpointProviderV2Test.php
+++ b/tests/EndpointV2/EndpointProviderV2Test.php
@@ -151,9 +151,10 @@ class EndpointProviderV2Test extends TestCase
             if (isset($expectedEndpoint['headers'])){
                 $this->assertEquals($expectedEndpoint['headers'], $endpoint->getHeaders());
             }
-            if (isset($expectedEndpoint['properties'])) {
-                $this->assertEquals($expectedEndpoint['properties'], $endpoint->getProperties());
-            }
+            $this->assertEquals(
+                $expectedEndpoint['properties'] ?? [],
+                $endpoint->getProperties() ?? []
+            );
         }
     }
 


### PR DESCRIPTION
*Description of changes:*
Updates endpoint resolution assertion on empty properties- our implementation provides `null` for an empty properties. Some tests model an empty array, which creates an incorrect expectation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
