### PR TITLE
bugfix: skip default Curl options for streamed Lambda commands

### DIFF
--- a/.changes/nextrelease/lambda-response-stream-curl-options.json
+++ b/.changes/nextrelease/lambda-response-stream-curl-options.json
@@ -1,0 +1,7 @@
+[
+    {
+        "type": "bugfix",
+        "category": "Lambda",
+        "description": "Stop applying the default Curl options to streamed commands such as InvokeWithResponseStream, which are handled by a stream handler that rejects Curl options."
+    }
+]

--- a/.changes/nextrelease/lambda-response-stream-curl-options.json
+++ b/.changes/nextrelease/lambda-response-stream-curl-options.json
@@ -2,6 +2,6 @@
     {
         "type": "bugfix",
         "category": "Lambda",
-        "description": "Stop applying the default Curl options to streamed commands such as InvokeWithResponseStream, which are handled by a stream handler that rejects Curl options."
+        "description": "Stops applying the default Curl options to streamed commands such as InvokeWithResponseStream, which are served by a stream handler that rejects them."
     }
 ]

--- a/src/Lambda/LambdaClient.php
+++ b/src/Lambda/LambdaClient.php
@@ -200,13 +200,19 @@ class LambdaClient extends AwsClient
     }
 
     /**
-     * Provides a middleware that sets default Curl options for the command
+     * Provides a middleware that sets default Curl options for the command.
+     * Streamed commands are skipped, as they are served by a stream handler
+     * that rejects Curl options.
      *
      * @return callable
      */
     public function getDefaultCurlOptionsMiddleware()
     {
         return Middleware::mapCommand(function (CommandInterface $cmd) {
+            if (!empty($cmd['@http']['stream'])) {
+                return $cmd;
+            }
+
             $defaultCurlOptions = [
                 CURLOPT_TCP_KEEPALIVE => 1,
             ];

--- a/tests/Lambda/LambdaClientTest.php
+++ b/tests/Lambda/LambdaClientTest.php
@@ -39,4 +39,28 @@ class LambdaClientTest extends TestCase
 
         $client->listFunctions();
     }
+
+    public function testsSkipsDefaultCurlOptionsWhenResponseIsStreamed()
+    {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('Test skipped on no cURL extension');
+        }
+
+        $client = new LambdaClient([
+            'region' => 'us-east-1',
+            'version' => 'latest'
+        ]);
+
+        $list = $client->getHandlerList();
+        $list->setHandler(function ($command, $request) {
+            $this->assertArrayNotHasKey('curl', $command['@http']);
+
+            return Promise\Create::promiseFor(new Result([]));
+        });
+
+        $client->invokeWithResponseStream([
+            'FunctionName' => 'test',
+            'Payload' => '{}'
+        ]);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #3345

*Description of changes:*
The Lambda client attaches `CURLOPT_TCP_KEEPALIVE` to every command, but `InvokeWithResponseStream` is flagged as streamed, so Guzzle routes it to the stream handler. Guzzle 8's stream handler rejects the `curl` request option, so the call fails before it ever leaves the process. The middleware now leaves streamed commands alone. Curl options a caller sets explicitly through `@http` are still passed on as before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
